### PR TITLE
Update dependencies and pin versions

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,16350 @@
+{
+  "dependencies": {
+    "babel-core": {
+      "version": "6.3.21",
+      "from": "babel-core@6.3.21",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.3.21.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.3.13",
+          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "js-tokens": {
+              "version": "1.0.2",
+              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+            },
+            "line-numbers": {
+              "version": "0.2.0",
+              "from": "line-numbers@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+              "dependencies": {
+                "left-pad": {
+                  "version": "0.0.3",
+                  "from": "left-pad@0.0.3",
+                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "from": "repeating@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.3.25",
+          "from": "babel-generator@>=6.3.21 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.3.25.tgz",
+          "dependencies": {
+            "detect-indent": {
+              "version": "3.0.1",
+              "from": "detect-indent@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                }
+              }
+            },
+            "is-integer": {
+              "version": "1.0.6",
+              "from": "is-integer@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "from": "repeating@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "from": "trim-right@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            }
+          }
+        },
+        "babel-helpers": {
+          "version": "6.3.13",
+          "from": "babel-helpers@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.3.13.tgz"
+        },
+        "babel-messages": {
+          "version": "6.3.18",
+          "from": "babel-messages@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+        },
+        "babel-template": {
+          "version": "6.3.13",
+          "from": "babel-template@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz"
+        },
+        "babel-runtime": {
+          "version": "5.8.34",
+          "from": "babel-runtime@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.6",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+            }
+          }
+        },
+        "babel-register": {
+          "version": "6.3.13",
+          "from": "babel-register@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.3.13.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.6",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+            },
+            "home-or-tmp": {
+              "version": "1.0.0",
+              "from": "home-or-tmp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                }
+              }
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "source-map@0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-traverse": {
+          "version": "6.3.25",
+          "from": "babel-traverse@>=6.3.21 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+          "dependencies": {
+            "globals": {
+              "version": "8.15.0",
+              "from": "globals@>=8.3.0 <9.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+            },
+            "invariant": {
+              "version": "2.2.0",
+              "from": "invariant@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+              "dependencies": {
+                "loose-envify": {
+                  "version": "1.1.0",
+                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                  "dependencies": {
+                    "js-tokens": {
+                      "version": "1.0.2",
+                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "from": "repeating@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.3.24",
+          "from": "babel-types@>=6.3.21 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "to-fast-properties": {
+              "version": "1.0.1",
+              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.3.25",
+          "from": "babylon@>=6.3.21 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.1.2",
+          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "json5": {
+          "version": "0.4.0",
+          "from": "json5@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "from": "minimatch@>=2.0.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.2",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "from": "path-exists@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "private": {
+          "version": "0.1.6",
+          "from": "private@>=0.1.6 <0.2.0",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "from": "shebang-regex@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+        },
+        "slash": {
+          "version": "1.0.0",
+          "from": "slash@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.3",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+        }
+      }
+    },
+    "babel-eslint": {
+      "version": "4.1.6",
+      "from": "babel-eslint@4.1.6",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-4.1.6.tgz",
+      "dependencies": {
+        "babel-core": {
+          "version": "5.8.34",
+          "from": "babel-core@>=5.8.33 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
+          "dependencies": {
+            "babel-plugin-constant-folding": {
+              "version": "1.0.1",
+              "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+            },
+            "babel-plugin-dead-code-elimination": {
+              "version": "1.0.2",
+              "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+            },
+            "babel-plugin-eval": {
+              "version": "1.0.1",
+              "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+            },
+            "babel-plugin-inline-environment-variables": {
+              "version": "1.0.1",
+              "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+            },
+            "babel-plugin-jscript": {
+              "version": "1.0.4",
+              "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+            },
+            "babel-plugin-member-expression-literals": {
+              "version": "1.0.1",
+              "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+            },
+            "babel-plugin-property-literals": {
+              "version": "1.0.1",
+              "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+            },
+            "babel-plugin-proto-to-assign": {
+              "version": "1.0.4",
+              "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+            },
+            "babel-plugin-react-constant-elements": {
+              "version": "1.0.3",
+              "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+            },
+            "babel-plugin-react-display-name": {
+              "version": "1.0.3",
+              "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+            },
+            "babel-plugin-remove-console": {
+              "version": "1.0.1",
+              "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+            },
+            "babel-plugin-remove-debugger": {
+              "version": "1.0.1",
+              "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+            },
+            "babel-plugin-runtime": {
+              "version": "1.0.7",
+              "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+            },
+            "babel-plugin-undeclared-variables-check": {
+              "version": "1.0.2",
+              "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+              "dependencies": {
+                "leven": {
+                  "version": "1.0.2",
+                  "from": "leven@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                }
+              }
+            },
+            "babel-plugin-undefined-to-void": {
+              "version": "1.1.6",
+              "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+            },
+            "babylon": {
+              "version": "5.8.34",
+              "from": "babylon@>=5.8.34 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
+            },
+            "bluebird": {
+              "version": "2.10.2",
+              "from": "bluebird@>=2.9.33 <3.0.0",
+              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+            },
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "convert-source-map": {
+              "version": "1.1.2",
+              "from": "convert-source-map@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+            },
+            "core-js": {
+              "version": "1.2.6",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "detect-indent": {
+              "version": "3.0.1",
+              "from": "detect-indent@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "fs-readdir-recursive": {
+              "version": "0.1.2",
+              "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+            },
+            "globals": {
+              "version": "6.4.1",
+              "from": "globals@>=6.4.0 <7.0.0",
+              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+            },
+            "home-or-tmp": {
+              "version": "1.0.0",
+              "from": "home-or-tmp@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                }
+              }
+            },
+            "is-integer": {
+              "version": "1.0.6",
+              "from": "is-integer@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "js-tokens": {
+              "version": "1.0.1",
+              "from": "js-tokens@1.0.1",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            },
+            "line-numbers": {
+              "version": "0.2.0",
+              "from": "line-numbers@0.2.0",
+              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+              "dependencies": {
+                "left-pad": {
+                  "version": "0.0.3",
+                  "from": "left-pad@0.0.3",
+                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@>=3.3.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@>=2.0.3 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.2",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "output-file-sync": {
+              "version": "1.1.1",
+              "from": "output-file-sync@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "path-exists": {
+              "version": "1.0.0",
+              "from": "path-exists@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "private": {
+              "version": "0.1.6",
+              "from": "private@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+            },
+            "regenerator": {
+              "version": "0.8.40",
+              "from": "regenerator@0.8.40",
+              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+              "dependencies": {
+                "commoner": {
+                  "version": "0.10.4",
+                  "from": "commoner@>=0.10.3 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@>=2.5.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "detective": {
+                      "version": "4.3.1",
+                      "from": "detective@>=4.3.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "1.2.2",
+                          "from": "acorn@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                        },
+                        "defined": {
+                          "version": "1.0.0",
+                          "from": "defined@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "glob@>=5.0.15 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.13",
+                      "from": "iconv-lite@>=0.4.5 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "q": {
+                      "version": "1.4.1",
+                      "from": "q@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                    }
+                  }
+                },
+                "defs": {
+                  "version": "1.1.1",
+                  "from": "defs@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                  "dependencies": {
+                    "alter": {
+                      "version": "0.2.0",
+                      "from": "alter@>=0.2.0 <0.3.0",
+                      "dependencies": {
+                        "stable": {
+                          "version": "0.1.5",
+                          "from": "stable@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                        }
+                      }
+                    },
+                    "ast-traverse": {
+                      "version": "0.1.1",
+                      "from": "ast-traverse@>=0.1.1 <0.2.0"
+                    },
+                    "breakable": {
+                      "version": "1.0.0",
+                      "from": "breakable@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                    },
+                    "simple-fmt": {
+                      "version": "0.1.0",
+                      "from": "simple-fmt@>=0.1.0 <0.2.0"
+                    },
+                    "simple-is": {
+                      "version": "0.2.0",
+                      "from": "simple-is@>=0.2.0 <0.3.0"
+                    },
+                    "stringmap": {
+                      "version": "0.2.2",
+                      "from": "stringmap@>=0.2.2 <0.3.0"
+                    },
+                    "stringset": {
+                      "version": "0.2.1",
+                      "from": "stringset@>=0.2.1 <0.3.0"
+                    },
+                    "tryor": {
+                      "version": "0.1.2",
+                      "from": "tryor@>=0.1.2 <0.2.0"
+                    },
+                    "yargs": {
+                      "version": "3.27.0",
+                      "from": "yargs@>=3.27.0 <3.28.0",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@>=1.2.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "from": "cliui@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.2",
+                              "from": "center-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "0.2.7",
+                                  "from": "lazy-cache@>=0.2.4 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "from": "right-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2"
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.1.1",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                        },
+                        "os-locale": {
+                          "version": "1.4.0",
+                          "from": "os-locale@>=1.4.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                          "dependencies": {
+                            "lcid": {
+                              "version": "1.0.0",
+                              "from": "lcid@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                              "dependencies": {
+                                "invert-kv": {
+                                  "version": "1.0.0",
+                                  "from": "invert-kv@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "window-size": {
+                          "version": "0.1.4",
+                          "from": "window-size@>=0.1.2 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                        },
+                        "y18n": {
+                          "version": "3.2.0",
+                          "from": "y18n@>=3.2.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "esprima-fb": {
+                  "version": "15001.1001.0-dev-harmony-fb",
+                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                },
+                "recast": {
+                  "version": "0.10.33",
+                  "from": "recast@0.10.33",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                  "dependencies": {
+                    "ast-types": {
+                      "version": "0.8.12",
+                      "from": "ast-types@0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                    }
+                  }
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@>=2.3.8 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                }
+              }
+            },
+            "regexpu": {
+              "version": "1.3.0",
+              "from": "regexpu@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "2.7.1",
+                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+                },
+                "recast": {
+                  "version": "0.10.39",
+                  "from": "recast@>=0.10.10 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "ast-types": {
+                      "version": "0.8.12",
+                      "from": "ast-types@0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                    }
+                  }
+                },
+                "regenerate": {
+                  "version": "1.2.1",
+                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "from": "repeating@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "from": "shebang-regex@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+            },
+            "slash": {
+              "version": "1.0.0",
+              "from": "slash@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "from": "source-map-support@>=0.2.10 <0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "source-map@0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.1",
+              "from": "to-fast-properties@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "from": "trim-right@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            },
+            "try-resolve": {
+              "version": "1.0.1",
+              "from": "try-resolve@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "3.2.0",
+          "from": "lodash.assign@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                }
+              }
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.1",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash.pick": {
+          "version": "3.1.0",
+          "from": "lodash.pick@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-3.1.0.tgz",
+          "dependencies": {
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                },
+                "lodash.keysin": {
+                  "version": "3.0.8",
+                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+                  "dependencies": {
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "acorn-to-esprima": {
+          "version": "1.0.7",
+          "from": "acorn-to-esprima@>=1.0.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-to-esprima/-/acorn-to-esprima-1.0.7.tgz"
+        }
+      }
+    },
+    "babel-jest": {
+      "version": "6.0.1",
+      "from": "babel-jest@6.0.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-6.0.1.tgz"
+    },
+    "babel-loader": {
+      "version": "6.2.0",
+      "from": "babel-loader@6.2.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.0.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.12",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.3.13",
+      "from": "babel-preset-es2015@6.3.13",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.3.13.tgz",
+      "dependencies": {
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-template-literals@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-literals@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.3.21",
+          "from": "babel-plugin-transform-es2015-function-name@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.3.21.tgz",
+          "dependencies": {
+            "babel-helper-function-name": {
+              "version": "6.3.15",
+              "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.25 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.3.13",
+                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+                },
+                "babel-template": {
+                  "version": "6.3.13",
+                  "from": "babel-template@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.24 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.25 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.3.15",
+          "from": "babel-plugin-transform-es2015-classes@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.3.15.tgz",
+          "dependencies": {
+            "babel-helper-optimise-call-expression": {
+              "version": "6.3.13",
+              "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
+            },
+            "babel-helper-function-name": {
+              "version": "6.3.15",
+              "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+              "dependencies": {
+                "babel-helper-get-function-arity": {
+                  "version": "6.3.13",
+                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+                }
+              }
+            },
+            "babel-helper-replace-supers": {
+              "version": "6.3.13",
+              "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz"
+            },
+            "babel-template": {
+              "version": "6.3.13",
+              "from": "babel-template@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            },
+            "babel-traverse": {
+              "version": "6.3.25",
+              "from": "babel-traverse@>=6.3.15 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.3.13",
+                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.4",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "1.0.2",
+                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "from": "left-pad@0.0.3",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.25 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "8.15.0",
+                  "from": "globals@>=8.3.0 <9.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.0",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.1.0",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-define-map": {
+              "version": "6.3.13",
+              "from": "babel-helper-define-map@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            },
+            "babel-messages": {
+              "version": "6.3.18",
+              "from": "babel-messages@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-object-super@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.3.13.tgz",
+          "dependencies": {
+            "babel-helper-replace-supers": {
+              "version": "6.3.13",
+              "from": "babel-helper-replace-supers@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.3.13.tgz",
+              "dependencies": {
+                "babel-helper-optimise-call-expression": {
+                  "version": "6.3.13",
+                  "from": "babel-helper-optimise-call-expression@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.3.13.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.25 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.3.18",
+                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                },
+                "babel-template": {
+                  "version": "6.3.13",
+                  "from": "babel-template@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.3.24",
+                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.3.13.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.24 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.25 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-computed-properties@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.3.13.tgz",
+          "dependencies": {
+            "babel-helper-define-map": {
+              "version": "6.3.13",
+              "from": "babel-helper-define-map@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "babel-types": {
+                  "version": "6.3.24",
+                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.24 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.3.25",
+                          "from": "babylon@>=6.3.25 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    }
+                  }
+                },
+                "babel-helper-function-name": {
+                  "version": "6.3.15",
+                  "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.15 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.3.25",
+                          "from": "babylon@>=6.3.25 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-helper-get-function-arity": {
+                      "version": "6.3.13",
+                      "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.3.13",
+              "from": "babel-template@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.3.24",
+                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-for-of@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.3.13.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.3.13",
+              "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.24 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.25 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.3.13.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.3.13",
+              "from": "babel-helper-regex@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.3.13.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "babel-types": {
+                  "version": "6.3.24",
+                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.24 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.3.25",
+                          "from": "babylon@>=6.3.25 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "regexpu": {
+              "version": "1.3.0",
+              "from": "regexpu@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "2.7.1",
+                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+                },
+                "recast": {
+                  "version": "0.10.39",
+                  "from": "recast@>=0.10.10 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.5.3",
+                      "from": "source-map@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "from": "private@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                    },
+                    "ast-types": {
+                      "version": "0.8.12",
+                      "from": "ast-types@0.8.12",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                    }
+                  }
+                },
+                "regenerate": {
+                  "version": "1.2.1",
+                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.3.13",
+          "from": "babel-plugin-check-es2015-constants@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.3.14",
+          "from": "babel-plugin-transform-es2015-spread@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.3.14.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.3.25",
+          "from": "babel-plugin-transform-es2015-parameters@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.3.25.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.3.25",
+              "from": "babel-traverse@>=6.3.25 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.3.13",
+                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.4",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "1.0.2",
+                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "from": "left-pad@0.0.3",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.3.18",
+                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                },
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.25 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "8.15.0",
+                  "from": "globals@>=8.3.0 <9.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.0",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.1.0",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.3.13",
+              "from": "babel-helper-call-delegate@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.3.13.tgz",
+              "dependencies": {
+                "babel-helper-hoist-variables": {
+                  "version": "6.3.13",
+                  "from": "babel-helper-hoist-variables@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.3.13.tgz"
+                }
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.3.13",
+              "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+            },
+            "babel-template": {
+              "version": "6.3.13",
+              "from": "babel-template@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.18 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.21 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.3.15",
+          "from": "babel-plugin-transform-es2015-destructuring@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.3.15.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-block-scoping@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.3.13.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.3.25",
+              "from": "babel-traverse@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.3.13",
+                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.4",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "1.0.2",
+                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "from": "left-pad@0.0.3",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.3.18",
+                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                },
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.25 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "8.15.0",
+                  "from": "globals@>=8.3.0 <9.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.0",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.1.0",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.3.13",
+              "from": "babel-template@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@>=3.10.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.3.16",
+          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.3.16.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.24 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.25 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.3.13",
+              "from": "babel-template@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.3.25",
+                  "from": "babylon@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.3.25",
+                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.3.13",
+                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        },
+                        "line-numbers": {
+                          "version": "0.2.0",
+                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                          "dependencies": {
+                            "left-pad": {
+                              "version": "0.0.3",
+                              "from": "left-pad@0.0.3",
+                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.3.18",
+                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "8.15.0",
+                      "from": "globals@>=8.3.0 <9.0.0",
+                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.0",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.1.0",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "repeating": {
+                      "version": "1.1.3",
+                      "from": "repeating@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            },
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.3.13",
+              "from": "babel-plugin-transform-strict-mode@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.3.13.tgz"
+            }
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.3.18",
+          "from": "babel-plugin-transform-regenerator@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.3.18.tgz",
+          "dependencies": {
+            "babel-plugin-syntax-async-functions": {
+              "version": "6.3.13",
+              "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            },
+            "babel-traverse": {
+              "version": "6.3.25",
+              "from": "babel-traverse@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.3.13",
+                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.1.0",
+                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.4",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.0",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "1.0.2",
+                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                    },
+                    "line-numbers": {
+                      "version": "0.2.0",
+                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                      "dependencies": {
+                        "left-pad": {
+                          "version": "0.0.3",
+                          "from": "left-pad@0.0.3",
+                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.3.18",
+                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "8.15.0",
+                  "from": "globals@>=8.3.0 <9.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.0",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.1.0",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "1.0.2",
+                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.3.24",
+              "from": "babel-types@>=6.3.18 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                }
+              }
+            },
+            "babylon": {
+              "version": "6.3.25",
+              "from": "babylon@>=6.3.18 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+            },
+            "private": {
+              "version": "0.1.6",
+              "from": "private@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "babel-preset-react": {
+      "version": "6.3.13",
+      "from": "babel-preset-react@6.3.13",
+      "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.3.13.tgz",
+      "dependencies": {
+        "babel-plugin-syntax-flow": {
+          "version": "6.3.13",
+          "from": "babel-plugin-syntax-flow@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.3.13",
+          "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.3.15",
+          "from": "babel-plugin-transform-flow-strip-types@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.3.15.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-react-display-name@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-react-jsx@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            },
+            "babel-helper-builder-react-jsx": {
+              "version": "6.3.13",
+              "from": "babel-helper-builder-react-jsx@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.3.13.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.3.24",
+                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.24 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.3.25",
+                          "from": "babylon@>=6.3.25 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.10.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-react-jsx-source@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.3.13.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "babel-preset-stage-0": {
+      "version": "6.3.13",
+      "from": "babel-preset-stage-0@6.3.13",
+      "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.3.13.tgz",
+      "dependencies": {
+        "babel-plugin-transform-do-expressions": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-do-expressions@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-do-expressions/-/babel-plugin-transform-do-expressions-6.3.13.tgz",
+          "dependencies": {
+            "babel-plugin-syntax-do-expressions": {
+              "version": "6.3.13",
+              "from": "babel-plugin-syntax-do-expressions@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-do-expressions/-/babel-plugin-syntax-do-expressions-6.3.13.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-function-bind": {
+          "version": "6.3.13",
+          "from": "babel-plugin-transform-function-bind@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-function-bind/-/babel-plugin-transform-function-bind-6.3.13.tgz",
+          "dependencies": {
+            "babel-plugin-syntax-function-bind": {
+              "version": "6.3.13",
+              "from": "babel-plugin-syntax-function-bind@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-syntax-function-bind/-/babel-plugin-syntax-function-bind-6.3.13.tgz"
+            },
+            "babel-runtime": {
+              "version": "5.8.34",
+              "from": "babel-runtime@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.6",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-preset-stage-1": {
+          "version": "6.3.13",
+          "from": "babel-preset-stage-1@>=6.3.13 <7.0.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.3.13.tgz",
+          "dependencies": {
+            "babel-plugin-transform-class-constructor-call": {
+              "version": "6.3.13",
+              "from": "babel-plugin-transform-class-constructor-call@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.3.13.tgz",
+              "dependencies": {
+                "babel-template": {
+                  "version": "6.3.13",
+                  "from": "babel-template@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.18 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.3.24",
+                      "from": "babel-types@>=6.3.18 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                      "dependencies": {
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.1",
+                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-syntax-class-constructor-call": {
+                  "version": "6.3.13",
+                  "from": "babel-plugin-syntax-class-constructor-call@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.3.13.tgz"
+                },
+                "babel-runtime": {
+                  "version": "5.8.34",
+                  "from": "babel-runtime@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "1.2.6",
+                      "from": "core-js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-class-properties": {
+              "version": "6.3.13",
+              "from": "babel-plugin-transform-class-properties@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.3.13.tgz",
+              "dependencies": {
+                "babel-plugin-syntax-class-properties": {
+                  "version": "6.3.13",
+                  "from": "babel-plugin-syntax-class-properties@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.3.13.tgz"
+                },
+                "babel-runtime": {
+                  "version": "5.8.34",
+                  "from": "babel-runtime@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "1.2.6",
+                      "from": "core-js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-decorators": {
+              "version": "6.3.13",
+              "from": "babel-plugin-transform-decorators@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.3.13.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.3.24",
+                  "from": "babel-types@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.24 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.3.25",
+                          "from": "babylon@>=6.3.25 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.1 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.1",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                    }
+                  }
+                },
+                "babel-helper-define-map": {
+                  "version": "6.3.13",
+                  "from": "babel-helper-define-map@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.3.13.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "babel-helper-function-name": {
+                      "version": "6.3.15",
+                      "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.3.25",
+                          "from": "babel-traverse@>=6.3.24 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.3.13",
+                              "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.1",
+                                  "from": "chalk@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.1.0",
+                                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.4",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.0",
+                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.0.0",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "from": "supports-color@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "from": "esutils@>=2.0.2 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                },
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                },
+                                "line-numbers": {
+                                  "version": "0.2.0",
+                                  "from": "line-numbers@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                  "dependencies": {
+                                    "left-pad": {
+                                      "version": "0.0.3",
+                                      "from": "left-pad@0.0.3",
+                                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.3.18",
+                              "from": "babel-messages@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                            },
+                            "babylon": {
+                              "version": "6.3.25",
+                              "from": "babylon@>=6.3.25 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "from": "debug@>=2.2.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "from": "ms@0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "8.15.0",
+                              "from": "globals@>=8.3.0 <9.0.0",
+                              "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                            },
+                            "invariant": {
+                              "version": "2.2.0",
+                              "from": "invariant@>=2.2.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.1.0",
+                                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeating": {
+                              "version": "1.1.3",
+                              "from": "repeating@>=1.1.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-helper-get-function-arity": {
+                          "version": "6.3.13",
+                          "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-syntax-decorators": {
+                  "version": "6.3.13",
+                  "from": "babel-plugin-syntax-decorators@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.3.13.tgz"
+                },
+                "babel-helper-explode-class": {
+                  "version": "6.3.13",
+                  "from": "babel-helper-explode-class@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.3.13.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.3.25",
+                          "from": "babylon@>=6.3.25 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "lodash": {
+                          "version": "3.10.1",
+                          "from": "lodash@>=3.10.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-helper-bindify-decorators": {
+                      "version": "6.3.13",
+                      "from": "babel-helper-bindify-decorators@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.3.13.tgz"
+                    }
+                  }
+                },
+                "babel-template": {
+                  "version": "6.3.13",
+                  "from": "babel-template@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.3.25",
+                      "from": "babylon@>=6.3.18 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                    },
+                    "babel-traverse": {
+                      "version": "6.3.25",
+                      "from": "babel-traverse@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.3.13",
+                          "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.1",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.1.0",
+                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.4",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.0",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.0.0",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "1.0.2",
+                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                            },
+                            "line-numbers": {
+                              "version": "0.2.0",
+                              "from": "line-numbers@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                              "dependencies": {
+                                "left-pad": {
+                                  "version": "0.0.3",
+                                  "from": "left-pad@0.0.3",
+                                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.3.18",
+                          "from": "babel-messages@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "8.15.0",
+                          "from": "globals@>=8.3.0 <9.0.0",
+                          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.0",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.1.0",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "1.0.2",
+                                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.10.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    }
+                  }
+                },
+                "babel-runtime": {
+                  "version": "5.8.34",
+                  "from": "babel-runtime@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "1.2.6",
+                      "from": "core-js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-export-extensions": {
+              "version": "6.3.13",
+              "from": "babel-plugin-transform-export-extensions@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.3.13.tgz",
+              "dependencies": {
+                "babel-plugin-syntax-export-extensions": {
+                  "version": "6.3.13",
+                  "from": "babel-plugin-syntax-export-extensions@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.3.13.tgz"
+                },
+                "babel-runtime": {
+                  "version": "5.8.34",
+                  "from": "babel-runtime@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "1.2.6",
+                      "from": "core-js@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-preset-stage-2": {
+              "version": "6.3.13",
+              "from": "babel-preset-stage-2@>=6.3.13 <7.0.0",
+              "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.3.13.tgz",
+              "dependencies": {
+                "babel-plugin-syntax-trailing-function-commas": {
+                  "version": "6.3.13",
+                  "from": "babel-plugin-syntax-trailing-function-commas@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.3.13.tgz",
+                  "dependencies": {
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "from": "babel-runtime@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "from": "core-js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-object-rest-spread": {
+                  "version": "6.3.13",
+                  "from": "babel-plugin-transform-object-rest-spread@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.3.13.tgz",
+                  "dependencies": {
+                    "babel-plugin-syntax-object-rest-spread": {
+                      "version": "6.3.13",
+                      "from": "babel-plugin-syntax-object-rest-spread@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.3.13.tgz"
+                    },
+                    "babel-runtime": {
+                      "version": "5.8.34",
+                      "from": "babel-runtime@>=5.0.0 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                      "dependencies": {
+                        "core-js": {
+                          "version": "1.2.6",
+                          "from": "core-js@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-preset-stage-3": {
+                  "version": "6.3.13",
+                  "from": "babel-preset-stage-3@>=6.3.13 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.3.13.tgz",
+                  "dependencies": {
+                    "babel-plugin-transform-async-to-generator": {
+                      "version": "6.3.13",
+                      "from": "babel-plugin-transform-async-to-generator@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.3.13.tgz",
+                      "dependencies": {
+                        "babel-helper-remap-async-to-generator": {
+                          "version": "6.3.13",
+                          "from": "babel-helper-remap-async-to-generator@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.3.13.tgz",
+                          "dependencies": {
+                            "babel-template": {
+                              "version": "6.3.13",
+                              "from": "babel-template@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.3.13.tgz",
+                              "dependencies": {
+                                "babylon": {
+                                  "version": "6.3.25",
+                                  "from": "babylon@>=6.3.13 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                                },
+                                "lodash": {
+                                  "version": "3.10.1",
+                                  "from": "lodash@>=3.10.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                }
+                              }
+                            },
+                            "babel-types": {
+                              "version": "6.3.24",
+                              "from": "babel-types@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                              "dependencies": {
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "from": "esutils@>=2.0.2 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                },
+                                "lodash": {
+                                  "version": "3.10.1",
+                                  "from": "lodash@>=3.10.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                },
+                                "to-fast-properties": {
+                                  "version": "1.0.1",
+                                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "babel-traverse": {
+                              "version": "6.3.25",
+                              "from": "babel-traverse@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.3.13",
+                                  "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.1",
+                                      "from": "chalk@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.1.0",
+                                          "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.4",
+                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.0",
+                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.0.0",
+                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "from": "supports-color@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "esutils": {
+                                      "version": "2.0.2",
+                                      "from": "esutils@>=2.0.2 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                    },
+                                    "js-tokens": {
+                                      "version": "1.0.2",
+                                      "from": "js-tokens@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                    },
+                                    "line-numbers": {
+                                      "version": "0.2.0",
+                                      "from": "line-numbers@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                      "dependencies": {
+                                        "left-pad": {
+                                          "version": "0.0.3",
+                                          "from": "left-pad@0.0.3",
+                                          "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.3.18",
+                                  "from": "babel-messages@>=6.3.13 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                },
+                                "babylon": {
+                                  "version": "6.3.25",
+                                  "from": "babylon@>=6.3.25 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                                },
+                                "debug": {
+                                  "version": "2.2.0",
+                                  "from": "debug@>=2.2.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "0.7.1",
+                                      "from": "ms@0.7.1",
+                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "8.15.0",
+                                  "from": "globals@>=8.3.0 <9.0.0",
+                                  "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                },
+                                "invariant": {
+                                  "version": "2.2.0",
+                                  "from": "invariant@>=2.2.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.1.0",
+                                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "lodash": {
+                                  "version": "3.10.1",
+                                  "from": "lodash@>=3.10.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                },
+                                "repeating": {
+                                  "version": "1.1.3",
+                                  "from": "repeating@>=1.1.3 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-helper-function-name": {
+                              "version": "6.3.15",
+                              "from": "babel-helper-function-name@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.3.15.tgz",
+                              "dependencies": {
+                                "babel-helper-get-function-arity": {
+                                  "version": "6.3.13",
+                                  "from": "babel-helper-get-function-arity@>=6.3.13 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.3.13.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-plugin-syntax-async-functions": {
+                          "version": "6.3.13",
+                          "from": "babel-plugin-syntax-async-functions@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.3.13.tgz"
+                        },
+                        "babel-runtime": {
+                          "version": "5.8.34",
+                          "from": "babel-runtime@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                          "dependencies": {
+                            "core-js": {
+                              "version": "1.2.6",
+                              "from": "core-js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-plugin-transform-exponentiation-operator": {
+                      "version": "6.3.13",
+                      "from": "babel-plugin-transform-exponentiation-operator@>=6.3.13 <7.0.0",
+                      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.3.13.tgz",
+                      "dependencies": {
+                        "babel-plugin-syntax-exponentiation-operator": {
+                          "version": "6.3.13",
+                          "from": "babel-plugin-syntax-exponentiation-operator@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.3.13.tgz"
+                        },
+                        "babel-helper-builder-binary-assignment-operator-visitor": {
+                          "version": "6.3.13",
+                          "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.3.13 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.3.13.tgz",
+                          "dependencies": {
+                            "babel-helper-explode-assignable-expression": {
+                              "version": "6.3.13",
+                              "from": "babel-helper-explode-assignable-expression@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.3.13.tgz",
+                              "dependencies": {
+                                "babel-traverse": {
+                                  "version": "6.3.25",
+                                  "from": "babel-traverse@>=6.3.13 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                                  "dependencies": {
+                                    "babel-code-frame": {
+                                      "version": "6.3.13",
+                                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                      "dependencies": {
+                                        "chalk": {
+                                          "version": "1.1.1",
+                                          "from": "chalk@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                          "dependencies": {
+                                            "ansi-styles": {
+                                              "version": "2.1.0",
+                                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                            },
+                                            "escape-string-regexp": {
+                                              "version": "1.0.4",
+                                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                            },
+                                            "has-ansi": {
+                                              "version": "2.0.0",
+                                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                              "dependencies": {
+                                                "ansi-regex": {
+                                                  "version": "2.0.0",
+                                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                }
+                                              }
+                                            },
+                                            "strip-ansi": {
+                                              "version": "3.0.0",
+                                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                              "dependencies": {
+                                                "ansi-regex": {
+                                                  "version": "2.0.0",
+                                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                }
+                                              }
+                                            },
+                                            "supports-color": {
+                                              "version": "2.0.0",
+                                              "from": "supports-color@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "esutils": {
+                                          "version": "2.0.2",
+                                          "from": "esutils@>=2.0.2 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                        },
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                        },
+                                        "line-numbers": {
+                                          "version": "0.2.0",
+                                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                          "dependencies": {
+                                            "left-pad": {
+                                              "version": "0.0.3",
+                                              "from": "left-pad@0.0.3",
+                                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "babel-messages": {
+                                      "version": "6.3.18",
+                                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                    },
+                                    "babylon": {
+                                      "version": "6.3.25",
+                                      "from": "babylon@>=6.3.25 <7.0.0",
+                                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                                    },
+                                    "debug": {
+                                      "version": "2.2.0",
+                                      "from": "debug@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                      "dependencies": {
+                                        "ms": {
+                                          "version": "0.7.1",
+                                          "from": "ms@0.7.1",
+                                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "globals": {
+                                      "version": "8.15.0",
+                                      "from": "globals@>=8.3.0 <9.0.0",
+                                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                    },
+                                    "invariant": {
+                                      "version": "2.2.0",
+                                      "from": "invariant@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                      "dependencies": {
+                                        "loose-envify": {
+                                          "version": "1.1.0",
+                                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                          "dependencies": {
+                                            "js-tokens": {
+                                              "version": "1.0.2",
+                                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "lodash": {
+                                      "version": "3.10.1",
+                                      "from": "lodash@>=3.10.1 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                    },
+                                    "repeating": {
+                                      "version": "1.1.3",
+                                      "from": "repeating@>=1.1.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                      "dependencies": {
+                                        "is-finite": {
+                                          "version": "1.0.1",
+                                          "from": "is-finite@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                          "dependencies": {
+                                            "number-is-nan": {
+                                              "version": "1.0.0",
+                                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "babel-types": {
+                              "version": "6.3.24",
+                              "from": "babel-types@>=6.3.13 <7.0.0",
+                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.3.24.tgz",
+                              "dependencies": {
+                                "babel-traverse": {
+                                  "version": "6.3.25",
+                                  "from": "babel-traverse@>=6.3.24 <7.0.0",
+                                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.3.25.tgz",
+                                  "dependencies": {
+                                    "babel-code-frame": {
+                                      "version": "6.3.13",
+                                      "from": "babel-code-frame@>=6.3.13 <7.0.0",
+                                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.3.13.tgz",
+                                      "dependencies": {
+                                        "chalk": {
+                                          "version": "1.1.1",
+                                          "from": "chalk@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                                          "dependencies": {
+                                            "ansi-styles": {
+                                              "version": "2.1.0",
+                                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                                            },
+                                            "escape-string-regexp": {
+                                              "version": "1.0.4",
+                                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                                            },
+                                            "has-ansi": {
+                                              "version": "2.0.0",
+                                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                              "dependencies": {
+                                                "ansi-regex": {
+                                                  "version": "2.0.0",
+                                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                }
+                                              }
+                                            },
+                                            "strip-ansi": {
+                                              "version": "3.0.0",
+                                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                                              "dependencies": {
+                                                "ansi-regex": {
+                                                  "version": "2.0.0",
+                                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                                }
+                                              }
+                                            },
+                                            "supports-color": {
+                                              "version": "2.0.0",
+                                              "from": "supports-color@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "js-tokens": {
+                                          "version": "1.0.2",
+                                          "from": "js-tokens@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                        },
+                                        "line-numbers": {
+                                          "version": "0.2.0",
+                                          "from": "line-numbers@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                                          "dependencies": {
+                                            "left-pad": {
+                                              "version": "0.0.3",
+                                              "from": "left-pad@0.0.3",
+                                              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "babel-messages": {
+                                      "version": "6.3.18",
+                                      "from": "babel-messages@>=6.3.13 <7.0.0",
+                                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.3.18.tgz"
+                                    },
+                                    "babylon": {
+                                      "version": "6.3.25",
+                                      "from": "babylon@>=6.3.25 <7.0.0",
+                                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.3.25.tgz"
+                                    },
+                                    "debug": {
+                                      "version": "2.2.0",
+                                      "from": "debug@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                                      "dependencies": {
+                                        "ms": {
+                                          "version": "0.7.1",
+                                          "from": "ms@0.7.1",
+                                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "globals": {
+                                      "version": "8.15.0",
+                                      "from": "globals@>=8.3.0 <9.0.0",
+                                      "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+                                    },
+                                    "invariant": {
+                                      "version": "2.2.0",
+                                      "from": "invariant@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.0.tgz",
+                                      "dependencies": {
+                                        "loose-envify": {
+                                          "version": "1.1.0",
+                                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+                                          "dependencies": {
+                                            "js-tokens": {
+                                              "version": "1.0.2",
+                                              "from": "js-tokens@>=1.0.1 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "repeating": {
+                                      "version": "1.1.3",
+                                      "from": "repeating@>=1.1.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                                      "dependencies": {
+                                        "is-finite": {
+                                          "version": "1.0.1",
+                                          "from": "is-finite@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                          "dependencies": {
+                                            "number-is-nan": {
+                                              "version": "1.0.0",
+                                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "from": "esutils@>=2.0.2 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                },
+                                "lodash": {
+                                  "version": "3.10.1",
+                                  "from": "lodash@>=3.10.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                                },
+                                "to-fast-properties": {
+                                  "version": "1.0.1",
+                                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-runtime": {
+                          "version": "5.8.34",
+                          "from": "babel-runtime@>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.34.tgz",
+                          "dependencies": {
+                            "core-js": {
+                              "version": "1.2.6",
+                              "from": "core-js@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "classnames": {
+      "version": "2.2.1",
+      "from": "classnames@2.2.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.1.tgz"
+    },
+    "es6-symbol": {
+      "version": "3.0.2",
+      "from": "es6-symbol@3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.0.2.tgz",
+      "dependencies": {
+        "d": {
+          "version": "0.1.1",
+          "from": "d@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+        },
+        "es5-ext": {
+          "version": "0.10.11",
+          "from": "es5-ext@>=0.10.10 <0.11.0",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz",
+          "dependencies": {
+            "es6-iterator": {
+              "version": "2.0.0",
+              "from": "es6-iterator@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "from": "eslint@1.10.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.5.1",
+          "from": "concat-stream@>=1.4.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.5 <0.1.0",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "2.0.5",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "from": "doctrine@>=0.7.1 <0.8.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "from": "esutils@>=1.1.6 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.4",
+          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+        },
+        "escope": {
+          "version": "3.3.0",
+          "from": "escope@>=3.3.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.3.0.tgz",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.3",
+              "from": "es6-map@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.11",
+                  "from": "es5-ext@>=0.10.8 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "from": "es6-iterator@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                },
+                "es6-set": {
+                  "version": "0.1.3",
+                  "from": "es6-set@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.3.tgz"
+                },
+                "event-emitter": {
+                  "version": "0.3.4",
+                  "from": "event-emitter@>=0.3.4 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.1",
+              "from": "es6-weak-map@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.11",
+                  "from": "es5-ext@>=0.10.8 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.11.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.0",
+                  "from": "es6-iterator@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "3.1.1",
+              "from": "esrecurse@>=3.1.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-3.1.1.tgz",
+              "dependencies": {
+                "estraverse": {
+                  "version": "3.1.0",
+                  "from": "estraverse@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-3.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "espree": {
+          "version": "2.2.5",
+          "from": "espree@>=2.2.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-2.2.5.tgz"
+        },
+        "estraverse": {
+          "version": "4.1.1",
+          "from": "estraverse@>=4.1.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
+        },
+        "estraverse-fb": {
+          "version": "1.3.1",
+          "from": "estraverse-fb@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.1.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "file-entry-cache": {
+          "version": "1.2.4",
+          "from": "file-entry-cache@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.2.4.tgz",
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.0.10",
+              "from": "flat-cache@>=1.0.9 <2.0.0",
+              "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.0.10.tgz",
+              "dependencies": {
+                "del": {
+                  "version": "2.2.0",
+                  "from": "del@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
+                  "dependencies": {
+                    "globby": {
+                      "version": "4.0.0",
+                      "from": "globby@>=4.0.0 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/globby/-/globby-4.0.0.tgz",
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.1",
+                          "from": "array-union@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.2",
+                              "from": "array-uniq@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1",
+                          "from": "arrify@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                        },
+                        "glob": {
+                          "version": "6.0.1",
+                          "from": "glob@>=6.0.1 <7.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.1.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0",
+                          "from": "is-path-inside@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "from": "pify@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.1",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.4.4",
+                      "from": "rimraf@>=2.2.8 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.2",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                },
+                "read-json-sync": {
+                  "version": "1.1.1",
+                  "from": "read-json-sync@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/read-json-sync/-/read-json-sync-1.1.1.tgz"
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "from": "write@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "from": "glob@>=5.0.14 <6.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "8.15.0",
+          "from": "globals@>=8.11.0 <9.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-8.15.0.tgz"
+        },
+        "handlebars": {
+          "version": "4.0.5",
+          "from": "handlebars@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "1.5.0",
+              "from": "async@>=1.4.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.4 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.6.1",
+              "from": "uglify-js@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0"
+                },
+                "source-map": {
+                  "version": "0.5.3",
+                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.2",
+                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.1",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.0",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "0.2.7",
+                              "from": "lazy-cache@>=0.2.4 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.3",
+                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "2.0.1",
+                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.0",
+                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "from": "wordwrap@0.0.2"
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.1.1",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.11.0",
+          "from": "inquirer@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.11.0.tgz",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.1.0",
+              "from": "ansi-escapes@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.1.0.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.0.0",
+              "from": "ansi-regex@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1",
+                      "from": "exit-hook@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+                    },
+                    "onetime": {
+                      "version": "1.1.0",
+                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "1.1.0",
+              "from": "cli-width@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.1.0.tgz"
+            },
+            "figures": {
+              "version": "1.4.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@>=3.3.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "from": "readline2@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.0.0.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "mute-stream@0.0.5",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "from": "run-async@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2",
+              "from": "rx-lite@>=3.1.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.6 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.12.3",
+          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "from": "generate-function@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "from": "generate-object-property@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "from": "is-property@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "2.0.0",
+              "from": "jsonpointer@2.0.0",
+              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "from": "is-resolvable@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.2",
+              "from": "tryit@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.2.tgz"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.4.5",
+          "from": "js-yaml@3.4.5",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.5.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.3",
+              "from": "argparse@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "3.10.1",
+                  "from": "lodash@>=3.2.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                },
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.1",
+              "from": "esprima@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.0",
+          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0"
+            }
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "from": "lodash.clonedeep@>=3.0.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "3.3.0",
+              "from": "lodash._baseclone@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+                },
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "from": "lodash.merge@>=3.3.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "from": "lodash._arraycopy@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz"
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "from": "lodash._arrayeach@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz"
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "from": "lodash._getnative@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+            },
+            "lodash.isarguments": {
+              "version": "3.0.4",
+              "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "from": "lodash.isarray@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "from": "lodash.isplainobject@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.2",
+              "from": "lodash.istypedarray@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.2.tgz"
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "from": "lodash.keysin@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz"
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "from": "lodash.toplainobject@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "from": "lodash.omit@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-3.1.0.tgz",
+          "dependencies": {
+            "lodash._arraymap": {
+              "version": "3.0.0",
+              "from": "lodash._arraymap@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz"
+            },
+            "lodash._basedifference": {
+              "version": "3.0.3",
+              "from": "lodash._basedifference@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0",
+                  "from": "lodash._baseindexof@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz"
+                },
+                "lodash._cacheindexof": {
+                  "version": "3.0.2",
+                  "from": "lodash._cacheindexof@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz"
+                },
+                "lodash._createcache": {
+                  "version": "3.1.2",
+                  "from": "lodash._createcache@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "from": "lodash._baseflatten@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "from": "lodash._pickbyarray@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz"
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "from": "lodash._pickbycallback@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.2",
+                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.2.tgz"
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "from": "lodash.keysin@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.0",
+          "from": "minimatch@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.2",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.3.0",
+                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "optionator": {
+          "version": "0.6.0",
+          "from": "optionator@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.6.0.tgz",
+          "dependencies": {
+            "prelude-ls": {
+              "version": "1.1.2",
+              "from": "prelude-ls@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "from": "deep-is@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "type-check": {
+              "version": "0.3.1",
+              "from": "type-check@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+            },
+            "levn": {
+              "version": "0.2.5",
+              "from": "levn@>=0.2.5 <0.3.0",
+              "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7",
+              "from": "fast-levenshtein@>=1.0.6 <1.1.0",
+              "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "path-is-inside": {
+          "version": "1.0.1",
+          "from": "path-is-inside@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "from": "shelljs@>=0.5.3 <0.6.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "from": "strip-json-comments@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.1",
+              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
+            }
+          }
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "from": "xml-escape@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.0.0.tgz"
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "3.12.0",
+      "from": "eslint-plugin-react@3.12.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-3.12.0.tgz"
+    },
+    "fbjs": {
+      "version": "0.5.1",
+      "from": "fbjs@0.5.1",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.5.1.tgz",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.6",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+        },
+        "loose-envify": {
+          "version": "1.1.0",
+          "from": "loose-envify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "1.0.2",
+              "from": "js-tokens@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+            }
+          }
+        },
+        "promise": {
+          "version": "7.0.4",
+          "from": "promise@>=7.0.3 <8.0.0",
+          "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
+          "dependencies": {
+            "asap": {
+              "version": "2.0.3",
+              "from": "asap@>=2.0.3 <2.1.0",
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+            }
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.10",
+          "from": "ua-parser-js@>=0.7.9 <0.8.0",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+        },
+        "whatwg-fetch": {
+          "version": "0.9.0",
+          "from": "whatwg-fetch@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+        }
+      }
+    },
+    "fbjs-scripts": {
+      "version": "0.5.0",
+      "from": "fbjs-scripts@0.5.0",
+      "resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.5.0.tgz",
+      "dependencies": {
+        "babel": {
+          "version": "5.8.34",
+          "from": "babel@>=5.4.7 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.34.tgz",
+          "dependencies": {
+            "babel-core": {
+              "version": "5.8.34",
+              "from": "babel-core@>=5.6.21 <6.0.0",
+              "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
+              "dependencies": {
+                "babel-plugin-constant-folding": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
+                },
+                "babel-plugin-dead-code-elimination": {
+                  "version": "1.0.2",
+                  "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
+                },
+                "babel-plugin-eval": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
+                },
+                "babel-plugin-inline-environment-variables": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
+                },
+                "babel-plugin-jscript": {
+                  "version": "1.0.4",
+                  "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
+                },
+                "babel-plugin-member-expression-literals": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
+                },
+                "babel-plugin-property-literals": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
+                },
+                "babel-plugin-proto-to-assign": {
+                  "version": "1.0.4",
+                  "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
+                },
+                "babel-plugin-react-constant-elements": {
+                  "version": "1.0.3",
+                  "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
+                },
+                "babel-plugin-react-display-name": {
+                  "version": "1.0.3",
+                  "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
+                },
+                "babel-plugin-remove-console": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
+                },
+                "babel-plugin-remove-debugger": {
+                  "version": "1.0.1",
+                  "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
+                },
+                "babel-plugin-runtime": {
+                  "version": "1.0.7",
+                  "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
+                },
+                "babel-plugin-undeclared-variables-check": {
+                  "version": "1.0.2",
+                  "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+                  "dependencies": {
+                    "leven": {
+                      "version": "1.0.2",
+                      "from": "leven@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-undefined-to-void": {
+                  "version": "1.1.6",
+                  "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
+                },
+                "babylon": {
+                  "version": "5.8.34",
+                  "from": "babylon@>=5.8.34 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
+                },
+                "bluebird": {
+                  "version": "2.10.2",
+                  "from": "bluebird@>=2.9.33 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+                },
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.1.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                    }
+                  }
+                },
+                "detect-indent": {
+                  "version": "3.0.1",
+                  "from": "detect-indent@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "globals": {
+                  "version": "6.4.1",
+                  "from": "globals@>=6.4.0 <7.0.0",
+                  "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+                },
+                "home-or-tmp": {
+                  "version": "1.0.0",
+                  "from": "home-or-tmp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    },
+                    "user-home": {
+                      "version": "1.1.1",
+                      "from": "user-home@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+                    }
+                  }
+                },
+                "is-integer": {
+                  "version": "1.0.6",
+                  "from": "is-integer@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "js-tokens": {
+                  "version": "1.0.1",
+                  "from": "js-tokens@1.0.1",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
+                },
+                "json5": {
+                  "version": "0.4.0",
+                  "from": "json5@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+                },
+                "line-numbers": {
+                  "version": "0.2.0",
+                  "from": "line-numbers@0.2.0",
+                  "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+                  "dependencies": {
+                    "left-pad": {
+                      "version": "0.0.3",
+                      "from": "left-pad@0.0.3",
+                      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.3 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.2",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "private@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "regenerator": {
+                  "version": "0.8.40",
+                  "from": "regenerator@0.8.40",
+                  "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
+                  "dependencies": {
+                    "commoner": {
+                      "version": "0.10.4",
+                      "from": "commoner@>=0.10.3 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
+                      "dependencies": {
+                        "detective": {
+                          "version": "4.3.1",
+                          "from": "detective@>=4.3.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
+                          "dependencies": {
+                            "acorn": {
+                              "version": "1.2.2",
+                              "from": "acorn@>=1.0.3 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                            },
+                            "defined": {
+                              "version": "1.0.0",
+                              "from": "defined@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "graceful-fs": {
+                          "version": "4.1.2",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                        },
+                        "iconv-lite": {
+                          "version": "0.4.13",
+                          "from": "iconv-lite@>=0.4.5 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+                        },
+                        "mkdirp": {
+                          "version": "0.5.1",
+                          "from": "mkdirp@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "q": {
+                          "version": "1.4.1",
+                          "from": "q@>=1.1.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+                        }
+                      }
+                    },
+                    "defs": {
+                      "version": "1.1.1",
+                      "from": "defs@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
+                      "dependencies": {
+                        "alter": {
+                          "version": "0.2.0",
+                          "from": "alter@>=0.2.0 <0.3.0",
+                          "dependencies": {
+                            "stable": {
+                              "version": "0.1.5",
+                              "from": "stable@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "ast-traverse": {
+                          "version": "0.1.1",
+                          "from": "ast-traverse@>=0.1.1 <0.2.0"
+                        },
+                        "breakable": {
+                          "version": "1.0.0",
+                          "from": "breakable@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
+                        },
+                        "simple-fmt": {
+                          "version": "0.1.0",
+                          "from": "simple-fmt@>=0.1.0 <0.2.0"
+                        },
+                        "simple-is": {
+                          "version": "0.2.0",
+                          "from": "simple-is@>=0.2.0 <0.3.0"
+                        },
+                        "stringmap": {
+                          "version": "0.2.2",
+                          "from": "stringmap@>=0.2.2 <0.3.0"
+                        },
+                        "stringset": {
+                          "version": "0.2.1",
+                          "from": "stringset@>=0.2.1 <0.3.0"
+                        },
+                        "tryor": {
+                          "version": "0.1.2",
+                          "from": "tryor@>=0.1.2 <0.2.0"
+                        },
+                        "yargs": {
+                          "version": "3.27.0",
+                          "from": "yargs@>=3.27.0 <3.28.0",
+                          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.2.1",
+                              "from": "camelcase@>=1.2.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                            },
+                            "cliui": {
+                              "version": "2.1.0",
+                              "from": "cliui@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                              "dependencies": {
+                                "center-align": {
+                                  "version": "0.1.2",
+                                  "from": "center-align@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.3",
+                                      "from": "align-text@>=0.1.0 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "2.0.1",
+                                          "from": "kind-of@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.0",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "longest@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    },
+                                    "lazy-cache": {
+                                      "version": "0.2.7",
+                                      "from": "lazy-cache@>=0.2.4 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                                    }
+                                  }
+                                },
+                                "right-align": {
+                                  "version": "0.1.3",
+                                  "from": "right-align@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                  "dependencies": {
+                                    "align-text": {
+                                      "version": "0.1.3",
+                                      "from": "align-text@>=0.1.1 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                      "dependencies": {
+                                        "kind-of": {
+                                          "version": "2.0.1",
+                                          "from": "kind-of@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.0",
+                                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                            }
+                                          }
+                                        },
+                                        "longest": {
+                                          "version": "1.0.1",
+                                          "from": "longest@>=1.0.1 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "wordwrap": {
+                                  "version": "0.0.2",
+                                  "from": "wordwrap@0.0.2"
+                                }
+                              }
+                            },
+                            "decamelize": {
+                              "version": "1.1.1",
+                              "from": "decamelize@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                            },
+                            "os-locale": {
+                              "version": "1.4.0",
+                              "from": "os-locale@>=1.4.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                              "dependencies": {
+                                "lcid": {
+                                  "version": "1.0.0",
+                                  "from": "lcid@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                                  "dependencies": {
+                                    "invert-kv": {
+                                      "version": "1.0.0",
+                                      "from": "invert-kv@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "window-size": {
+                              "version": "0.1.4",
+                              "from": "window-size@>=0.1.2 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
+                            },
+                            "y18n": {
+                              "version": "3.2.0",
+                              "from": "y18n@>=3.2.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.33",
+                      "from": "recast@0.10.33",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
+                      "dependencies": {
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "from": "ast-types@0.8.12",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        }
+                      }
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.3.8 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "regexpu": {
+                  "version": "1.3.0",
+                  "from": "regexpu@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
+                  "dependencies": {
+                    "esprima": {
+                      "version": "2.7.1",
+                      "from": "esprima@>=2.6.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+                    },
+                    "recast": {
+                      "version": "0.10.39",
+                      "from": "recast@>=0.10.10 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
+                      "dependencies": {
+                        "esprima-fb": {
+                          "version": "15001.1001.0-dev-harmony-fb",
+                          "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
+                        },
+                        "ast-types": {
+                          "version": "0.8.12",
+                          "from": "ast-types@0.8.12",
+                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
+                        }
+                      }
+                    },
+                    "regenerate": {
+                      "version": "1.2.1",
+                      "from": "regenerate@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "regjsgen@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "regjsparser@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "jsesc@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "repeating": {
+                  "version": "1.1.3",
+                  "from": "repeating@>=1.1.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "resolve": {
+                  "version": "1.1.6",
+                  "from": "resolve@>=1.1.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+                },
+                "shebang-regex": {
+                  "version": "1.0.0",
+                  "from": "shebang-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+                },
+                "source-map-support": {
+                  "version": "0.2.10",
+                  "from": "source-map-support@>=0.2.10 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+                  "dependencies": {
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "source-map@0.1.32",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "1.0.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-fast-properties": {
+                  "version": "1.0.1",
+                  "from": "to-fast-properties@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+                },
+                "trim-right": {
+                  "version": "1.0.1",
+                  "from": "trim-right@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+                },
+                "try-resolve": {
+                  "version": "1.0.1",
+                  "from": "try-resolve@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+                }
+              }
+            },
+            "chokidar": {
+              "version": "1.4.1",
+              "from": "chokidar@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                    },
+                    "micromatch": {
+                      "version": "2.3.7",
+                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.0.1",
+                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                        },
+                        "braces": {
+                          "version": "1.8.3",
+                          "from": "braces@>=1.8.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.1",
+                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "2.0.0",
+                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.5",
+                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.4",
+                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                        },
+                        "extglob": {
+                          "version": "0.3.1",
+                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                          "dependencies": {
+                            "ansi-green": {
+                              "version": "0.1.1",
+                              "from": "ansi-green@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                              "dependencies": {
+                                "ansi-wrap": {
+                                  "version": "0.1.0",
+                                  "from": "ansi-wrap@0.1.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                                }
+                              }
+                            },
+                            "success-symbol": {
+                              "version": "0.1.0",
+                              "from": "success-symbol@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                            }
+                          }
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "3.0.2",
+                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.0",
+                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.0.1",
+                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                        },
+                        "object.omit": {
+                          "version": "2.0.0",
+                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.2",
+                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.2",
+                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.4.0",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "readdirp": {
+                  "version": "2.0.0",
+                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.10 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.2",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fsevents": {
+                  "version": "1.0.6",
+                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.6.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.1.0",
+                      "from": "nan@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.17",
+                      "from": "node-pre-gyp@>=0.6.17 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.17.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.6",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.7",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@^2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "async": {
+                      "version": "1.5.0",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@^1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.10.1",
+                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.4.0",
+                      "from": "deep-extend@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.3",
+                      "from": "har-validator@~2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@4.1",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "1.0.1",
+                      "from": "has-unicode@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.0",
+                      "from": "http-signature@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.2",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@*",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.3",
+                      "from": "is-my-json-valid@^2.12.3",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "from": "lodash._createpadding@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                    },
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "from": "lodash._basetostring@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.1",
+                      "from": "lodash.pad@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "from": "lodash.padleft@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "from": "lodash.padright@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "mime-db@~1.19.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "3.0.1",
+                      "from": "lodash.repeat@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.7",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "npmlog": {
+                      "version": "2.0.0",
+                      "from": "npmlog@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                    },
+                    "pinkie": {
+                      "version": "2.0.1",
+                      "from": "pinkie@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "from": "qs@~5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+                    },
+                    "request": {
+                      "version": "2.67.0",
+                      "from": "request@2.x",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1",
+                      "from": "tunnel-agent@~0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.2",
+                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    },
+                    "rc": {
+                      "version": "1.1.5",
+                      "from": "rc@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.0",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "from": "assert-plus@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "from": "bl@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.4",
+                          "from": "readable-stream@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "from": "process-nextick-args@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.1.0",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@~1.0.2",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.3",
+                      "from": "fstream-ignore@~1.0.3",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "from": "brace-expansion@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.1",
+                                  "from": "balanced-match@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.4.4",
+                      "from": "rimraf@~2.4.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "glob@^5.0.14",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.1",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.1",
+                                      "from": "balanced-match@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@^1.3.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "from": "commander@>=2.6.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "convert-source-map": {
+              "version": "1.1.2",
+              "from": "convert-source-map@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
+            },
+            "fs-readdir-recursive": {
+              "version": "0.1.2",
+              "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+            },
+            "glob": {
+              "version": "5.0.15",
+              "from": "glob@>=5.0.5 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "3.0.0",
+                  "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.2",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@>=3.2.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+            },
+            "output-file-sync": {
+              "version": "1.1.1",
+              "from": "output-file-sync@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "path-exists": {
+              "version": "1.0.0",
+              "from": "path-exists@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+            },
+            "slash": {
+              "version": "1.0.0",
+              "from": "slash@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+            }
+          }
+        },
+        "core-js": {
+          "version": "1.2.6",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+        },
+        "gulp-util": {
+          "version": "3.0.7",
+          "from": "gulp-util@>=3.0.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "beeper": {
+              "version": "1.1.0",
+              "from": "beeper@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
+            },
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "dateformat": {
+              "version": "1.0.12",
+              "from": "dateformat@>=1.0.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.6.0",
+                  "from": "meow@>=3.3.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.0.0",
+                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.0.1",
+                          "from": "camelcase@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "loud-rejection": {
+                      "version": "1.2.0",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                      "dependencies": {
+                        "signal-exit": {
+                          "version": "2.1.2",
+                          "from": "signal-exit@>=2.1.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                        }
+                      }
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.4",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.0",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.1.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.2",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.4",
+                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.1.0",
+                                  "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "object-assign": {
+                      "version": "4.0.1",
+                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.0",
+                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.0",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.1",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.2",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.2",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "from": "redent@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.0",
+                              "from": "repeating@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fancy-log": {
+              "version": "1.1.0",
+              "from": "fancy-log@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
+            },
+            "gulplog": {
+              "version": "1.0.0",
+              "from": "gulplog@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+              "dependencies": {
+                "glogg": {
+                  "version": "1.0.0",
+                  "from": "glogg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                  "dependencies": {
+                    "sparkles": {
+                      "version": "1.0.0",
+                      "from": "sparkles@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "has-gulplog": {
+              "version": "0.1.0",
+              "from": "has-gulplog@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+              "dependencies": {
+                "sparkles": {
+                  "version": "1.0.0",
+                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                }
+              }
+            },
+            "lodash._reescape": {
+              "version": "3.0.0",
+              "from": "lodash._reescape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+            },
+            "lodash._reevaluate": {
+              "version": "3.0.0",
+              "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+            },
+            "lodash._reinterpolate": {
+              "version": "3.0.0",
+              "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+            },
+            "lodash.template": {
+              "version": "3.6.2",
+              "from": "lodash.template@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "3.0.1",
+                  "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                },
+                "lodash._basevalues": {
+                  "version": "3.0.0",
+                  "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.escape": {
+                  "version": "3.0.0",
+                  "from": "lodash.escape@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                },
+                "lodash.templatesettings": {
+                  "version": "3.1.0",
+                  "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "3.0.0",
+              "from": "object-assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "vinyl": {
+              "version": "0.5.3",
+              "from": "vinyl@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "1.0.2",
+                  "from": "clone@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "semver": {
+          "version": "5.1.0",
+          "from": "semver@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+        },
+        "through2": {
+          "version": "2.0.0",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.5",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <4.1.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "flow-bin": {
+      "version": "0.20.1",
+      "from": "flow-bin@0.20.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.20.1.tgz",
+      "dependencies": {
+        "bin-wrapper": {
+          "version": "2.1.3",
+          "from": "bin-wrapper@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/bin-wrapper/-/bin-wrapper-2.1.3.tgz",
+          "dependencies": {
+            "bin-check": {
+              "version": "1.1.0",
+              "from": "bin-check@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/bin-check/-/bin-check-1.1.0.tgz",
+              "dependencies": {
+                "executable": {
+                  "version": "1.1.0",
+                  "from": "executable@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/executable/-/executable-1.1.0.tgz",
+                  "dependencies": {
+                    "meow": {
+                      "version": "3.6.0",
+                      "from": "meow@>=3.1.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "2.0.0",
+                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "2.0.1",
+                              "from": "camelcase@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "loud-rejection": {
+                          "version": "1.2.0",
+                          "from": "loud-rejection@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                          "dependencies": {
+                            "signal-exit": {
+                              "version": "2.1.2",
+                              "from": "signal-exit@>=2.1.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.4",
+                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.0",
+                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0",
+                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.1.0",
+                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-exceptions": {
+                                      "version": "1.0.4",
+                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                    },
+                                    "spdx-license-ids": {
+                                      "version": "1.1.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg-up": {
+                          "version": "1.0.1",
+                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                          "dependencies": {
+                            "find-up": {
+                              "version": "1.1.0",
+                              "from": "find-up@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "dependencies": {
+                                "path-exists": {
+                                  "version": "2.1.0",
+                                  "from": "path-exists@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "read-pkg": {
+                              "version": "1.1.0",
+                              "from": "read-pkg@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                              "dependencies": {
+                                "load-json-file": {
+                                  "version": "1.1.0",
+                                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "2.2.0",
+                                      "from": "parse-json@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.0",
+                                          "from": "error-ex@>=1.2.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-bom": {
+                                      "version": "2.0.0",
+                                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                      "dependencies": {
+                                        "is-utf8": {
+                                          "version": "0.2.1",
+                                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "1.1.0",
+                                  "from": "path-type@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "redent": {
+                          "version": "1.0.0",
+                          "from": "redent@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "2.1.0",
+                              "from": "indent-string@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "dependencies": {
+                                "repeating": {
+                                  "version": "2.0.0",
+                                  "from": "repeating@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "strip-indent": {
+                              "version": "1.0.1",
+                              "from": "strip-indent@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                              "dependencies": {
+                                "get-stdin": {
+                                  "version": "4.0.1",
+                                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "trim-newlines": {
+                          "version": "1.0.0",
+                          "from": "trim-newlines@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "spawn-sync": {
+                  "version": "1.0.14",
+                  "from": "spawn-sync@>=1.0.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.14.tgz",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.1",
+                      "from": "concat-stream@>=1.4.7 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@>=0.0.5 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.5",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "os-shim": {
+                      "version": "0.1.3",
+                      "from": "os-shim@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "bin-version-check": {
+              "version": "2.1.0",
+              "from": "bin-version-check@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/bin-version-check/-/bin-version-check-2.1.0.tgz",
+              "dependencies": {
+                "bin-version": {
+                  "version": "1.0.4",
+                  "from": "bin-version@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bin-version/-/bin-version-1.0.4.tgz",
+                  "dependencies": {
+                    "find-versions": {
+                      "version": "1.2.1",
+                      "from": "find-versions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-1.2.1.tgz",
+                      "dependencies": {
+                        "array-uniq": {
+                          "version": "1.0.2",
+                          "from": "array-uniq@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "meow": {
+                          "version": "3.6.0",
+                          "from": "meow@>=3.5.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                          "dependencies": {
+                            "camelcase-keys": {
+                              "version": "2.0.0",
+                              "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                              "dependencies": {
+                                "camelcase": {
+                                  "version": "2.0.1",
+                                  "from": "camelcase@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                                },
+                                "map-obj": {
+                                  "version": "1.0.1",
+                                  "from": "map-obj@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "loud-rejection": {
+                              "version": "1.2.0",
+                              "from": "loud-rejection@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                              "dependencies": {
+                                "signal-exit": {
+                                  "version": "2.1.2",
+                                  "from": "signal-exit@>=2.1.2 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                                }
+                              }
+                            },
+                            "normalize-package-data": {
+                              "version": "2.3.5",
+                              "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                              "dependencies": {
+                                "hosted-git-info": {
+                                  "version": "2.1.4",
+                                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                                },
+                                "is-builtin-module": {
+                                  "version": "1.0.0",
+                                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                                  "dependencies": {
+                                    "builtin-modules": {
+                                      "version": "1.1.0",
+                                      "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "validate-npm-package-license": {
+                                  "version": "3.0.1",
+                                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                                  "dependencies": {
+                                    "spdx-correct": {
+                                      "version": "1.0.2",
+                                      "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                      "dependencies": {
+                                        "spdx-license-ids": {
+                                          "version": "1.1.0",
+                                          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "spdx-expression-parse": {
+                                      "version": "1.0.2",
+                                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                                      "dependencies": {
+                                        "spdx-exceptions": {
+                                          "version": "1.0.4",
+                                          "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                        },
+                                        "spdx-license-ids": {
+                                          "version": "1.1.0",
+                                          "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "read-pkg-up": {
+                              "version": "1.0.1",
+                              "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                              "dependencies": {
+                                "find-up": {
+                                  "version": "1.1.0",
+                                  "from": "find-up@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                                  "dependencies": {
+                                    "path-exists": {
+                                      "version": "2.1.0",
+                                      "from": "path-exists@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "read-pkg": {
+                                  "version": "1.1.0",
+                                  "from": "read-pkg@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                                  "dependencies": {
+                                    "load-json-file": {
+                                      "version": "1.1.0",
+                                      "from": "load-json-file@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "4.1.2",
+                                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                        },
+                                        "parse-json": {
+                                          "version": "2.2.0",
+                                          "from": "parse-json@>=2.2.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                          "dependencies": {
+                                            "error-ex": {
+                                              "version": "1.3.0",
+                                              "from": "error-ex@>=1.2.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                              "dependencies": {
+                                                "is-arrayish": {
+                                                  "version": "0.2.1",
+                                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "pify": {
+                                          "version": "2.3.0",
+                                          "from": "pify@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                        },
+                                        "pinkie-promise": {
+                                          "version": "2.0.0",
+                                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                          "dependencies": {
+                                            "pinkie": {
+                                              "version": "2.0.1",
+                                              "from": "pinkie@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "strip-bom": {
+                                          "version": "2.0.0",
+                                          "from": "strip-bom@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                          "dependencies": {
+                                            "is-utf8": {
+                                              "version": "0.2.1",
+                                              "from": "is-utf8@>=0.2.0 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "path-type": {
+                                      "version": "1.1.0",
+                                      "from": "path-type@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                                      "dependencies": {
+                                        "graceful-fs": {
+                                          "version": "4.1.2",
+                                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                        },
+                                        "pify": {
+                                          "version": "2.3.0",
+                                          "from": "pify@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                        },
+                                        "pinkie-promise": {
+                                          "version": "2.0.0",
+                                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                          "dependencies": {
+                                            "pinkie": {
+                                              "version": "2.0.1",
+                                              "from": "pinkie@>=2.0.0 <3.0.0",
+                                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "redent": {
+                              "version": "1.0.0",
+                              "from": "redent@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                              "dependencies": {
+                                "indent-string": {
+                                  "version": "2.1.0",
+                                  "from": "indent-string@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                                  "dependencies": {
+                                    "repeating": {
+                                      "version": "2.0.0",
+                                      "from": "repeating@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                      "dependencies": {
+                                        "is-finite": {
+                                          "version": "1.0.1",
+                                          "from": "is-finite@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                          "dependencies": {
+                                            "number-is-nan": {
+                                              "version": "1.0.0",
+                                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "strip-indent": {
+                                  "version": "1.0.1",
+                                  "from": "strip-indent@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "trim-newlines": {
+                              "version": "1.0.0",
+                              "from": "trim-newlines@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "semver-regex": {
+                          "version": "1.0.0",
+                          "from": "semver-regex@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "semver": {
+                  "version": "4.3.6",
+                  "from": "semver@>=4.0.3 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+                },
+                "semver-truncate": {
+                  "version": "1.1.0",
+                  "from": "semver-truncate@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-1.1.0.tgz",
+                  "dependencies": {
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@>=5.0.3 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "download": {
+              "version": "3.3.0",
+              "from": "download@>=3.3.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/download/-/download-3.3.0.tgz",
+              "dependencies": {
+                "concat-stream": {
+                  "version": "1.5.1",
+                  "from": "concat-stream@>=1.4.6 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "typedarray": {
+                      "version": "0.0.6",
+                      "from": "typedarray@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "decompress-tar": {
+                  "version": "2.0.2",
+                  "from": "decompress-tar@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-2.0.2.tgz",
+                  "dependencies": {
+                    "is-tar": {
+                      "version": "1.0.0",
+                      "from": "is-tar@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                    },
+                    "strip-dirs": {
+                      "version": "0.1.1",
+                      "from": "strip-dirs@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-0.1.1.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "0.5.1",
+                          "from": "chalk@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "1.1.0",
+                              "from": "ansi-styles@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "0.1.0",
+                              "from": "has-ansi@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "0.3.0",
+                              "from": "strip-ansi@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "0.2.0",
+                              "from": "supports-color@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                            }
+                          }
+                        },
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "is-integer": {
+                          "version": "1.0.6",
+                          "from": "is-integer@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "tar-stream": {
+                      "version": "0.4.7",
+                      "from": "tar-stream@>=0.4.5 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+                      "dependencies": {
+                        "bl": {
+                          "version": "0.9.4",
+                          "from": "bl@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.26 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.1.0",
+                          "from": "end-of-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                          "dependencies": {
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "decompress-tarbz2": {
+                  "version": "2.0.2",
+                  "from": "decompress-tarbz2@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-2.0.2.tgz",
+                  "dependencies": {
+                    "is-bzip2": {
+                      "version": "1.0.0",
+                      "from": "is-bzip2@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                    },
+                    "seek-bzip": {
+                      "version": "1.0.5",
+                      "from": "seek-bzip@>=1.0.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "2.8.1",
+                          "from": "commander@>=2.8.1 <2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "graceful-readlink@>=1.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-dirs": {
+                      "version": "0.1.1",
+                      "from": "strip-dirs@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-0.1.1.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "0.5.1",
+                          "from": "chalk@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "1.1.0",
+                              "from": "ansi-styles@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "0.1.0",
+                              "from": "has-ansi@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "0.3.0",
+                              "from": "strip-ansi@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "0.2.1",
+                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "0.2.0",
+                              "from": "supports-color@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                            }
+                          }
+                        },
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "is-integer": {
+                          "version": "1.0.6",
+                          "from": "is-integer@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "tar-stream": {
+                      "version": "0.4.7",
+                      "from": "tar-stream@>=0.4.5 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-0.4.7.tgz",
+                      "dependencies": {
+                        "bl": {
+                          "version": "0.9.4",
+                          "from": "bl@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@>=1.0.26 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.1.0",
+                          "from": "end-of-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                          "dependencies": {
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.0.27-1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "decompress-targz": {
+                  "version": "2.1.0",
+                  "from": "decompress-targz@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-2.1.0.tgz",
+                  "dependencies": {
+                    "is-gzip": {
+                      "version": "1.0.0",
+                      "from": "is-gzip@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                    },
+                    "strip-dirs": {
+                      "version": "1.1.1",
+                      "from": "strip-dirs@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "is-natural-number": {
+                          "version": "2.0.0",
+                          "from": "is-natural-number@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "sum-up": {
+                          "version": "1.0.2",
+                          "from": "sum-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "tar-stream": {
+                      "version": "1.3.1",
+                      "from": "tar-stream@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
+                      "dependencies": {
+                        "bl": {
+                          "version": "1.0.0",
+                          "from": "bl@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz"
+                        },
+                        "end-of-stream": {
+                          "version": "1.1.0",
+                          "from": "end-of-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                          "dependencies": {
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.0.5",
+                          "from": "readable-stream@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "decompress-unzip": {
+                  "version": "2.1.2",
+                  "from": "decompress-unzip@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-2.1.2.tgz",
+                  "dependencies": {
+                    "is-zip": {
+                      "version": "1.0.0",
+                      "from": "is-zip@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                    },
+                    "strip-dirs": {
+                      "version": "1.1.1",
+                      "from": "strip-dirs@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "is-natural-number": {
+                          "version": "2.0.0",
+                          "from": "is-natural-number@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "sum-up": {
+                          "version": "1.0.2",
+                          "from": "sum-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "yauzl": {
+                      "version": "2.3.1",
+                      "from": "yauzl@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                      "dependencies": {
+                        "fd-slicer": {
+                          "version": "1.0.1",
+                          "from": "fd-slicer@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                        },
+                        "pend": {
+                          "version": "1.2.0",
+                          "from": "pend@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "each-async": {
+                  "version": "1.1.1",
+                  "from": "each-async@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+                  "dependencies": {
+                    "onetime": {
+                      "version": "1.1.0",
+                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                    }
+                  }
+                },
+                "get-stdin": {
+                  "version": "3.0.2",
+                  "from": "get-stdin@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-3.0.2.tgz"
+                },
+                "gulp-rename": {
+                  "version": "1.2.2",
+                  "from": "gulp-rename@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+                },
+                "meow": {
+                  "version": "2.1.0",
+                  "from": "meow@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-2.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.2",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
+                      "dependencies": {
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "repeating": {
+                          "version": "1.1.3",
+                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    },
+                    "object-assign": {
+                      "version": "2.1.1",
+                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "0.5.5",
+                  "from": "rc@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.7 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "deep-extend@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    }
+                  }
+                },
+                "request": {
+                  "version": "2.67.0",
+                  "from": "request@>=2.34.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "1.0.0",
+                      "from": "bl@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.5",
+                          "from": "readable-stream@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@>=0.11.0 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@>=3.0.0 <3.1.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@>=1.0.0-rc3 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "1.5.0",
+                          "from": "async@>=1.4.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.8",
+                      "from": "mime-types@>=2.1.7 <2.2.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.20.0",
+                          "from": "mime-db@>=1.20.0 <1.21.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@>=1.4.7 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "from": "qs@>=5.2.0 <5.3.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@>=2.2.0 <2.3.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.0",
+                      "from": "http-signature@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "jsprim": {
+                          "version": "1.2.2",
+                          "from": "jsprim@>=1.2.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                          "dependencies": {
+                            "extsprintf": {
+                              "version": "1.0.2",
+                              "from": "extsprintf@1.0.2",
+                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                            },
+                            "json-schema": {
+                              "version": "0.2.2",
+                              "from": "json-schema@0.2.2",
+                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                            },
+                            "verror": {
+                              "version": "1.3.6",
+                              "from": "verror@1.3.6",
+                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                            }
+                          }
+                        },
+                        "sshpk": {
+                          "version": "1.7.1",
+                          "from": "sshpk@>=1.7.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "from": "asn1@>=0.2.3 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                            },
+                            "assert-plus": {
+                              "version": "0.2.0",
+                              "from": "assert-plus@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                            },
+                            "dashdash": {
+                              "version": "1.10.1",
+                              "from": "dashdash@>=1.10.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.5",
+                                  "from": "assert-plus@>=0.1.0 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                }
+                              }
+                            },
+                            "jsbn": {
+                              "version": "0.1.0",
+                              "from": "jsbn@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                            },
+                            "tweetnacl": {
+                              "version": "0.13.2",
+                              "from": "tweetnacl@>=0.13.0 <1.0.0",
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                            },
+                            "jodid25519": {
+                              "version": "1.0.2",
+                              "from": "jodid25519@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@>=0.8.0 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.2",
+                      "from": "hawk@>=3.1.0 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "2.16.3",
+                          "from": "hoek@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                        },
+                        "boom": {
+                          "version": "2.10.1",
+                          "from": "boom@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "2.0.5",
+                          "from": "cryptiles@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                        },
+                        "sntp": {
+                          "version": "1.0.9",
+                          "from": "sntp@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@>=1.0.5 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "from": "delayed-stream@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.3",
+                      "from": "har-validator@>=2.0.2 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.1",
+                          "from": "chalk@>=1.1.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.1.0",
+                              "from": "ansi-styles@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.0",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.9.0",
+                          "from": "commander@>=2.9.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "graceful-readlink@>=1.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.12.3",
+                          "from": "is-my-json-valid@>=2.12.3 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0",
+                              "from": "generate-function@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "from": "generate-object-property@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2",
+                                  "from": "is-property@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "2.0.0",
+                              "from": "jsonpointer@2.0.0",
+                              "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                            },
+                            "xtend": {
+                              "version": "4.0.1",
+                              "from": "xtend@>=4.0.0 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                            }
+                          }
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.0",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.1",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "stream-combiner": {
+                  "version": "0.2.2",
+                  "from": "stream-combiner@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+                  "dependencies": {
+                    "duplexer": {
+                      "version": "0.1.1",
+                      "from": "duplexer@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+                    },
+                    "through": {
+                      "version": "2.3.8",
+                      "from": "through@>=2.3.4 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.6.5",
+                  "from": "through2@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@>=4.0.0 <4.1.0-0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    }
+                  }
+                },
+                "url-regex": {
+                  "version": "2.1.3",
+                  "from": "url-regex@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/url-regex/-/url-regex-2.1.3.tgz",
+                  "dependencies": {
+                    "ip-regex": {
+                      "version": "1.0.3",
+                      "from": "ip-regex@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-1.0.3.tgz"
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.4.6",
+                  "from": "vinyl@>=0.4.3 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                  "dependencies": {
+                    "clone": {
+                      "version": "0.2.0",
+                      "from": "clone@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                    },
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "from": "clone-stats@>=0.0.1 <0.0.2",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                },
+                "vinyl-fs": {
+                  "version": "0.3.14",
+                  "from": "vinyl-fs@>=0.3.7 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+                  "dependencies": {
+                    "defaults": {
+                      "version": "1.0.3",
+                      "from": "defaults@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+                      "dependencies": {
+                        "clone": {
+                          "version": "1.0.2",
+                          "from": "clone@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "glob-stream": {
+                      "version": "3.1.18",
+                      "from": "glob-stream@>=3.1.5 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "4.5.3",
+                          "from": "glob@>=4.3.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@>=1.0.4 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "2.0.10",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.2",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "ordered-read-streams": {
+                          "version": "0.1.0",
+                          "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                        },
+                        "glob2base": {
+                          "version": "0.0.12",
+                          "from": "glob2base@>=0.0.12 <0.0.13",
+                          "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                          "dependencies": {
+                            "find-index": {
+                              "version": "0.1.1",
+                              "from": "find-index@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "unique-stream": {
+                          "version": "1.0.0",
+                          "from": "unique-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "glob-watcher": {
+                      "version": "0.0.6",
+                      "from": "glob-watcher@>=0.0.6 <0.0.7",
+                      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+                      "dependencies": {
+                        "gaze": {
+                          "version": "0.5.2",
+                          "from": "gaze@>=0.5.1 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+                          "dependencies": {
+                            "globule": {
+                              "version": "0.1.0",
+                              "from": "globule@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                              "dependencies": {
+                                "lodash": {
+                                  "version": "1.0.2",
+                                  "from": "lodash@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                                },
+                                "glob": {
+                                  "version": "3.1.21",
+                                  "from": "glob@>=3.1.21 <3.2.0",
+                                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "1.2.3",
+                                      "from": "graceful-fs@>=1.2.0 <1.3.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "1.0.2",
+                                      "from": "inherits@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@>=0.2.11 <0.3.0",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.7.3",
+                                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.1",
+                                      "from": "sigmund@>=1.0.0 <1.1.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "3.0.8",
+                      "from": "graceful-fs@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "strip-bom": {
+                      "version": "1.0.0",
+                      "from": "strip-bom@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                      "dependencies": {
+                        "first-chunk-stream": {
+                          "version": "1.0.0",
+                          "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                        },
+                        "is-utf8": {
+                          "version": "0.2.1",
+                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ware": {
+                  "version": "1.3.0",
+                  "from": "ware@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+                  "dependencies": {
+                    "wrap-fn": {
+                      "version": "0.1.4",
+                      "from": "wrap-fn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                      "dependencies": {
+                        "co": {
+                          "version": "3.1.0",
+                          "from": "co@3.1.0",
+                          "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "download-status": {
+              "version": "2.2.1",
+              "from": "download-status@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/download-status/-/download-status-2.2.1.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "0.5.1",
+                  "from": "chalk@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "1.1.0",
+                      "from": "ansi-styles@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "0.1.0",
+                      "from": "has-ansi@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "0.3.0",
+                      "from": "strip-ansi@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "0.2.1",
+                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "from": "supports-color@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                    }
+                  }
+                },
+                "lpad-align": {
+                  "version": "1.1.0",
+                  "from": "lpad-align@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "longest": {
+                      "version": "1.0.1",
+                      "from": "longest@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                    },
+                    "lpad": {
+                      "version": "2.0.1",
+                      "from": "lpad@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+                    },
+                    "meow": {
+                      "version": "3.6.0",
+                      "from": "meow@>=3.3.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "2.0.0",
+                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "2.0.1",
+                              "from": "camelcase@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "loud-rejection": {
+                          "version": "1.2.0",
+                          "from": "loud-rejection@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                          "dependencies": {
+                            "signal-exit": {
+                              "version": "2.1.2",
+                              "from": "signal-exit@>=2.1.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.4",
+                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.0",
+                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0",
+                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.1.0",
+                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-exceptions": {
+                                      "version": "1.0.4",
+                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                    },
+                                    "spdx-license-ids": {
+                                      "version": "1.1.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "object-assign": {
+                          "version": "4.0.1",
+                          "from": "object-assign@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+                        },
+                        "read-pkg-up": {
+                          "version": "1.0.1",
+                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                          "dependencies": {
+                            "find-up": {
+                              "version": "1.1.0",
+                              "from": "find-up@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "dependencies": {
+                                "path-exists": {
+                                  "version": "2.1.0",
+                                  "from": "path-exists@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "read-pkg": {
+                              "version": "1.1.0",
+                              "from": "read-pkg@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                              "dependencies": {
+                                "load-json-file": {
+                                  "version": "1.1.0",
+                                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "2.2.0",
+                                      "from": "parse-json@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.0",
+                                          "from": "error-ex@>=1.2.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-bom": {
+                                      "version": "2.0.0",
+                                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                      "dependencies": {
+                                        "is-utf8": {
+                                          "version": "0.2.1",
+                                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "1.1.0",
+                                  "from": "path-type@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "redent": {
+                          "version": "1.0.0",
+                          "from": "redent@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "2.1.0",
+                              "from": "indent-string@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "dependencies": {
+                                "repeating": {
+                                  "version": "2.0.0",
+                                  "from": "repeating@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "strip-indent": {
+                              "version": "1.0.1",
+                              "from": "strip-indent@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "trim-newlines": {
+                          "version": "1.0.0",
+                          "from": "trim-newlines@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                },
+                "progress": {
+                  "version": "1.1.8",
+                  "from": "progress@>=1.1.8 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+                }
+              }
+            },
+            "globby": {
+              "version": "1.2.0",
+              "from": "globby@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+              "dependencies": {
+                "array-union": {
+                  "version": "1.0.1",
+                  "from": "array-union@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "array-uniq@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    }
+                  }
+                },
+                "async": {
+                  "version": "0.9.2",
+                  "from": "async@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.4.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.2",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.1.1",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+                }
+              }
+            },
+            "is-path-global": {
+              "version": "1.0.2",
+              "from": "is-path-global@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-path-global/-/is-path-global-1.0.2.tgz",
+              "dependencies": {
+                "is-path-inside": {
+                  "version": "1.0.0",
+                  "from": "is-path-inside@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+                  "dependencies": {
+                    "path-is-inside": {
+                      "version": "1.0.1",
+                      "from": "path-is-inside@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lnfs": {
+              "version": "1.1.0",
+              "from": "lnfs@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/lnfs/-/lnfs-1.1.0.tgz",
+              "dependencies": {
+                "meow": {
+                  "version": "3.6.0",
+                  "from": "meow@>=3.3.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "2.0.0",
+                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "2.0.1",
+                          "from": "camelcase@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "loud-rejection": {
+                      "version": "1.2.0",
+                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                      "dependencies": {
+                        "signal-exit": {
+                          "version": "2.1.2",
+                          "from": "signal-exit@>=2.1.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.2.0",
+                      "from": "minimist@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.4",
+                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.0",
+                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.1.0",
+                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.1.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.2",
+                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.4",
+                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.1.0",
+                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg-up": {
+                      "version": "1.0.1",
+                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                      "dependencies": {
+                        "find-up": {
+                          "version": "1.1.0",
+                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "dependencies": {
+                            "path-exists": {
+                              "version": "2.1.0",
+                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.0",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.1",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg": {
+                          "version": "1.1.0",
+                          "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                          "dependencies": {
+                            "load-json-file": {
+                              "version": "1.1.0",
+                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.2",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                },
+                                "parse-json": {
+                                  "version": "2.2.0",
+                                  "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                  "dependencies": {
+                                    "error-ex": {
+                                      "version": "1.3.0",
+                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                      "dependencies": {
+                                        "is-arrayish": {
+                                          "version": "0.2.1",
+                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-bom": {
+                                  "version": "2.0.0",
+                                  "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-utf8": {
+                                      "version": "0.2.1",
+                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "path-type": {
+                              "version": "1.1.0",
+                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "4.1.2",
+                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                },
+                                "pify": {
+                                  "version": "2.3.0",
+                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "redent": {
+                      "version": "1.0.0",
+                      "from": "redent@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                      "dependencies": {
+                        "indent-string": {
+                          "version": "2.1.0",
+                          "from": "indent-string@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "2.0.0",
+                              "from": "repeating@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "strip-indent": {
+                          "version": "1.0.1",
+                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                          "dependencies": {
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "trim-newlines": {
+                      "version": "1.0.0",
+                      "from": "trim-newlines@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.4.4",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "glob@>=5.0.14 <6.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.2",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.3.0",
+                                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "path-is-absolute": {
+                          "version": "1.0.0",
+                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "npm-installed": {
+              "version": "1.0.0",
+              "from": "npm-installed@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/npm-installed/-/npm-installed-1.0.0.tgz",
+              "dependencies": {
+                "npm-which": {
+                  "version": "1.0.2",
+                  "from": "npm-which@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-1.0.2.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@>=2.2.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "npm-path": {
+                      "version": "1.0.2",
+                      "from": "npm-path@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.0.2.tgz"
+                    },
+                    "which": {
+                      "version": "1.2.0",
+                      "from": "which@>=1.0.5 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+                      "dependencies": {
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.7 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "rc": {
+                  "version": "0.5.5",
+                  "from": "rc@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@>=0.0.7 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "deep-extend@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "strip-json-comments@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "os-filter-obj": {
+              "version": "1.0.3",
+              "from": "os-filter-obj@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-filter-obj/-/os-filter-obj-1.0.3.tgz"
+            }
+          }
+        },
+        "logalot": {
+          "version": "2.1.0",
+          "from": "logalot@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
+          "dependencies": {
+            "figures": {
+              "version": "1.4.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+            },
+            "squeak": {
+              "version": "1.3.0",
+              "from": "squeak@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "1.1.1",
+                  "from": "chalk@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.4",
+                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    }
+                  }
+                },
+                "console-stream": {
+                  "version": "0.1.1",
+                  "from": "console-stream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/console-stream/-/console-stream-0.1.1.tgz"
+                },
+                "lpad-align": {
+                  "version": "1.1.0",
+                  "from": "lpad-align@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/lpad-align/-/lpad-align-1.1.0.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "longest": {
+                      "version": "1.0.1",
+                      "from": "longest@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                    },
+                    "lpad": {
+                      "version": "2.0.1",
+                      "from": "lpad@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lpad/-/lpad-2.0.1.tgz"
+                    },
+                    "meow": {
+                      "version": "3.6.0",
+                      "from": "meow@>=3.3.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "2.0.0",
+                          "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "2.0.1",
+                              "from": "camelcase@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "loud-rejection": {
+                          "version": "1.2.0",
+                          "from": "loud-rejection@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
+                          "dependencies": {
+                            "signal-exit": {
+                              "version": "2.1.2",
+                              "from": "signal-exit@>=2.1.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "normalize-package-data": {
+                          "version": "2.3.5",
+                          "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.1.4",
+                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.0",
+                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.1.0",
+                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                              "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.1.0",
+                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-exceptions": {
+                                      "version": "1.0.4",
+                                      "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
+                                    },
+                                    "spdx-license-ids": {
+                                      "version": "1.1.0",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "read-pkg-up": {
+                          "version": "1.0.1",
+                          "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                          "dependencies": {
+                            "find-up": {
+                              "version": "1.1.0",
+                              "from": "find-up@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "dependencies": {
+                                "path-exists": {
+                                  "version": "2.1.0",
+                                  "from": "path-exists@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                                },
+                                "pinkie-promise": {
+                                  "version": "2.0.0",
+                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "dependencies": {
+                                    "pinkie": {
+                                      "version": "2.0.1",
+                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "read-pkg": {
+                              "version": "1.1.0",
+                              "from": "read-pkg@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                              "dependencies": {
+                                "load-json-file": {
+                                  "version": "1.1.0",
+                                  "from": "load-json-file@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    },
+                                    "parse-json": {
+                                      "version": "2.2.0",
+                                      "from": "parse-json@>=2.2.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                                      "dependencies": {
+                                        "error-ex": {
+                                          "version": "1.3.0",
+                                          "from": "error-ex@>=1.2.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                          "dependencies": {
+                                            "is-arrayish": {
+                                              "version": "0.2.1",
+                                              "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                              "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-bom": {
+                                      "version": "2.0.0",
+                                      "from": "strip-bom@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                                      "dependencies": {
+                                        "is-utf8": {
+                                          "version": "0.2.1",
+                                          "from": "is-utf8@>=0.2.0 <0.3.0",
+                                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "path-type": {
+                                  "version": "1.1.0",
+                                  "from": "path-type@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                                  "dependencies": {
+                                    "graceful-fs": {
+                                      "version": "4.1.2",
+                                      "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                                    },
+                                    "pify": {
+                                      "version": "2.3.0",
+                                      "from": "pify@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                                    },
+                                    "pinkie-promise": {
+                                      "version": "2.0.0",
+                                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "dependencies": {
+                                        "pinkie": {
+                                          "version": "2.0.1",
+                                          "from": "pinkie@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "redent": {
+                          "version": "1.0.0",
+                          "from": "redent@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                          "dependencies": {
+                            "indent-string": {
+                              "version": "2.1.0",
+                              "from": "indent-string@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                              "dependencies": {
+                                "repeating": {
+                                  "version": "2.0.0",
+                                  "from": "repeating@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "dependencies": {
+                                    "is-finite": {
+                                      "version": "1.0.1",
+                                      "from": "is-finite@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                      "dependencies": {
+                                        "number-is-nan": {
+                                          "version": "1.0.0",
+                                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "strip-indent": {
+                              "version": "1.0.1",
+                              "from": "strip-indent@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "trim-newlines": {
+                          "version": "1.0.0",
+                          "from": "trim-newlines@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "immutable": {
+      "version": "3.7.6",
+      "from": "immutable@3.7.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz"
+    },
+    "jest-cli": {
+      "version": "0.8.2",
+      "from": "jest-cli@0.8.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-0.8.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.1",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.1.0",
+              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.4",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.0",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.0.0",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "cover": {
+          "version": "0.2.9",
+          "from": "cover@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/cover/-/cover-0.2.9.tgz",
+          "dependencies": {
+            "cli-table": {
+              "version": "0.0.2",
+              "from": "cli-table@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.0.2.tgz",
+              "dependencies": {
+                "colors": {
+                  "version": "0.3.0",
+                  "from": "colors@0.3.0",
+                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.3.0.tgz"
+                }
+              }
+            },
+            "underscore": {
+              "version": "1.2.4",
+              "from": "underscore@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.2.4.tgz"
+            },
+            "underscore.string": {
+              "version": "2.0.0",
+              "from": "underscore.string@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.0.0.tgz"
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "2.2.1",
+          "from": "diff@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.1.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.2",
+          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+        },
+        "istanbul": {
+          "version": "0.3.22",
+          "from": "istanbul@>=0.3.19 <0.4.0",
+          "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.22.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+            },
+            "async": {
+              "version": "1.5.0",
+              "from": "async@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+            },
+            "escodegen": {
+              "version": "1.7.1",
+              "from": "escodegen@>=1.7.0 <1.8.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.2.0",
+                  "from": "source-map@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.5.0",
+              "from": "esprima@>=2.5.0 <2.6.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.5.0.tgz"
+            },
+            "fileset": {
+              "version": "0.2.1",
+              "from": "fileset@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.2",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "5.0.15",
+                  "from": "glob@>=5.0.0 <6.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "4.0.5",
+              "from": "handlebars@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.5.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.4 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.6.1",
+                  "from": "uglify-js@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@>=0.2.6 <0.3.0"
+                    },
+                    "source-map": {
+                      "version": "0.5.3",
+                      "from": "source-map@>=0.5.1 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                    },
+                    "yargs": {
+                      "version": "3.10.0",
+                      "from": "yargs@>=3.10.0 <3.11.0",
+                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "from": "cliui@>=2.1.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.2",
+                              "from": "center-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "0.2.7",
+                                  "from": "lazy-cache@>=0.2.4 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "from": "right-align@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.0",
+                                          "from": "is-buffer@>=1.0.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@>=1.0.1 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2"
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.1.1",
+                          "from": "decamelize@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "from": "window-size@0.1.0",
+                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.4.6",
+              "from": "js-yaml@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.3",
+                  "from": "argparse@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "3.10.1",
+                      "from": "lodash@>=3.2.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+                    },
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "from": "sprintf-js@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.7.1",
+                  "from": "esprima@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+                },
+                "inherit": {
+                  "version": "2.2.2",
+                  "from": "inherit@>=2.2.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.2.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "from": "nopt@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+            },
+            "once": {
+              "version": "1.3.3",
+              "from": "once@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "from": "supports-color@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "from": "wordwrap@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+            }
+          }
+        },
+        "jsdom": {
+          "version": "7.2.1",
+          "from": "jsdom@>=7.2.0 <8.0.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.1.tgz",
+          "dependencies": {
+            "abab": {
+              "version": "1.0.1",
+              "from": "abab@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.1.tgz"
+            },
+            "acorn": {
+              "version": "2.6.4",
+              "from": "acorn@>=2.4.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.6.4.tgz"
+            },
+            "acorn-globals": {
+              "version": "1.0.9",
+              "from": "acorn-globals@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz"
+            },
+            "cssom": {
+              "version": "0.3.0",
+              "from": "cssom@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.0.tgz"
+            },
+            "cssstyle": {
+              "version": "0.2.30",
+              "from": "cssstyle@>=0.2.29 <0.3.0",
+              "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.30.tgz"
+            },
+            "escodegen": {
+              "version": "1.7.1",
+              "from": "escodegen@>=1.6.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "from": "estraverse@>=1.9.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "esprima": {
+                  "version": "1.2.5",
+                  "from": "esprima@>=1.2.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                },
+                "optionator": {
+                  "version": "0.5.0",
+                  "from": "optionator@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                  "dependencies": {
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "from": "prelude-ls@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                    },
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "from": "deep-is@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    },
+                    "type-check": {
+                      "version": "0.3.1",
+                      "from": "type-check@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                    },
+                    "levn": {
+                      "version": "0.2.5",
+                      "from": "levn@>=0.2.5 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.0.7",
+                      "from": "fast-levenshtein@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.2.0",
+                  "from": "source-map@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nwmatcher": {
+              "version": "1.3.7",
+              "from": "nwmatcher@>=1.3.7 <2.0.0",
+              "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.7.tgz"
+            },
+            "parse5": {
+              "version": "1.5.1",
+              "from": "parse5@>=1.5.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
+            },
+            "request": {
+              "version": "2.67.0",
+              "from": "request@>=2.55.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "1.0.0",
+                  "from": "bl@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@>=0.11.0 <0.12.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.1 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "1.0.0-rc3",
+                  "from": "form-data@>=1.0.0-rc3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "1.5.0",
+                      "from": "async@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.8",
+                  "from": "mime-types@>=2.1.7 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.20.0",
+                      "from": "mime-db@>=1.20.0 <1.21.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "from": "node-uuid@>=1.4.7 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                },
+                "qs": {
+                  "version": "5.2.0",
+                  "from": "qs@>=5.2.0 <5.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "from": "tunnel-agent@>=0.4.1 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
+                },
+                "http-signature": {
+                  "version": "1.1.0",
+                  "from": "http-signature@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@>=1.2.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "from": "extsprintf@1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        },
+                        "json-schema": {
+                          "version": "0.2.2",
+                          "from": "json-schema@0.2.2",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "from": "verror@1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.1",
+                      "from": "sshpk@>=1.7.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "from": "asn1@>=0.2.3 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                        },
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "from": "assert-plus@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        },
+                        "dashdash": {
+                          "version": "1.10.1",
+                          "from": "dashdash@>=1.10.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
+                          "dependencies": {
+                            "assert-plus": {
+                              "version": "0.1.5",
+                              "from": "assert-plus@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                            }
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "from": "jsbn@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                        },
+                        "tweetnacl": {
+                          "version": "0.13.2",
+                          "from": "tweetnacl@>=0.13.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "jodid25519@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.0",
+                  "from": "oauth-sign@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                },
+                "hawk": {
+                  "version": "3.1.2",
+                  "from": "hawk@>=3.1.0 <3.2.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@>=1.0.5 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                },
+                "har-validator": {
+                  "version": "2.0.3",
+                  "from": "har-validator@>=2.0.2 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@>=2.9.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.3",
+                      "from": "is-my-json-valid@>=2.12.3 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "2.0.0",
+                          "from": "jsonpointer@2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.1",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sax": {
+              "version": "1.1.4",
+              "from": "sax@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
+            },
+            "symbol-tree": {
+              "version": "3.1.4",
+              "from": "symbol-tree@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.1.4.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.2.1",
+              "from": "tough-cookie@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+            },
+            "webidl-conversions": {
+              "version": "2.0.1",
+              "from": "webidl-conversions@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz"
+            },
+            "whatwg-url-compat": {
+              "version": "0.6.5",
+              "from": "whatwg-url-compat@>=0.6.5 <0.7.0",
+              "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
+              "dependencies": {
+                "tr46": {
+                  "version": "0.0.2",
+                  "from": "tr46@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.2.tgz"
+                }
+              }
+            },
+            "xml-name-validator": {
+              "version": "2.0.1",
+              "from": "xml-name-validator@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.0",
+          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.0.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "node-haste": {
+          "version": "1.2.8",
+          "from": "node-haste@>=1.2.8 <2.0.0",
+          "resolved": "https://registry.npmjs.org/node-haste/-/node-haste-1.2.8.tgz",
+          "dependencies": {
+            "esprima-fb": {
+              "version": "4001.1001.0-dev-harmony-fb",
+              "from": "esprima-fb@4001.1001.0-dev-harmony-fb",
+              "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-4001.1001.0-dev-harmony-fb.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "from": "resolve@>=1.1.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+        },
+        "sane": {
+          "version": "1.3.0",
+          "from": "sane@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-1.3.0.tgz",
+          "dependencies": {
+            "exec-sh": {
+              "version": "0.2.0",
+              "from": "exec-sh@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
+              "dependencies": {
+                "merge": {
+                  "version": "1.2.0",
+                  "from": "merge@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+                }
+              }
+            },
+            "fb-watchman": {
+              "version": "1.6.0",
+              "from": "fb-watchman@>=1.5.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.6.0.tgz",
+              "dependencies": {
+                "bser": {
+                  "version": "1.0.2",
+                  "from": "bser@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+                  "dependencies": {
+                    "node-int64": {
+                      "version": "0.4.0",
+                      "from": "node-int64@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.14 <0.3.0",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "walker": {
+              "version": "1.0.7",
+              "from": "walker@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+              "dependencies": {
+                "makeerror": {
+                  "version": "1.0.11",
+                  "from": "makeerror@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+                  "dependencies": {
+                    "tmpl": {
+                      "version": "1.0.4",
+                      "from": "tmpl@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "watch": {
+              "version": "0.10.0",
+              "from": "watch@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/watch/-/watch-0.10.0.tgz"
+            }
+          }
+        },
+        "which": {
+          "version": "1.2.0",
+          "from": "which@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.0.tgz",
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "worker-farm": {
+          "version": "1.3.1",
+          "from": "worker-farm@>=1.3.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.3.1.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "errno@>=0.1.1 <0.2.0-0",
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "json-loader": {
+      "version": "0.5.4",
+      "from": "json-loader@0.5.4",
+      "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
+    },
+    "node-libs-browser": {
+      "version": "0.5.3",
+      "from": "node-libs-browser@0.5.3",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
+      "dependencies": {
+        "assert": {
+          "version": "1.3.0",
+          "from": "assert@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "from": "browserify-zlib@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.8",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.5.5",
+          "from": "buffer@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8",
+              "from": "base64-js@0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.6",
+              "from": "ieee754@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "from": "constants-browserify@0.0.1",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.2.8",
+          "from": "crypto-browserify@>=3.2.6 <3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+          "dependencies": {
+            "pbkdf2-compat": {
+              "version": "2.0.1",
+              "from": "pbkdf2-compat@2.0.1",
+              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+            },
+            "ripemd160": {
+              "version": "0.2.0",
+              "from": "ripemd160@0.2.0",
+              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+            },
+            "sha.js": {
+              "version": "2.2.6",
+              "from": "sha.js@2.2.6",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "from": "domain-browser@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+        },
+        "events": {
+          "version": "1.1.0",
+          "from": "events@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "from": "http-browserify@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "dependencies": {
+            "Base64": {
+              "version": "0.2.1",
+              "from": "Base64@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0",
+          "from": "https-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "from": "path-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
+        "process": {
+          "version": "0.11.2",
+          "from": "process@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
+        },
+        "punycode": {
+          "version": "1.4.0",
+          "from": "punycode@>=1.2.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.25 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@1.3.2",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "from": "querystring@0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@>=0.10.3 <0.11.0",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "from": "vm-browserify@0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "dependencies": {
+            "indexof": {
+              "version": "0.0.1",
+              "from": "indexof@0.0.1",
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "object-assign": {
+      "version": "4.0.1",
+      "from": "object-assign@4.0.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
+    },
+    "react": {
+      "version": "0.14.3",
+      "from": "react@0.14.3",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.14.3.tgz",
+      "dependencies": {
+        "envify": {
+          "version": "3.4.0",
+          "from": "envify@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.0.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            },
+            "jstransform": {
+              "version": "10.1.0",
+              "from": "jstransform@>=10.0.1 <11.0.0",
+              "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-10.1.0.tgz",
+              "dependencies": {
+                "base62": {
+                  "version": "0.1.1",
+                  "from": "base62@0.1.1",
+                  "resolved": "https://registry.npmjs.org/base62/-/base62-0.1.1.tgz"
+                },
+                "esprima-fb": {
+                  "version": "13001.1001.0-dev-harmony-fb",
+                  "from": "esprima-fb@13001.1001.0-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-13001.1001.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.31",
+                  "from": "source-map@0.1.31",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.31.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "fbjs": {
+          "version": "0.3.2",
+          "from": "fbjs@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.3.2.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.6",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
+            },
+            "loose-envify": {
+              "version": "1.1.0",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.1.0.tgz",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "1.0.2",
+                  "from": "js-tokens@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.2.tgz"
+                }
+              }
+            },
+            "promise": {
+              "version": "7.0.4",
+              "from": "promise@>=7.0.3 <8.0.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-7.0.4.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.3",
+                  "from": "asap@>=2.0.3 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
+                }
+              }
+            },
+            "ua-parser-js": {
+              "version": "0.7.10",
+              "from": "ua-parser-js@>=0.7.9 <0.8.0",
+              "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
+            },
+            "whatwg-fetch": {
+              "version": "0.9.0",
+              "from": "whatwg-fetch@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "react-addons-create-fragment": {
+      "version": "0.14.3",
+      "from": "react-addons-create-fragment@0.14.3",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-0.14.3.tgz"
+    },
+    "react-dom": {
+      "version": "0.14.3",
+      "from": "react-dom@0.14.3",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.3.tgz"
+    },
+    "webpack": {
+      "version": "1.12.9",
+      "from": "webpack@1.12.9",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.0",
+          "from": "async@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "clone@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "memory-fs@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.2",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+            }
+          }
+        },
+        "esprima": {
+          "version": "2.7.1",
+          "from": "esprima@>=2.5.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@>=0.6.4 <0.7.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.12",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "from": "memory-fs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "errno@>=0.1.3 <0.2.0",
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.0.5",
+              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.6",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "from": "tapable@>=0.1.8 <0.2.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+        },
+        "uglify-js": {
+          "version": "2.6.1",
+          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.2",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "0.2.7",
+                          "from": "lazy-cache@>=0.2.4 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.3",
+                          "from": "align-text@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "2.0.1",
+                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.0",
+                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.5.2",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.1.1",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "from": "watchpack@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "chokidar": {
+              "version": "1.4.1",
+              "from": "chokidar@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                    },
+                    "micromatch": {
+                      "version": "2.3.7",
+                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.7.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.0.1",
+                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                        },
+                        "braces": {
+                          "version": "1.8.3",
+                          "from": "braces@>=1.8.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.3.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.1",
+                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "2.0.0",
+                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "0.0.1",
+                                          "from": "isarray@0.0.1",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.5",
+                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.4",
+                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
+                        },
+                        "extglob": {
+                          "version": "0.3.1",
+                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
+                          "dependencies": {
+                            "ansi-green": {
+                              "version": "0.1.1",
+                              "from": "ansi-green@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
+                              "dependencies": {
+                                "ansi-wrap": {
+                                  "version": "0.1.0",
+                                  "from": "ansi-wrap@0.1.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
+                                }
+                              }
+                            },
+                            "success-symbol": {
+                              "version": "0.1.0",
+                              "from": "success-symbol@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
+                            }
+                          }
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "3.0.2",
+                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.0",
+                              "from": "is-buffer@>=1.0.2 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.0.1",
+                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                        },
+                        "object.omit": {
+                          "version": "2.0.0",
+                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.3 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.2",
+                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.2",
+                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.6 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.4.0",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                },
+                "readdirp": {
+                  "version": "2.0.0",
+                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "2.0.10",
+                      "from": "minimatch@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.2",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.3.0",
+                              "from": "balanced-match@>=0.3.0 <0.4.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.0.5",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.6",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fsevents": {
+                  "version": "1.0.6",
+                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.6.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.1.0",
+                      "from": "nan@>=2.1.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.1.0.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.17",
+                      "from": "node-pre-gyp@>=0.6.17 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.17.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.6",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.7",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@~0.3.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                    },
+                    "ansi-styles": {
+                      "version": "2.1.0",
+                      "from": "ansi-styles@^2.1.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "async": {
+                      "version": "1.5.0",
+                      "from": "async@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@~0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.1.1",
+                      "from": "chalk@^1.1.1",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.4.0",
+                      "from": "deep-extend@~0.4.0",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.10.1",
+                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz"
+                    },
+                    "delegates": {
+                      "version": "0.1.0",
+                      "from": "delegates@^0.1.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@~0.7.2",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "escape-string-regexp@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "form-data": {
+                      "version": "1.0.0-rc3",
+                      "from": "form-data@~1.0.0-rc3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.8",
+                      "from": "fstream@^1.0.2",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.8.tgz"
+                    },
+                    "gauge": {
+                      "version": "1.2.2",
+                      "from": "gauge@~1.2.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.2.tgz"
+                    },
+                    "generate-function": {
+                      "version": "2.0.0",
+                      "from": "generate-function@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@4.1",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                    },
+                    "generate-object-property": {
+                      "version": "1.2.0",
+                      "from": "generate-object-property@^1.1.0",
+                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+                    },
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>= 1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    },
+                    "har-validator": {
+                      "version": "2.0.3",
+                      "from": "har-validator@~2.0.2",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "1.0.1",
+                      "from": "has-unicode@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.1.tgz"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.2",
+                      "from": "hawk@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.0",
+                      "from": "http-signature@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@~1.3.0",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@*",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.3",
+                      "from": "is-my-json-valid@^2.12.3",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz"
+                    },
+                    "is-property": {
+                      "version": "1.0.2",
+                      "from": "is-property@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.0",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.2",
+                      "from": "json-schema@0.2.2",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "jsprim": {
+                      "version": "1.2.2",
+                      "from": "jsprim@^1.2.2",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz"
+                    },
+                    "lodash._basetostring": {
+                      "version": "3.0.1",
+                      "from": "lodash._basetostring@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
+                    },
+                    "jsonpointer": {
+                      "version": "2.0.0",
+                      "from": "jsonpointer@2.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
+                    },
+                    "lodash.pad": {
+                      "version": "3.1.1",
+                      "from": "lodash.pad@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-3.1.1.tgz"
+                    },
+                    "lodash.padright": {
+                      "version": "3.1.1",
+                      "from": "lodash.padright@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padright/-/lodash.padright-3.1.1.tgz"
+                    },
+                    "lodash._createpadding": {
+                      "version": "3.6.1",
+                      "from": "lodash._createpadding@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._createpadding/-/lodash._createpadding-3.6.1.tgz"
+                    },
+                    "lodash.padleft": {
+                      "version": "3.1.1",
+                      "from": "lodash.padleft@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.padleft/-/lodash.padleft-3.1.1.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.19.0",
+                      "from": "mime-db@~1.19.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                    },
+                    "lodash.repeat": {
+                      "version": "3.0.1",
+                      "from": "lodash.repeat@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-3.0.1.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.3.0 <0.4.0||>=0.4.0 <0.5.0||>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.7",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "npmlog": {
+                      "version": "2.0.0",
+                      "from": "npmlog@~2.0.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.0",
+                      "from": "oauth-sign@~0.8.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
+                    },
+                    "once": {
+                      "version": "1.1.1",
+                      "from": "once@~1.1.1",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                    },
+                    "pinkie": {
+                      "version": "2.0.1",
+                      "from": "pinkie@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.0",
+                      "from": "pinkie-promise@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@^1.1.13",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+                    },
+                    "request": {
+                      "version": "2.67.0",
+                      "from": "request@2.x",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.0",
+                      "from": "qs@~5.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
+                    "semver": {
+                      "version": "5.1.0",
+                      "from": "semver@~5.1.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.0",
+                      "from": "strip-ansi@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@~0.0.4",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "1.0.4",
+                      "from": "strip-json-comments@~1.0.4",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@~2.2.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.13.2",
+                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.1",
+                      "from": "tunnel-agent@~0.4.1",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.3",
+                      "from": "uid-number@0.0.3",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "xtend": {
+                      "version": "4.0.1",
+                      "from": "xtend@^4.0.0",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                    },
+                    "rc": {
+                      "version": "1.1.5",
+                      "from": "rc@~1.1.0",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.5.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@^1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.7.0",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.2.0",
+                          "from": "assert-plus@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "bl": {
+                      "version": "1.0.0",
+                      "from": "bl@~1.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "2.0.4",
+                          "from": "readable-stream@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.4.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.3",
+                              "from": "process-nextick-args@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tar-pack": {
+                      "version": "3.1.0",
+                      "from": "tar-pack@~3.1.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.0.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@~1.0.2",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.0",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.3",
+                      "from": "fstream-ignore@~1.0.3",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.3.tgz",
+                      "dependencies": {
+                        "minimatch": {
+                          "version": "3.0.0",
+                          "from": "minimatch@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.1",
+                              "from": "brace-expansion@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.1",
+                                  "from": "balanced-match@^0.2.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.4.4",
+                      "from": "rimraf@~2.4.0",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.4.tgz",
+                      "dependencies": {
+                        "glob": {
+                          "version": "5.0.15",
+                          "from": "glob@^5.0.14",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.1",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.2.1",
+                                      "from": "balanced-match@^0.2.0",
+                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@^1.3.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            },
+                            "path-is-absolute": {
+                              "version": "1.0.0",
+                              "from": "path-is-absolute@^1.0.0",
+                              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.2",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.8",
+          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.5",
+              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,17 +1,28 @@
 {
   "dependencies": {
+    "babel-core": "6.3.21",
+    "babel-eslint": "4.1.6",
+    "babel-jest": "6.0.1",
+    "babel-loader": "6.2.0",
     "babel-preset-es2015": "6.3.13",
     "babel-preset-react": "6.3.13",
     "babel-preset-stage-0": "6.3.13",
     "classnames": "2.2.1",
     "es6-symbol": "3.0.2",
+    "eslint": "1.10.3",
+    "eslint-plugin-react": "3.12.0",
     "fbjs": "0.5.1",
     "fbjs-scripts": "0.5.0",
+    "flow-bin": "0.20.1",
     "immutable": "3.7.6",
+    "jest-cli": "0.8.2",
+    "json-loader": "0.5.4",
+    "node-libs-browser": "0.5.3",
     "object-assign": "4.0.1",
     "react": "0.14.3",
     "react-addons-create-fragment": "0.14.3",
-    "react-dom": "0.14.3"
+    "react-dom": "0.14.3",
+    "webpack": "1.12.9"
   },
   "license": "BSD-3-Clause",
   "repository": "facebook/react-devtools",
@@ -32,18 +43,5 @@
       "json",
       "es6"
     ]
-  },
-  "devDependencies": {
-    "babel-core": "6.3.21",
-    "babel-eslint": "4.1.6",
-    "babel-jest": "6.0.1",
-    "babel-loader": "6.2.0",
-    "eslint": "1.10.3",
-    "eslint-plugin-react": "3.12.0",
-    "flow-bin": "0.20.1",
-    "jest-cli": "0.8.2",
-    "json-loader": "0.5.4",
-    "node-libs-browser": "0.5.3",
-    "webpack": "1.12.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "dependencies": {
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-react": "^6.1.18",
-    "babel-preset-stage-0": "^6.1.18",
-    "classnames": "^2.1.2",
-    "es6-symbol": "^2.0.1",
+    "babel-preset-es2015": "6.3.13",
+    "babel-preset-react": "6.3.13",
+    "babel-preset-stage-0": "6.3.13",
+    "classnames": "2.2.1",
+    "es6-symbol": "3.0.2",
     "fbjs": "0.5.1",
     "fbjs-scripts": "0.5.0",
-    "immutable": "^3.7.4",
-    "object-assign": "^3.0.0",
+    "immutable": "3.7.6",
+    "object-assign": "4.0.1",
     "react": "0.14.3",
     "react-addons-create-fragment": "0.14.3",
     "react-dom": "0.14.3"
@@ -34,16 +34,16 @@
     ]
   },
   "devDependencies": {
-    "babel-core": "^6.1.19",
-    "babel-eslint": "^4.1.3",
-    "babel-jest": "^6.0.1",
-    "babel-loader": "^6.1.0",
-    "eslint": "^1.5.1",
-    "eslint-plugin-react": "^3.5.0",
+    "babel-core": "6.3.21",
+    "babel-eslint": "4.1.6",
+    "babel-jest": "6.0.1",
+    "babel-loader": "6.2.0",
+    "eslint": "1.10.3",
+    "eslint-plugin-react": "3.12.0",
     "flow-bin": "0.20.1",
     "jest-cli": "0.8.2",
-    "json-loader": "^0.5.2",
-    "node-libs-browser": "^0.5.2",
-    "webpack": "^1.9.10"
+    "json-loader": "0.5.4",
+    "node-libs-browser": "0.5.3",
+    "webpack": "1.12.9"
   }
 }


### PR DESCRIPTION
Using fixed versions to make builds more reproducible and updates of dependencies more transparent.

[node-check-updates](https://www.npmjs.com/package/npm-check-updates) makes it pretty easy to explicitly update dependencies.