### PR TITLE
Update Firefox shell for path change in Firefox 44 and later

### DIFF
--- a/shells/firefox/main/trackSelection.js
+++ b/shells/firefox/main/trackSelection.js
@@ -10,7 +10,16 @@
 'use strict';
 
 const { Cu } = require('chrome');
-const { gDevTools } = Cu.import('resource:///modules/devtools/gDevTools.jsm', {});
+
+// The path to this file was moved in Firefox 44 and later.
+// See https://bugzil.la/912121 for more details.
+let gDevTools;
+try {
+  ({ gDevTools } = Cu.import('resource:///modules/devtools/client/framework/' +
+                             'gDevTools.jsm', {}));
+} catch (e) {
+  ({ gDevTools } = Cu.import('resource:///modules/devtools/gDevTools.jsm', {}));
+}
 
 /**
  * Whenever the devtools inspector panel selection changes, pass that node to


### PR DESCRIPTION
In Firefox 44, we are [moving DevTools files][1] to a new location. This impacts some add-ons that import those files at their old paths.

For React, there's only one, as the rest go through the Add-on SDK APIs which are already updated correctly.

I've updated the add-on to use the new path when available (Firefox 44 and later) and fallback to the old one if not.

I tested this add-on build in Firefox 43 and 44.

At the moment, the old path also works in 44, but we'll soon start logging deprecation warnings for the old paths, so now you'll already be updated to avoid such warnings.

[1]: https://bugzil.la/912121