### PR TITLE
Fix some $FlowFixMe by subclassing React.Component

### DIFF
--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -16,7 +16,7 @@ var Simple = require('./Simple');
 var consts = require('../../agent/consts');
 var previewComplex = require('./previewComplex');
 
-class DataView {
+class DataView extends React.Component {
   props: {
     data: Object,
     path: Array<string>,
@@ -136,7 +136,6 @@ class DataItem extends React.Component {
       // TODO path
       children = (
         <div style={styles.children}>
-          {/* $FlowFixMe flow thinks DataView must subclass React.Component */}
           <DataView
             data={this.props.value}
             path={this.props.path}

--- a/frontend/Draggable.js
+++ b/frontend/Draggable.js
@@ -13,7 +13,7 @@
 var React = require('react');
 import type {DOMEvent} from './types';
 
-class Draggable {
+class Draggable extends React.Component {
   _onMove: (evt: DOMEvent) => void;
   _onUp: (evt: DOMEvent) => void;
   props: {

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -134,7 +134,6 @@ class Node {
             <span style={styles.tagText}>
               <span style={styles.openTag}>
                 <span style={tagStyle}>&lt;{name}</span>
-                {/* $FlowFixMe doesn't need to inherit from React.Component */}
                 {node.get('props') && <Props props={node.get('props')}/>}
                 {!content && '/'}
                 <span style={tagStyle}>&gt;</span>
@@ -187,7 +186,6 @@ class Node {
         <span style={styles.tagText}>
           <span style={styles.openTag}>
             <span style={tagStyle}>&lt;{'' + node.get('name')}</span>
-            {/* $FlowFixMe doesn't need to inherit from React.Component */}
             {node.get('props') && <Props props={node.get('props')}/>}
             <span style={tagStyle}>&gt;</span>
           </span>

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -81,7 +81,6 @@ class PropState extends React.Component {
         <div style={styles.section}>
           <strong>Props</strong>
           {propsReadOnly && <em> read-only</em>}
-          {/* $FlowFixMe flow thinks DataView must subclass React.Component */}
           <DataView
             path={['props']}
             readOnly={propsReadOnly}
@@ -94,7 +93,6 @@ class PropState extends React.Component {
         {state &&
           <div style={styles.section}>
             <strong>State</strong>
-            {/* $FlowFixMe flow thinks DataView must subclass React.Component */}
             <DataView
               data={state}
               path={['state']}
@@ -106,7 +104,6 @@ class PropState extends React.Component {
         {context &&
           <div style={styles.section}>
             <strong>Context</strong>
-            {/* $FlowFixMe flow thinks DataView must subclass React.Component */}
             <DataView
               data={context}
               path={['context']}

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -13,7 +13,7 @@
 var React = require('react');
 var PropVal = require('./PropVal');
 
-class Props {
+class Props extends React.Component {
   props: Object;
   shouldComponentUpdate(nextProps: Object): boolean {
     if (nextProps === this.props) {

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -41,7 +41,6 @@ class SplitPane extends React.Component {
       <div style={styles.leftPane}>
         {this.props.left()}
       </div>
-      {/* $FlowFixMe the "extends React.Component" is just to help flow */}
       <Draggable
         style={dragStyle}
         onStart={() => this.setState({moving: true})}

--- a/plugins/DepGraph/DepGraph.js
+++ b/plugins/DepGraph/DepGraph.js
@@ -45,7 +45,6 @@ class DisplayDeps {
     return (
       <div style={styles.container}>
         <div style={styles.scrollParent}>
-          {/* $FlowFixMe doesn't need to inherit from React.Component */}
           <SvgGraph
             onHover={this.props.onHover}
             onClick={this.props.onClick}
@@ -61,7 +60,7 @@ class DisplayDeps {
   }
 }
 
-class SvgGraph {
+class SvgGraph extends React.Component {
   props: Object;
   render() {
     var graph = this.props.graph;


### PR DESCRIPTION
Is there a reason we should avoid extending `React.Component`?