### PR TITLE
Auto-open `<Top Level>`, try to preserve selection

### DIFF
--- a/agents/DOMAgent.js
+++ b/agents/DOMAgent.js
@@ -84,11 +84,26 @@ var DOMAgent = {
     );
   },
 
+  pushNodeByPathToFrontend: function(path, callback) {
+    ReactInspectorAgent.call('DOM.getNodeForPath', path,
+      function(result, error) {
+        if (error) {
+          callback(error);
+          return;
+        }
+        var changeLog = result.changeLog;
+        for (var i = 0; i < changeLog.length; i++) {
+          var change = changeLog[i];
+          InspectorBackend.notifyDOM(change.method, change.args);
+        }
+        callback(null, result.node ? result.node.nodeId : 0);
+      }
+    );
+  },
+
   // ???
 
   setInspectModeEnabled: function() {},
-
-  pushNodeByPathToFrontend: function(path, callback) {},
 
   // Search
   performSearch: function(query, callback) {},

--- a/injected/DOMHost.js
+++ b/injected/DOMHost.js
@@ -275,6 +275,40 @@ DOMHost.getChildNodes = function(parentId, depth) {
   return children;
 };
 
+DOMHost.getNodeForPath = function(path) {
+  // https://github.com/mirrors/blink/blob/b9bce8c/Source/core/inspector/InspectorDOMAgent.cpp#L1942-L1971
+  var changeLog = [];
+  var ancestorWithMissingChildren = null;
+  var node = DOMHost.getDocument();
+  var pathTokens = path.split(',');
+  if (!pathTokens) {
+    return {changeLog: changeLog, node: null};
+  }
+  for (var i = 0; i < pathTokens.length; i += 2) {
+    var childNumber = +pathTokens[i];
+    var childName = pathTokens[i + 1];
+    if (isNaN(childNumber) || childNumber >= node.children.length) {
+      return {changeLog: changeLog, node: null};
+    }
+    child = node.children[childNumber];
+    if (!child || child.nodeName != childName) {
+      return {changeLog: changeLog, node: null};
+    }
+    node = child;
+    if (!node.children) {
+      node.children = getChildren(instanceCache[node.nodeId], 0);
+      if (!ancestorWithMissingChildren) {
+        ancestorWithMissingChildren = node;
+        changeLog.push({
+          method: 'setChildNodes',
+          args: [node.nodeId, node.children]
+        });
+      }
+    }
+  }
+  return {changeLog: changeLog, node: node};
+};
+
 DOMHost.resolveNode = function(id, objectGroup) {
   var instance = instanceCache[id];
   if (!instance) return null;
@@ -851,7 +885,7 @@ var Subscriber = {
 
 };
 
-ReactHost.subscribeToChanges(Subscriber)
+ReactHost.subscribeToChanges(Subscriber);
 
 return DOMHost;
 

--- a/views/components/ReactPanel.js
+++ b/views/components/ReactPanel.js
@@ -333,7 +333,7 @@ ReactPanel.prototype = {
         function selectNode(candidateFocusNode)
         {
             if (!candidateFocusNode)
-                candidateFocusNode = inspectedRootDocument.body || inspectedRootDocument.documentElement;
+                candidateFocusNode = inspectedRootDocument;
 
             if (!candidateFocusNode)
                 return;


### PR DESCRIPTION
It seems that the children often aren't properly mounted by the time the inspector initializes so individual node selections aren't preserved. However, if you select a top-level component and then reload, the selection is preserved.
