### PR TITLE
Do not run global hook in Chrome panel context

### DIFF
--- a/shells/chrome/src/panel.js
+++ b/shells/chrome/src/panel.js
@@ -94,8 +94,6 @@ var config: Props = {
   },
 };
 
-var globalHook = require('../../../backend/GlobalHook');
-globalHook(window);
 var Panel = require('../../../frontend/Panel');
 var React = require('react');
 


### PR DESCRIPTION
The file `shells/chrome/src/GlobalHook.js` already runs `backend/GlobalHook.js`
in the context of the page. I don't think there's a reason to also execute it in
the context of the Chrome extensions developer panel.