### PR TITLE
Hide internal props

### DIFF
--- a/injected/DOMHost.js
+++ b/injected/DOMHost.js
@@ -192,8 +192,8 @@ function getDOMNode(instance, depth, diveTo) {
   // For several reasons, there's only one React class in Om. So we
   // check for getDisplayName on the instance itself (if available).
   var instanceName = instance.getDisplayName && instance.getDisplayName();
-  var name = instance.constructor.displayName || tagName ||
-             instanceName || 'Unknown';
+  var name = instanceName || instance.constructor.displayName || tagName ||
+             'Unknown';
   var children = null;
 
   if (depth != 0 || ReactHost.hasTextContent(instance)) {


### PR DESCRIPTION
Includes a previous commit in a separate PR on accident, can clean that up if necessary. If both are alright though, then that's unnecessary.

Allows libraries to mark props as internal so they're not displayed as attributes in RDT. It's globally useful, but especially pertinent to libraries like Om, where RDT can't (and shouldn't) show ClojureScript data structures.

Before:
![cx](https://f.cloud.github.com/assets/35296/2297291/c61fc3f8-a0aa-11e3-81ed-c94541b38575.png)

After:
![c_](https://f.cloud.github.com/assets/35296/2297282/bb900484-a0aa-11e3-9e6f-9325972316f4.png)
