### PR TITLE
Set minimum_chrome_version for Chrome extension

### DIFF
--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -3,6 +3,7 @@
   "name": "React Developer Tools",
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
   "version": "0.14.1",
+  "minimum_chrome_version": "43",
   "icons": {
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"


### PR DESCRIPTION
43 is 2 versions behind the current stable to cover people lagging behind in the
updater.

Closes #159