### PR TITLE
Add support for Firefox private browsing

### DIFF
--- a/shells/firefox/package.json
+++ b/shells/firefox/package.json
@@ -8,5 +8,8 @@
   "engines": {
     "firefox": ">=38.0a1"
   },
-  "license": "BSD-3-Clause"
+  "license": "BSD-3-Clause",
+  "permissions": {
+    "private-browsing": true
+  }
 }


### PR DESCRIPTION
Without this, the React tab would still show up, but it stays stuck on "Connecting to devtools"

<img width="1072" alt="screen shot 2015-09-14 at 2 45 08 pm" src="https://cloud.githubusercontent.com/assets/6135313/9843856/bb704412-5af0-11e5-8183-08b7f1908e53.png">

Documentation for the "permissions" key can be found at: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json#permissions