### PR TITLE
Tweak Firefox shell again for 44 and later

### DIFF
--- a/shells/firefox/main/trackSelection.js
+++ b/shells/firefox/main/trackSelection.js
@@ -12,10 +12,10 @@
 const { Cu } = require('chrome');
 
 // The path to this file was moved in Firefox 44 and later.
-// See https://bugzil.la/912121 for more details.
+// See https://bugzil.la/912121 and https://bugzil.la/1203159 for more details.
 let gDevTools;
 try {
-  ({ gDevTools } = Cu.import('resource:///modules/devtools/client/framework/' +
+  ({ gDevTools } = Cu.import('resource://devtools/client/framework/' +
                              'gDevTools.jsm', {}));
 } catch (e) {
   ({ gDevTools } = Cu.import('resource:///modules/devtools/gDevTools.jsm', {}));


### PR DESCRIPTION
In #218, I updated some internal Firefox DevTools paths for 44 and later.

On the Firefox DevTools team, we made [one more change][1] that also landed in 44, so here's another update to cover that. No other changes like this are anticipated in the near future.

[1]: https://bugzil.la/1203159