### PR TITLE
Fix search results

### DIFF
--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -353,11 +353,7 @@ class Store extends EventEmitter {
     if (up) {
       return this._parents.get(id);
     }
-    var children = node.get('children');
-    if ('string' === typeof children) {
-      return children;
-    }
-    return children[0];
+    return node.get('children')[0];
   }
 
   off(evt: string, fn: ListenerFunction): void {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -180,7 +180,7 @@ class Store extends EventEmitter {
           });
       } else {
         this.searchRoots = this._nodes.entrySeq()
-          .filter(([key, val]) => nodeMatchesText(val, needle))
+          .filter(([key, val]) => nodeMatchesText(val, needle, key, this))
           .map(([key, val]) => key)
           .toList();
       }
@@ -347,13 +347,17 @@ class Store extends EventEmitter {
     if (nodeType !== 'Wrapper' && nodeType !== 'Native') {
       return id;
     }
-    if (nodeType === 'Native' && this.get(this._parents.get(id)).get('nodeType') !== 'NativeWrapper') {
+    if (nodeType === 'Native' && (!up || this.get(this._parents.get(id)).get('nodeType') !== 'NativeWrapper')) {
       return id;
     }
     if (up) {
       return this._parents.get(id);
     }
-    return node.get('children')[0];
+    var children = node.get('children');
+    if ('string' === typeof children) {
+      return children;
+    }
+    return children[0];
   }
 
   off(evt: string, fn: ListenerFunction): void {
@@ -427,7 +431,7 @@ class Store extends EventEmitter {
     var curNodes = this._nodesByName.get(data.name) || new Set();
     this._nodesByName = this._nodesByName.set(data.name, curNodes.add(data.id));
     this.emit(data.id);
-    if (this.searchRoots && nodeMatchesText(map, this.searchText.toLowerCase())) {
+    if (this.searchRoots && nodeMatchesText(map, this.searchText.toLowerCase(), data.id, this)) {
       this.searchRoots = this.searchRoots.push(data.id);
       this.emit('searchRoots');
     }

--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -11,9 +11,13 @@
 'use strict';
 
 import type {Map} from 'immutable';
+import type Store from './Store';
 
-function nodeMatchesText(node: Map, needle: string): boolean {
+function nodeMatchesText(node: Map, needle: string, key: string, store: Store): boolean {
   var name = node.get('name');
+  if (node.get('nodeType') === 'Native' && store.get(store.getParent(key)).get('nodeType') === 'NativeWrapper') {
+    return false;
+  }
   if (name) {
     if (node.get('nodeType') !== 'Wrapper' && name.toLowerCase().indexOf(needle) !== -1) {
       return true;


### PR DESCRIPTION
Before this change, both `Native` and `NativeWrapper` components were showing up in listings under 0.13.
We want to only display NativeWrappers in 0.13, but in 0.14 there are no native wrappers, so we just show the native components.

Before:
![image](https://cloud.githubusercontent.com/assets/112170/9230173/a6d439da-40d5-11e5-9501-b8faf92366d4.png)

After:
![image](https://cloud.githubusercontent.com/assets/112170/9230191/bd68bd7e-40d5-11e5-83b8-f1b0d0825e21.png)

(half as many native components shown)
