### PR TITLE
Autofocus panel when created

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,7 @@ function createMainPanel() {
 
 function mainPanelShown(mainPanelWindow) {
   if (!mainPanelWindow.wasShown) {
+    mainPanelWindow.focus();
     mainPanelWindow.initialize({
       InspectorBackend: InspectorBackend,
       DOMAgent: DOMAgent,

--- a/views/components/ReactPanel.js
+++ b/views/components/ReactPanel.js
@@ -338,7 +338,7 @@ ReactPanel.prototype = {
             if (!candidateFocusNode)
                 return;
 
-            this.selectDOMNode(candidateFocusNode);
+            this.selectDOMNode(candidateFocusNode, true);
             if (this.treeOutline.selectedTreeElement)
                 this.treeOutline.selectedTreeElement.expand();
         }


### PR DESCRIPTION
Now you can click "React" then navigate the tree with arrow keys without needing to first click on "Top Level".
