### PR TITLE
Show `{…}` instead of `{}` for displaying objects

### DIFF
--- a/frontend/DataView/previewComplex.js
+++ b/frontend/DataView/previewComplex.js
@@ -38,7 +38,7 @@ function previewComplex(data: Object) {
   } else if (type === 'object') {
     return (
       <span style={valueStyles.object}>
-        {data[consts.name] + '{}'}
+        {data[consts.name] + '{…}'}
       </span>
     );
   } else if (type === 'symbol') {

--- a/frontend/PropVal.js
+++ b/frontend/PropVal.js
@@ -71,7 +71,7 @@ function previewProp(val: any, nested: boolean) {
       );
     }
     if (type === 'object') {
-      return <span>{val[consts.name] + '{}'}</span>;
+      return <span>{val[consts.name] + '{…}'}</span>;
     }
     if (type === 'array') {
       return <span>Array[{val[consts.meta].length}]</span>;


### PR DESCRIPTION
Displaying some objects as `{}` in the devtools and others as `{…}` makes it
look like the objects displayed as `{}` are empty, when in reality they are
just as likely to contain things.

This updates objects displayed in the PropPane and the SearchPane to be
displayed as `{…}`.