### PR TITLE
run the backend in an iframe in the <head>

### DIFF
--- a/frontend/Highlighter/setup.js
+++ b/frontend/Highlighter/setup.js
@@ -14,8 +14,8 @@ var Highlighter = require('./Highlighter');
 
 import type * as Agent from '../../agent/Agent';
 
-module.exports = function setup(agent: Agent) {
-  var hl = new Highlighter(window, node => {
+module.exports = function setup(agent: Agent, win?: Object) {
+  var hl = new Highlighter(win || window, node => {
     agent.selectFromDOMNode(node);
   });
   agent.on('highlight', data => hl.highlight(data.node, data.name));

--- a/shells/chrome/src/contentScript.js
+++ b/shells/chrome/src/contentScript.js
@@ -34,7 +34,6 @@ declare var chrome: {
     },
   },
   runtime: {
-    getURL: (path: string) => string,
     connect: (config: Object) => Port,
   },
 };

--- a/shells/chrome/src/inject.js
+++ b/shells/chrome/src/inject.js
@@ -21,9 +21,13 @@ declare var chrome: {
 module.exports = function (scriptName: string, done: () => void) {
   var src = `
   // the prototype stuff is in case document.createElement has been modified
-  var script = document.constructor.prototype.createElement.call(document, 'script');
+  var iframe = document.constructor.prototype.createElement.call(document, 'iframe');
+  iframe.style.display = 'none';
+  document.head.appendChild(iframe);
+  var doc = iframe.contentDocument;
+  var script = doc.createElement('script');
   script.src = "${scriptName}";
-  document.documentElement.appendChild(script);
+  doc.body.appendChild(script);
   script.parentNode.removeChild(script);
   `;
 

--- a/test/example/sink.html
+++ b/test/example/sink.html
@@ -6,6 +6,12 @@
     </head>
     <body>
         <script src="build/sink.js"></script>
+        <script>
+            window.Map = null;
+            Object.create = null;
+            window.Set = null;
+            window.WeakMap = null;
+        </script>
     </body>
 </html>
 


### PR DESCRIPTION
an alternative to #113, fixes #104 

This runs all the of the backend code that needs to be in the same context as the React runtime in an `iframe` that is added to the `<head>` of the page.

#### Why does the iframe need to be on the DOM?
At least in chrome, iframes that are not attached to the DOM are garbage collected - such that all listeners, timers, etc. from code executed in the iframe are invalid.

See #113 for other possible solutions