### PR TITLE
Debouncing search text change

### DIFF
--- a/utils/debounce.js
+++ b/utils/debounce.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+function debounce(fn: Function, delay: number): Function {
+  var timeout;
+  return function() {
+    var context = this;
+    var args = arguments;
+    var later = function() {
+      timeout = null;
+      fn.apply(context, args);
+    };
+
+    clearTimeout(timeout);
+    timeout = setTimeout(later, delay);
+    if (!timeout) {
+      fn.apply(context, args);
+    }
+  };
+}
+
+module.exports = debounce;


### PR DESCRIPTION
When using the search box in devtools, if my keystrokes are too quick, then they are dropped. For an example, typing "Table" would amount to:

![image](https://dl.dropboxusercontent.com/u/3240167/devtools.gif)

Therefore, I propose that the `onChangeSearch` function be `debounce`d.