### PR TITLE
A bunch of hacks to support 0.13

### DIFF
--- a/agents/ReactInspectorVersion.js
+++ b/agents/ReactInspectorVersion.js
@@ -1,20 +1,20 @@
 /**
- * Copyright (c) 2013-2014, Facebook, Inc. All rights reserved.
- * 
+ * Copyright (c) 2013-2015, Facebook, Inc. All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  * Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  *  * Neither the name Facebook nor the names of its contributors may be used to
  *    endorse or promote products derived from this software without specific
  *    prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,4 +28,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-var ReactInspectorVersion = '0_8_0';
+var ReactInspectorVersion = '0_13_0';

--- a/injected/ReactHost.js
+++ b/injected/ReactHost.js
@@ -1,20 +1,20 @@
 /**
- * Copyright (c) 2013-2014, Facebook, Inc. All rights reserved.
- * 
+ * Copyright (c) 2013-2015, Facebook, Inc. All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *  * Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  *  * Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  *  * Neither the name Facebook nor the names of its contributors may be used to
  *    endorse or promote products derived from this software without specific
  *    prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -53,8 +53,6 @@ if (!ReactInternals) {
   throw new Error('Unsupported environment. You need version 0.5+ of React.');
 }
 
-// Monkey patched to track updates
-var ReactComponent = ReactInternals.Component;
 // Track which component the current breakpoint is in
 var ReactCurrentOwner = ReactInternals.CurrentOwner;
 // Get top level instances and extract IDs from real DOM nodes
@@ -64,27 +62,69 @@ var ReactTextComponent = ReactInternals.TextComponent;
 // Used to see if one instance is the ancestor of an instance or dom node
 var ReactInstanceHandles = ReactInternals.InstanceHandles;
 
-// Monkey patch Components to track rerenders
+if (ReactInternals.Component) {
+  // 0.11 - 0.12
+  // Monkey patched to track updates
+  var ReactComponent = ReactInternals.Component;
 
-var ComponentMixin = ReactComponent.Mixin;
-var originalMountComponent = ComponentMixin.mountComponent;
-var originalUpdateComponent = ComponentMixin.updateComponent;
-var originalUnmountComponent = ComponentMixin.unmountComponent;
+  // Monkey patch Components to track rerenders
 
-ComponentMixin.mountComponent = function() {
-  originalMountComponent.apply(this, arguments);
-  ReactHost._changeSubscriber.componentWillMount(this);
-};
+  var ComponentMixin = ReactComponent.Mixin;
+  var originalMountComponent = ComponentMixin.mountComponent;
+  var originalUpdateComponent = ComponentMixin.updateComponent;
+  var originalUnmountComponent = ComponentMixin.unmountComponent;
 
-ComponentMixin.updateComponent = function() {
-  originalUpdateComponent.apply(this, arguments);
-  ReactHost._changeSubscriber.componentWillUpdate(this);
-};
+  ComponentMixin.mountComponent = function() {
+    originalMountComponent.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillMount(this);
+  };
 
-ComponentMixin.unmountComponent = function() {
-  originalUnmountComponent.apply(this, arguments);
-  ReactHost._changeSubscriber.componentWillUnmount(this);
-};
+  ComponentMixin.updateComponent = function() {
+    originalUpdateComponent.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillUpdate(this);
+  };
+
+  ComponentMixin.unmountComponent = function() {
+    originalUnmountComponent.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillUnmount(this);
+  };
+} else if (ReactInternals.Reconciler) {
+  // 0.13
+
+  // Monkey patched to track updates
+  var ReactReconciler = ReactInternals.Reconciler;
+
+  // Monkey patch Components to track rerenders
+
+  var originalMountComponent = ReactReconciler.mountComponent;
+  var originalPerformUpdateIfNecessary = ReactReconciler.performUpdateIfNecessary;
+  var originalReceiveComponent = ReactReconciler.receiveComponent;
+  var originalUnmountComponent = ReactReconciler.unmountComponent;
+
+  ReactReconciler.mountComponent = function(instance) {
+    var result = originalMountComponent.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillMount(instance);
+    return result;
+  };
+
+  ReactReconciler.performUpdateIfNecessary = function(instance) {
+    var result = originalPerformUpdateIfNecessary.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillUpdate(instance);
+    return result;
+  };
+
+  ReactReconciler.receiveComponent = function(instance) {
+    var result = originalReceiveComponent.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillUpdate(instance);
+    return result;
+  };
+
+  ReactReconciler.unmountComponent = function(instance) {
+    var result = originalUnmountComponent.apply(this, arguments);
+    ReactHost._changeSubscriber.componentWillUnmount(instance);
+    return result;
+  };
+}
 
 // React Host API
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "icons": {
     "16": "icons/icon16.png", "48": "icons/icon48.png", "128": "icons/icon128.png"
   },


### PR DESCRIPTION
In 0.13 we no longer have access to ReactComponentMixin so we'll monkey
patch the ReactReconciler module instead.

Also, fixed a quirk around text components so that it is now possible
to see and edit text in the middle of a sequence of components.

Ultimately, we'll need a better long term strategy for this.