### PR TITLE
Fix incorrect URL in warning message for old versions of React

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ or by inspecting [Facebook](https://www.facebook.com/).
 
 Currently iframes and Chrome apps/extensions are not inspectable.
 
+### How do I use this for React < 0.13?
+
+Download and manually install [an older version of the Chrome extension](https://github.com/facebook/react-devtools/releases/tag/v0.13.1).
+
+If you try to open the downloaded `crx` file directly in Chrome, you will see
+the following message:
+
+> Apps, extensions and user scripts cannot be added from this website.
+
+Instead, follow [these instructions](http://stackoverflow.com/a/11879334/349353)
+to install the extension manually.
+
 ### ProTips
 
 If you inspect a React element on the page using the regular **Elements** tab,

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ or by inspecting [Facebook](https://www.facebook.com/).
 
 Currently iframes and Chrome apps/extensions are not inspectable.
 
-### How do I use this for React < 0.13?
+### How do I use this for React < 0.13? (Chrome only)
 
 Download and manually install [an older version of the Chrome extension](https://github.com/facebook/react-devtools/releases/tag/v0.13.1).
 
@@ -78,6 +78,9 @@ the following message:
 
 Instead, follow [these instructions](http://stackoverflow.com/a/11879334/349353)
 to install the extension manually.
+
+**Note**: The older version is for Chrome only. Firefox support was introduced
+in [a newer release](https://github.com/facebook/react-devtools/releases/tag/v2-beta1).
 
 ### ProTips
 

--- a/backend/attachRenderer.js
+++ b/backend/attachRenderer.js
@@ -82,7 +82,7 @@ function attachRenderer(hook: Hook, rid: string, renderer: ReactRenderer): Helpe
   }
 
   if (renderer.Component) {
-    console.error('You are using a version of React with limited support in this version of the devtools.\nPlease upgrade to use at least 0.13, or you can downgrade to use the old version of the devtools:\ninstructions here https://github.com/facebook/react-devtools/tree/devtools-next#how-do-i-use-this-for-react--013');
+    console.error('You are using a version of React with limited support in this version of the devtools.\nPlease upgrade to use at least 0.13, or you can downgrade to use the old version of the devtools:\ninstructions here https://github.com/facebook/react-devtools/tree/master#how-do-i-use-this-for-react--013-chrome-only');
     // 0.11 - 0.12
     // $FlowFixMe renderer.Component is not "possibly undefined"
     oldMethods = decorateMany(renderer.Component.Mixin, {


### PR DESCRIPTION
Addresses facebook/react-devtools#268.

## Todo

- [ ] Tag https://github.com/facebook/react-devtools/tree/329363301da8fad70d1b49f830886c55ed53b1ef as `v0.13.1` (assuming that's the right commit)
- [ ] Create a new (well, old) release
- [ ] Attach the packed extension from https://github.com/peterjmag/react-devtools-issue-228/blob/master/react-devtools-329363301da8.crx

Ping @zpao @jaredly (since they have access to the FB GitHub org)