### PR TITLE
Use BSD-3-Clause in Firefox package

### DIFF
--- a/shells/firefox/package.json
+++ b/shells/firefox/package.json
@@ -8,5 +8,5 @@
   "engines": {
     "firefox": ">=38.0a1"
   },
-  "license": "BSD 2-clause"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
We're using the 3 clause, not the 2 clause. This shows up on AMO where it links off-site to OSI. We have the right license in the root, so it's just a matter of correctness.