### PR TITLE
Set __REACT_DEVTOOLS_GLOBAL_HOOK__ before page

### DIFF
--- a/document_start.js
+++ b/document_start.js
@@ -1,0 +1,14 @@
+// Inject a `__REACT_DEVTOOLS_GLOBAL_HOOK__` global so that React can detect that the
+// devtools are installed (and skip its suggestion to install the devtools).
+var js = (
+  "Object.defineProperty(" +
+    "window, '__REACT_DEVTOOLS_GLOBAL_HOOK__', {value: true}" +
+  ")"
+);
+
+// This script runs before the <head> element is created, so we add the script
+// to <html> instead.
+var script = document.createElement('script');
+script.textContent = js;
+document.documentElement.appendChild(script);
+script.parentNode.removeChild(script);

--- a/manifest.json
+++ b/manifest.json
@@ -15,5 +15,13 @@
   "devtools_page": "main.html",
 
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-  "web_accessible_resources": [ "main.html", "views/devpanel.html" ]
+  "web_accessible_resources": [ "main.html", "views/devpanel.html" ],
+
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["document_start.js"],
+      "run_at": "document_start"
+    }
+  ]
 }


### PR DESCRIPTION
With this, we can skip the annoying warning for people who've installed the devtools.

cc @sebmarkbage @petehunt @cpojer
