### PR TITLE
Fix mktemp on Linux

### DIFF
--- a/shells/chrome/build.sh
+++ b/shells/chrome/build.sh
@@ -2,7 +2,7 @@
 set -ex
 
 SHELL_DIR=$PWD
-PACKAGE_TMP=$(mktemp -d -t devtools)
+PACKAGE_TMP=$(mktemp -d -t devtools.XXX)
 
 NODE_ENV=production ../../node_modules/.bin/webpack --config webpack.config.js
 NODE_ENV=production ../../node_modules/.bin/webpack --config webpack.backend.js


### PR DESCRIPTION
From Linux man page: TEMPLATE must contain at least 3 consecutive 'X's in last component.