### PR TITLE
Fix changes to the internal state tree in master

### DIFF
--- a/agents/ReactInspectorAgent.js
+++ b/agents/ReactInspectorAgent.js
@@ -103,6 +103,7 @@ function loadRuntime() {
       script += RUNTIME_NAMESPACE + '.' + name + ' = ' + moduleScripts[name] +
                 '(' + dependencies + ')\n\n';
     }
+    // TODO: Remove this before publishing to avoid spamming content
     script += '//@ sourceURL=InjectedRuntime.js';
     chrome.devtools.inspectedWindow.eval(script, runtimeLoaded);
   }


### PR DESCRIPTION
This _should_ be backwards compatible. I tested on facebook.com

These are some hacky fixes to track the new changes to the internal state
tree in master. Which makes the devtools work on master.

It's basically just making sure that we skip internal dom components.
We also avoid mutating the state tree since they are frozen now.

We still mutate props. We should stop doing that too.

This will likely not persist beyond one release of devtools. We will likely
change this structure in master before the next release and therefore,
we won't keep these changes in devtools.

In the future, we should move this code into the core to ensure that
we're continuously compatible.
