### PR TITLE
Revert "use webpack DefinePlugin to dramatically simplify things"

### DIFF
--- a/shells/chrome/helpers/map.js
+++ b/shells/chrome/helpers/map.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+module.exports = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeMap;

--- a/shells/chrome/helpers/object-create.js
+++ b/shells/chrome/helpers/object-create.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+module.exports = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeObjectCreate;

--- a/shells/chrome/helpers/set.js
+++ b/shells/chrome/helpers/set.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+module.exports = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeSet;

--- a/shells/chrome/helpers/weak-map.js
+++ b/shells/chrome/helpers/weak-map.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+module.exports = window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeWeakMap;

--- a/shells/chrome/webpack.backend.js
+++ b/shells/chrome/webpack.backend.js
@@ -31,10 +31,10 @@ module.exports = {
     }],
   },
 
-  plugins: [new webpack.DefinePlugin({
-    'Object.create': 'window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeObjectCreate',
-    WeakMap: 'window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeWeakMap',
-    Map: 'window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeMap',
-    Set: 'window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeSet',
+  plugins: [new webpack.ProvidePlugin({
+    'Object.create': __dirname + '/helpers/object-create.js',
+    Map: __dirname + '/helpers/map.js',
+    WeakMap: __dirname + '/helpers/weak-map.js',
+    Set: __dirname + '/helpers/set.js',
   })],
 };


### PR DESCRIPTION
This reverts commit d748a51b9562dd6253f20b8795f765a9b1e5000c.

To address the issue raised in #313 

I am not a webpack expert and seems like this is caused by using DefinePlugin which overrides all `Map` call site to `window.__REACT_DEVTOOLS_GLOBAL_HOOK__.nativeMap` (same to `Set`)

rollback to ProvidePlugin which unbreak BananaSlug plugin release. @jaredly do you see any potential problems by reverting this commit?