### PR TITLE
Chunk up Relay query test to prevent cutoff

### DIFF
--- a/plugins/Relay/Store.js
+++ b/plugins/Relay/Store.js
@@ -64,7 +64,11 @@ class Store extends EventEmitter {
       pendingQueries.forEach(pendingQuery => {
         this.queries = this.queries.set(
           pendingQuery.id,
-          new Map(pendingQuery).set('status', 'pending')
+          new Map({
+            ...pendingQuery,
+            status: 'pending',
+            text: pendingQuery.text.join(''),
+          })
         );
         this.emit('queries');
         this.emit(pendingQuery.id);

--- a/plugins/Relay/installRelayHook.js
+++ b/plugins/Relay/installRelayHook.js
@@ -15,6 +15,8 @@
  *       function in some places and inject the source into the page.
  */
 function installRelayHook(window: Object) {
+  const TEXT_CHUNK_LENGTH = 500;
+
   var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
   if (!hook) {
     return;
@@ -74,11 +76,17 @@ function installRelayHook(window: Object) {
         });
       },
     );
+    const textChunks = [];
+    let text = request.getQueryString();
+    while (text.length > 0) {
+      textChunks.push(text.substr(0, TEXT_CHUNK_LENGTH));
+      text = text.substr(TEXT_CHUNK_LENGTH);
+    }
     return {
       id: id,
       name: request.getDebugName(),
       start: performance.now(),
-      text: request.getQueryString(),
+      text: textChunks,
       type: type,
       variables: request.getVariables(),
     };


### PR DESCRIPTION
The dehydration for sending data over the bridge cuts off strings at 500
characters. This is good to prevent overly large strings inside of elements. For
Relay queries which can often get longer, we don't want to have them shortened
though as it makes them useless.

Simple solution is to chop them up into multiple chunks and rebuild the string
when we receive it.

#187 