### PR TITLE
Use performance.now() shim in the backend

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 .*node_modules/json-loader.*
 .*node_modules/node-libs-browser.*
 .*node_modules/webpack.*
+.*node_modules/fbjs/flow.*
 
 [libs]
 flow

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -13,6 +13,7 @@
 var consts = require('./consts');
 var hydrate = require('./hydrate');
 var dehydrate = require('./dehydrate');
+var performanceNow = require('fbjs/lib/performanceNow');
 
 type AnyFn = (...x: any) => any;
 export type Wall = {
@@ -222,7 +223,7 @@ class Bridge {
   }
 
   flush() {
-    var start = performance.now();
+    var start = performanceNow();
     var events = this._buffer.map(({evt, data}) => {
       var cleaned = [];
       var san = dehydrate(data, cleaned);
@@ -234,7 +235,7 @@ class Bridge {
     this._wall.send({type: 'many-events', events});
     this._buffer = [];
     this._waiting = null;
-    this._lastTime = performance.now() - start;
+    this._lastTime = performanceNow() - start;
   }
 
   forget(id: string) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "fbjs-scripts": "0.2.1",
     "immutable": "^3.7.4",
     "object-assign": "^3.0.0",
-    "react": "^0.13.3"
+    "react": "^0.13.3",
+    "fbjs": "^0.4.0"
   },
   "license": "BSD-3-Clause",
   "repository": "facebook/react-devtools",


### PR DESCRIPTION
I've been trying to get the inspector backend working in a barebones JS environment that doesn't have the `performance` object.

Other than this and `setTimeout` I don't seem to see any other HTML API dependencies