### PR TITLE
Add missing comma to GlobalHook.js injected script

### DIFF
--- a/injected/GlobalHook.js
+++ b/injected/GlobalHook.js
@@ -3,7 +3,7 @@
 var js = (
   "Object.defineProperty(" +
     "window, '__REACT_DEVTOOLS_GLOBAL_HOOK__', {value: {" +
-      "inject: function(runtime) { this._reactRuntime = runtime; }" +
+      "inject: function(runtime) { this._reactRuntime = runtime; }," +
       "getSelectedInstance: null," +
       "Overlay: null" +
     "}}" +


### PR DESCRIPTION
The perils of creating JS in a string... :-)
Have you considered doing something like:

```
var js = (function() {
Object.defineProperty(
    window, '__REACT_DEVTOOLS_GLOBAL_HOOK__', {value: {
        inject: function(runtime) { this._reactRuntime = runtime; },
        getSelectedInstance: null,
        Overlay: null
    }}
);
}).toString() + "()";
```

a bit sketchy but it's lintable. I can change my pull request for something like this if you're happy with the suggestion.
