### PR TITLE
[chrome] hide highlight when switching devtools tab

### DIFF
--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -98,6 +98,10 @@ class Panel extends React.Component {
     this.props.getNewSelection(this._bridge);
   }
 
+  hideHighlight() {
+    this._store.hideHighlight();
+  }
+
   sendSelection(id: string) {
     if (!this._bridge || (!id && !this._store.selected)) {
       return;

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -288,11 +288,19 @@ class Store extends EventEmitter {
       this.emit('hover');
       this._bridge.send('highlight', id);
     } else if (this.hovered === id) {
-      this.hovered = null;
-      this.emit(id);
-      this.emit('hover');
-      this._bridge.send('hideHighlight');
+      this.hideHighlight();
     }
+  }
+
+  hideHighlight() {
+    this._bridge.send('hideHighlight');
+    if (!this.hovered) {
+      return;
+    }
+    var id = this.hovered;
+    this.hovered = null;
+    this.emit(id);
+    this.emit('hover');
   }
 
   selectTop(id: ?ElementID, noHighlight?: boolean) {

--- a/shells/chrome/src/GlobalHook.js
+++ b/shells/chrome/src/GlobalHook.js
@@ -20,7 +20,7 @@ var checkForOld = `
 if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
   console.error("REACT DEVTOOLS ERROR\\nYou need to disable the official version of React Devtools in order to use the beta.");
 }
-`
+`;
 
 var js = (
   ';(' + globalHook.toString() + '(window))'

--- a/shells/chrome/src/main.js
+++ b/shells/chrome/src/main.js
@@ -11,6 +11,9 @@
 'use strict';
 
 type Panel = { // eslint-disable-line no-unused-vars
+  onHidden: {
+    addListener: (cb: (window: Object) => void) => void,
+  },
   onShown: {
     addListener: (cb: (window: Object) => void) => void,
   }
@@ -35,10 +38,17 @@ chrome.devtools.inspectedWindow.eval(`!!(
   }
 
   chrome.devtools.panels.create('React', '', 'panel.html', function (panel) {
+    var reactPanel = null;
     panel.onShown.addListener(function (window) {
       // when the user switches to the panel, check for an elements tab
       // selection
       window.panel.getNewSelection();
+      reactPanel = window.panel;
+    });
+    panel.onHidden.addListener(function () {
+      if (reactPanel) {
+        reactPanel.hideHighlight();
+      }
     });
   });
 });


### PR DESCRIPTION
The Elements pane will hide its highlight if you go to a different devtools tab, and I think that behavior makes more sense.

This is what happens w/ this PR:

![chrome-highlight](https://cloud.githubusercontent.com/assets/112170/9071144/7e00161a-3aa8-11e5-836b-c69e54e6f54e.gif)
