### PR TITLE
Fix bug in Relay store

### DIFF
--- a/plugins/Relay/Store.js
+++ b/plugins/Relay/Store.js
@@ -88,7 +88,7 @@ class Store extends EventEmitter {
       }
       this.nodesToDataIDs[data.id] = new window.Set();
       for (var name in data.props) {
-        var id = data.props[name].__dataID__;
+        var id = data.props[name] && data.props[name].__dataID__;
         if (!id) {
           continue;
         }
@@ -105,7 +105,7 @@ class Store extends EventEmitter {
       }
       var newIds = new window.Set();
       for (var name in data.props) {
-        var id = data.props[name].__dataID__;
+        var id = data.props[name] && data.props[name].__dataID__;
         if (!id) {
           continue;
         }


### PR DESCRIPTION
When the node was `null`, the Relay store would error on the change line. This
prevented the store from initializing correctly.

Test Plan:
Load the Relay todo example and open the React elements panel, see it's loaded
correctly.