### PR TITLE
pause the data transfer if the tab is not selected

### DIFF
--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -82,6 +82,18 @@ class Panel extends React.Component {
     }
   }
 
+  pauseTransfer() {
+    if (this._bridge) {
+      this._bridge.pause();
+    }
+  }
+
+  resumeTransfer() {
+    if (this._bridge) {
+      this._bridge.resume();
+    }
+  }
+
   reload() {
     if (this._unsub) {
       this._unsub();

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -85,6 +85,8 @@ class Store extends EventEmitter {
   _nodes: Map;
   _parents: Map;
   _nodesByName: Map;
+  _eventQueue: Array<string>;
+  _eventTimer: ?number;
 
   // Public state
   contextMenu: ?ContextMenu;
@@ -141,6 +143,24 @@ class Store extends EventEmitter {
     });
 
     this._establishConnection();
+    this._eventQueue = [];
+    this._eventTimer = null;
+  }
+
+  emit(evt: string): boolean {
+    if (!this._eventTimer) {
+      this._eventTimer = setTimeout(() => {
+        this._eventQueue.forEach(evt => EventEmitter.prototype.emit.call(this, evt));
+        this._eventQueue = [];
+        this._eventTimer = null;
+      }, 50);
+      this._eventQueue = [];
+    }
+    if (this._eventQueue.indexOf(evt) === -1) {
+      this._eventQueue.push(evt);
+    }
+    // to appease flow
+    return true;
   }
 
   // Public actions

--- a/shells/chrome/src/main.js
+++ b/shells/chrome/src/main.js
@@ -44,10 +44,12 @@ chrome.devtools.inspectedWindow.eval(`!!(
       // selection
       window.panel.getNewSelection();
       reactPanel = window.panel;
+      reactPanel.resumeTransfer();
     });
     panel.onHidden.addListener(function () {
       if (reactPanel) {
         reactPanel.hideHighlight();
+        reactPanel.pauseTransfer();
       }
     });
   });


### PR DESCRIPTION
Changes
- when the devtools panel is not visible, don't send data from the backend to the panel (this slows down pages)
- once the devtools panel is shown, send over all the buffered events
- dedup events sent from the store so that all the buffered events don't kill the panel UI

addresses #129