### PR TITLE
[relay] always enable Relay dev tools

### DIFF
--- a/plugins/Relay/backend.js
+++ b/plugins/Relay/backend.js
@@ -28,10 +28,7 @@ function decorate(obj, attr, fn) {
 let subscriptionEnabled = false;
 
 module.exports = (bridge: Bridge, agent: Agent, hook: Object) => {
-  var shouldEnable = !!(
-    hook._relayInternals &&
-    window.location.hash.indexOf('relaydevtools') >= 0
-  );
+  var shouldEnable = !!hook._relayInternals;
 
   bridge.onCall('relay:check', () => shouldEnable);
   if (!shouldEnable) {


### PR DESCRIPTION
This removes the URL gating from the Relay dev tab and always enables it if
Relay is found on the page.

Closes #187.