### PR TITLE
Allow you to expand/collapse tree elements

### DIFF
--- a/views/components/ObjectSidebarPane.js
+++ b/views/components/ObjectSidebarPane.js
@@ -46,7 +46,7 @@ ReactPanel.ObjectSidebarPane.prototype = {
 
     var section = new WebInspector.ObjectPropertiesSection(object, '', '', this._emptyPlaceholder, false, null, ReactPanel.EditableObjectPropertyTreeElement.bind(null, this.onedit.bind(this)));
     section.expanded = true;
-    section.editable = true;
+    section.editable = false;
     section.headerElement.addStyleClass("hidden");
     body.appendChild(section.element);
   },
@@ -89,7 +89,15 @@ ReactPanel.EditableObjectPropertyTreeElement.prototype = {
     };
     this.property.parentObject.setPropertyValue(this.property.name, expression.trim(), callback.bind(this));
   },
-
   __proto__: WebInspector.ObjectPropertyTreeElement.prototype
-
 };
+
+
+
+TreeElement.prototype.isEventWithinDisclosureTriangle = function(event)
+{
+    var paddingLeftValue = window.getComputedStyle(this._listItemNode).paddingLeft;
+    var computedLeftPadding = parseFloat(paddingLeftValue);
+    var left = this._listItemNode.totalOffsetLeft() + computedLeftPadding;
+    return event.pageX >= left && event.pageX <= left + TreeElement._ArrowToggleWidth && this._expandable;
+}


### PR DESCRIPTION
In newer versions of Chrome you can't expand any tree element (e.g. I can't expand/collpse the state props). The cause was [this line of code which I'm guessing is using a depreciated API](https://github.com/sebmarkbage/blink-devtools/blob/master/Source/devtools/front_end/treeoutline.js#L943).

I'm guessing the correct thing to do would be to update blink-devtools to the latest however as a stop gap we can update ``TreeElement.prototype.isEventWithinDisclosureTriangle`` with its [latest
implementation](https://chromium.googlesource.com/chromium/blink/+/master/Source/devtools/front_end/ui/treeoutline.js). It's far from ideal but it solves the problem.

I also made the sections non-editable to avoid accidental double clicks

Fixes #63.