### PR TITLE
Add npm-debug.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /backend/integration/v0.14/node_modules
 /backend/integration/build
 /shells/firefox/*.xpi
+npm-debug.log


### PR DESCRIPTION
This file is generated when `npm` has an error such as `npm run lint` failing.