### PR TITLE
add a breadcrumb trail to fix #133

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var assign = require('object-assign');
+var decorate = require('./decorate');
+
+class Breadcrumb extends React.Component {
+  render() {
+    return (
+      <ul style={styles.container}>
+        {this.props.path.map(({id, node}) => {
+          var isSelected = id === this.props.selected;
+          var style = assign(
+            {},
+            styles.item,
+            node.get('nodeType') === 'Composite' && styles.composite,
+            isSelected && styles.selected
+          );
+          return (
+            <li
+              style={style}
+              onMouseOver={() => this.props.hover(id, true)}
+              onMouseOut={() => this.props.hover(id, false)}
+              onClick={isSelected ? null : () => this.props.select(id)}
+            >
+              {node.get('name') || '"' + node.get('text') + '"'}
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+}
+
+var styles = {
+  container: {
+    borderTop: '1px solid #ccc',
+    backgroundColor: 'white',
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+  },
+
+  selected: {
+    cursor: 'default',
+    backgroundColor: 'rgb(56, 121, 217)',
+    color: 'white',
+  },
+
+  composite: {
+    color: 'rgb(136, 18, 128)',
+  },
+
+  item: {
+    padding: '3px 7px',
+    cursor: 'pointer',
+    display: 'inline-block',
+  },
+};
+
+function getBreadcrumbPath(store) {
+  var path = [];
+  var current = store.breadcrumbHead;
+  while (current) {
+    path.splice(0, 0, {
+      id: current,
+      node: store.get(current),
+    });
+    current = store.skipWrapper(store.getParent(current), true);
+  }
+  return path;
+}
+
+module.exports = decorate({
+  listeners: () => ['breadcrumbHead', 'selected'],
+  props(store, props) {
+    return {
+      select: id => store.selectBreadcrumb(id),
+      hover: (id, isHovered) => store.setHover(id, isHovered),
+      selected: store.selected,
+      path: getBreadcrumbPath(store),
+    };
+  },
+}, Breadcrumb);

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -10,6 +10,9 @@
  */
 'use strict';
 
+import type Store from './Store';
+import type {ElementID} from './types';
+
 var React = require('react');
 var assign = require('object-assign');
 var decorate = require('./decorate');
@@ -68,11 +71,11 @@ var styles = {
   },
 };
 
-function getBreadcrumbPath(store) {
+function getBreadcrumbPath(store: Store): Array<{id: ElementID, node: Object}> {
   var path = [];
   var current = store.breadcrumbHead;
   while (current) {
-    path.splice(0, 0, {
+    path.unshift({
       id: current,
       node: store.get(current),
     });

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -310,12 +310,13 @@ class Store extends EventEmitter {
   selectBreadcrumb(id: ElementID) {
     this._revealDeep(id);
     this.changeSearch('');
-    this.selectTop(id, false, true);
+    this.isBottomTagSelected = false;
+    this.select(id, false, true);
   }
 
-  selectTop(id: ?ElementID, noHighlight?: boolean, keepBreadcrumb?: boolean) {
+  selectTop(id: ?ElementID, noHighlight?: boolean) {
     this.isBottomTagSelected = false;
-    this.select(id, noHighlight, keepBreadcrumb);
+    this.select(id, noHighlight);
   }
 
   selectBottom(id: ElementID) {

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -12,6 +12,7 @@
 
 var React = require('react');
 var Node = require('./Node');
+var Breadcrumb = require('./Breadcrumb');
 
 var decorate = require('./decorate');
 
@@ -72,9 +73,12 @@ class TreeView extends React.Component {
 
     return (
       <div style={styles.container}>
-        {this.props.roots.map(id => (
-          <Node key={id} id={id} depth={0} />
-        )).toJS()}
+        <div style={styles.scroll}>
+          {this.props.roots.map(id => (
+            <Node key={id} id={id} depth={0} />
+          )).toJS()}
+        </div>
+        <Breadcrumb />
       </div>
     );
   }
@@ -86,16 +90,23 @@ TreeView.childContextTypes = {
 
 var styles = {
   container: {
-    padding: 3,
-    overflow: 'auto',
     fontFamily: 'Menlo, monospace',
     fontSize: '11px',
     flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
 
     WebkitUserSelect: 'none',
     MozUserSelect: 'none',
     MsUserSelect: 'none',
     userSelect: 'none',
+  },
+  scroll: {
+    padding: 3,
+    overflow: 'auto',
+    minHeight: 0,
+    flex: 1,
   },
 };
 

--- a/shells/plain/index.html
+++ b/shells/plain/index.html
@@ -7,6 +7,7 @@
             #target {
                 flex: 1;
                 border: none;
+                border-bottom: 1px solid #ccc;
             }
             #container {
                 display: flex;


### PR DESCRIPTION
fixes #133.
We also have a breadcrumb trail in the official version, so it makes sense to bring it back.
However, this breadcrumb trail reflects the **parent** hierarchy, whereas the old one showed the **owner** hierarchy. Owners are going away, so I used parents.
![breadcrumbs](https://cloud.githubusercontent.com/assets/112170/9230262/1e4eb7a6-40d6-11e5-8008-4cdad8675ba6.gif)
