### PR TITLE
Make sure a Bridge always has a Wall

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -118,7 +118,7 @@ class Bridge {
   _callers: {[key: string]: AnyFn};
   _paused: boolean;
 
-  constructor() {
+  constructor(wall: Wall) {
     this._cbs = new Map();
     this._inspectables = new Map();
     this._cid = 0;
@@ -128,11 +128,9 @@ class Bridge {
     this._lastTime = 5;
     this._callers = {};
     this._paused = false;
-  }
-
-  attach(wall: Wall) {
     this._wall = wall;
-    this._wall.listen(this._handleMessage.bind(this));
+
+    wall.listen(this._handleMessage.bind(this));
   }
 
   inspect(id: string, path: Array<string>, cb: (val: any) => any) {

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -159,8 +159,7 @@ class Panel extends React.Component {
     this.props.inject((wall, teardown) => {
       this._teardownWall = teardown;
 
-      this._bridge = new Bridge();
-      this._bridge.attach(wall);
+      this._bridge = new Bridge(wall);
 
       if (this._bridge) {
         this._store = new Store(this._bridge);

--- a/shells/chrome/src/backend.js
+++ b/shells/chrome/src/backend.js
@@ -56,8 +56,7 @@ function setup(hook) {
 
   var isReactNative = !!hook.resolveRNStyle;
 
-  var bridge = new Bridge();
-  bridge.attach(wall);
+  var bridge = new Bridge(wall);
   var agent = new Agent(window, {
     rnStyle: isReactNative,
   });

--- a/shells/firefox/src/backend.js
+++ b/shells/firefox/src/backend.js
@@ -60,8 +60,7 @@ function setup() {
     },
   };
 
-  var bridge = new Bridge();
-  bridge.attach(wall);
+  var bridge = new Bridge(wall);
   var agent = new Agent(window);
   agent.addBridge(bridge);
 

--- a/shells/plain/backend.js
+++ b/shells/plain/backend.js
@@ -25,8 +25,7 @@ var wall = {
   },
 };
 
-var bridge = new Bridge();
-bridge.attach(wall);
+var bridge = new Bridge(wall);
 var agent = new Agent(window);
 agent.addBridge(bridge);
 


### PR DESCRIPTION
The flow type annotation was already promising that there would always be a wall
set. This ensures it by making the wall part of the constructor.