### PR TITLE
Fix webpack.config to exclude node_modules

### DIFF
--- a/backend/integration/webpack.config.js
+++ b/backend/integration/webpack.config.js
@@ -43,11 +43,9 @@ module.exports = {
     wrappedContextCritical: false,
 
     loaders: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader:  'babel-loader?stage=0',
-      exclude: [
-        'node_modules',
-      ],
+      exclude: /node_modules/,
     }],
   },
 };

--- a/shells/chrome/webpack.backend.js
+++ b/shells/chrome/webpack.backend.js
@@ -25,12 +25,9 @@ module.exports = {
 
   module: {
     loaders: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader:  'babel-loader?stage=0',
-      exclude: [
-        'node_modules',
-        './helpers.js',
-      ],
+      exclude: /node_modules/,
     }],
   },
 

--- a/shells/chrome/webpack.config.js
+++ b/shells/chrome/webpack.config.js
@@ -27,11 +27,9 @@ module.exports = {
 
   module: {
     loaders: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader:  'babel-loader?stage=0',
-      exclude: [
-        'node_modules',
-      ],
+      exclude: /node_modules/,
     }],
   },
 };

--- a/shells/firefox/webpack.config.js
+++ b/shells/firefox/webpack.config.js
@@ -24,11 +24,9 @@ module.exports = {
 
   module: {
     loaders: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader:  'babel-loader?stage=0',
-      exclude: [
-        'node_modules',
-      ],
+      exclude: /node_modules/,
     }],
   },
 };

--- a/shells/plain/webpack.config.js
+++ b/shells/plain/webpack.config.js
@@ -22,11 +22,9 @@ module.exports = {
 
   module: {
     loaders: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader:  'babel-loader?stage=0',
-      exclude: [
-        'node_modules',
-      ],
+      exclude: /node_modules/,
     }],
   },
 };

--- a/test/example/webpack.config.js
+++ b/test/example/webpack.config.js
@@ -24,11 +24,9 @@ module.exports = {
 
   module: {
     loaders: [{
-      test: /\.jsx?$/,
+      test: /\.js$/,
       loader:  'babel-loader?stage=0',
-      exclude: [
-        'node_modules',
-      ],
+      exclude: /node_modules/,
     }],
   },
 };


### PR DESCRIPTION
If it's a string it actually has to be an absolute path to exclude. Using a
regex like this seems to be the norm that most people do.

The benefit is that we no longer transform code like React's which is already
transformed.

We also don't use `.jsx` files, so I dropped that support from the regex too.

The `helper.js` file doesn't seem to exist anymore, so I removed it from the
exclusion list.