### PR TITLE
Use babel-plugin-object-create-multiple-to-single-and-define-propery

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,4 @@
-{"stage": 0}
+{
+  "stage": 0,
+  "plugins": ["object-create-multiple-to-single-and-define-property:after"]
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "babel-eslint": "^3.1.23",
     "babel-jest": "^5.3.0",
     "babel-loader": "^5.1.4",
+    "babel-plugin-object-create-multiple-to-single-and-define-property": "^1.0.1",
     "eslint": "^0.24.1",
     "eslint-plugin-react": "^3.0.0",
     "jest-cli": "facebook/jest#0.5.x",


### PR DESCRIPTION
_Should_ fix #104.

This plugin replaces:

```javascript
Object.create(foo, {});
```

with:

```javascript
var _temp;
_temp = Object.create(foo), Object.defineProperties(_temp, {}), _temp;
```

This is pretty hacky, it only just gets around the error for `Object.create`.