### PR TITLE
fixed tabbed resizing bug on Chrome

### DIFF
--- a/frontend/TabbedPane.js
+++ b/frontend/TabbedPane.js
@@ -57,6 +57,7 @@ var styles = {
     flex: 1,
     display: 'flex',
     flexDirection: 'column',
+    width: '100%',
   },
   tabs: {
     display: 'flex',


### PR DESCRIPTION
This fixes a tabbed panel resizing issue on Chrome 48+ based on #275 and #296. This bug is present when there is a tabbed panel and can be seen on any site with Relay.