### PR TITLE
Prevent DOM explorer from flickering

### DIFF
--- a/injected/Overlay.js
+++ b/injected/Overlay.js
@@ -183,7 +183,10 @@ var Overlay = {
       element = null;
     }
     if (element == null) {
-      DOMHost.hideHighlight();
+      try {
+        DOMHost.hideHighlight();
+      } catch(x) {
+      }
       return;
     }
 
@@ -220,7 +223,9 @@ var Overlay = {
   },
 
   hideHighlight: function() {
-    inspectorIframe.style.display = 'none';
+    if (inspectorIframe) {
+      inspectorIframe.style.display = 'none';
+    }
     inspectorIframeVisible = false;
   }
 


### PR DESCRIPTION
This PR fixes #73.

Thanks to @LeZuse [for the hint](https://github.com/facebook/react-devtools/issues/73#issuecomment-95767146). :)