### PR TITLE
Improve rendering perf when expanding large objects in sidebar panel.

### DIFF
--- a/views/devpanel.css
+++ b/views/devpanel.css
@@ -1,0 +1,7 @@
+/*
+ * Fixes long delay observed when expanding an object with many properties in
+ * the sidebar panel.
+ */
+.fill {
+    overflow: auto;
+}

--- a/views/devpanel.html
+++ b/views/devpanel.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="../blink/Source/devtools/front_end/inspectorCommon.css">
     <link rel="stylesheet" type="text/css" href="../blink/Source/devtools/front_end/inspectorSyntaxHighlight.css">
     <link rel="stylesheet" type="text/css" href="../blink/Source/devtools/front_end/popover.css">
+    <link rel="stylesheet" type="text/css" href="devpanel.css">
 
     <script src="../blink/Source/devtools/front_end/inspector.js"></script>
 


### PR DESCRIPTION
If you have an object with many properties, particularly those with getters and setters, expanding the object tree in the right sidebar panel in the React tab can take upwards of 10 seconds or more.

This patch adds an overflow: auto; rule to any elements with class="fill" which prevents Chrome from rendering content outside of its bounding box and vastly improves performance for large object expansions.

(CLA completed)
