### PR TITLE
Add element's `key` and `ref` to tree and prop views

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -24,6 +24,8 @@ function getData(element: Object): DataType {
   var updater = null;
   var name = null;
   var type = null;
+  var key = null;
+  var ref = null;
   var text = null;
   var publicInstance = null;
   var nodeType = 'Native';
@@ -52,6 +54,8 @@ function getData(element: Object): DataType {
 
   if (element._currentElement) {
     type = element._currentElement.type;
+    key = element._currentElement.key;
+    ref = element._currentElement.ref;
     if (typeof type === 'string') {
       name = type;
     } else if (element.getName) {
@@ -95,6 +99,8 @@ function getData(element: Object): DataType {
   return {
     nodeType,
     type,
+    key,
+    ref,
     name,
     props,
     state,

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -54,7 +54,9 @@ function getData(element: Object): DataType {
 
   if (element._currentElement) {
     type = element._currentElement.type;
-    key = element._currentElement.key;
+    if (element._currentElement.key) {
+      key = String(element._currentElement.key);
+    }
     ref = element._currentElement.ref;
     if (typeof type === 'string') {
       name = type;

--- a/backend/getData012.js
+++ b/backend/getData012.js
@@ -21,6 +21,8 @@ function getData012(element: Object): DataType {
   var updater = null;
   var name = null;
   var type = null;
+  var key = null;
+  var ref = null;
   var text = null;
   var publicInstance = null;
   var nodeType = 'Native';
@@ -46,6 +48,8 @@ function getData012(element: Object): DataType {
 
   if (element._currentElement) {
     type = element._currentElement.type;
+    key = element._currentElement.key;
+    ref = element._currentElement.ref;
     if (typeof type === 'string') {
       name = type;
     } else {
@@ -83,6 +87,8 @@ function getData012(element: Object): DataType {
   return {
     nodeType,
     type,
+    key,
+    ref,
     name,
     props,
     state,

--- a/backend/getData012.js
+++ b/backend/getData012.js
@@ -48,7 +48,9 @@ function getData012(element: Object): DataType {
 
   if (element._currentElement) {
     type = element._currentElement.type;
-    key = element._currentElement.key;
+    if (element._currentElement.key) {
+      key = String(element._currentElement.key);
+    }
     ref = element._currentElement.ref;
     if (typeof type === 'string') {
       name = type;

--- a/backend/types.js
+++ b/backend/types.js
@@ -13,6 +13,8 @@
 export type DataType = {
   nodeType: 'Native' | 'Wrapper' | 'NativeWrapper' | 'Composite' | 'Text' | 'Empty',
   type: ?(string | AnyFn),
+  key: ?string,
+  ref: ?string,
   name: ?string,
   props: ?Object,
   state: ?Object,

--- a/backend/types.js
+++ b/backend/types.js
@@ -14,7 +14,7 @@ export type DataType = {
   nodeType: 'Native' | 'Wrapper' | 'NativeWrapper' | 'Composite' | 'Text' | 'Empty',
   type: ?(string | AnyFn),
   key: ?string,
-  ref: ?string,
+  ref: ?(string | AnyFn),
   name: ?string,
   props: ?Object,
   state: ?Object,

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -230,6 +230,7 @@ var styles = {
     fontSize: 8,
     cursor: 'pointer',
     position: 'absolute',
+    top: '-2px',
     right: '100%',
     padding: '5px 0',
   },

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -144,6 +144,8 @@ class Node extends React.Component {
             <span style={styles.tagText}>
               <span style={styles.openTag}>
                 <span style={tagStyle}>&lt;{name}</span>
+                {node.get('key') && <Props props={{'key': node.get('key')}}/>}
+                {node.get('ref') && <Props props={{'ref': node.get('ref')}}/>}
                 {node.get('props') && <Props props={node.get('props')}/>}
                 {!content && '/'}
                 <span style={tagStyle}>&gt;</span>
@@ -158,11 +160,6 @@ class Node extends React.Component {
           </div>
         </div>
       );
-    }
-
-    // Plain string
-    if (typeof children === 'string') {
-      return <div style={leftPad}>{children}</div>;
     }
 
     var closeTag = (
@@ -196,6 +193,8 @@ class Node extends React.Component {
         <span style={styles.tagText}>
           <span style={styles.openTag}>
             <span style={tagStyle}>&lt;{'' + node.get('name')}</span>
+            {node.get('key') && <Props props={{'key': node.get('key')}}/>}
+            {node.get('ref') && <Props props={{'ref': node.get('ref')}}/>}
             {node.get('props') && <Props props={node.get('props')}/>}
             <span style={tagStyle}>&gt;</span>
           </span>

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -193,9 +193,9 @@ class Node extends React.Component {
         <span style={styles.tagText}>
           <span style={styles.openTag}>
             <span style={tagStyle}>&lt;{'' + node.get('name')}</span>
-            {node.get('key') && <Props props={{'key': node.get('key')}}/>}
-            {node.get('ref') && <Props props={{'ref': node.get('ref')}}/>}
-            {node.get('props') && <Props props={node.get('props')}/>}
+            {node.get('key') && <Props key='key' props={{'key': node.get('key')}}/>}
+            {node.get('ref') && <Props key='ref' props={{'ref': node.get('ref')}}/>}
+            {node.get('props') && <Props key='props' props={node.get('props')}/>}
             <span style={tagStyle}>&gt;</span>
           </span>
           {collapsed && '…'}

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -144,9 +144,9 @@ class Node extends React.Component {
             <span style={styles.tagText}>
               <span style={styles.openTag}>
                 <span style={tagStyle}>&lt;{name}</span>
-                {node.get('key') && <Props key='key' props={{'key': node.get('key')}}/>}
-                {node.get('ref') && <Props key='ref' props={{'ref': node.get('ref')}}/>}
-                {node.get('props') && <Props key='props' props={node.get('props')}/>}
+                {node.get('key') && <Props key="key" props={{'key': node.get('key')}}/>}
+                {node.get('ref') && <Props key="ref" props={{'ref': node.get('ref')}}/>}
+                {node.get('props') && <Props key="props" props={node.get('props')}/>}
                 {!content && '/'}
                 <span style={tagStyle}>&gt;</span>
               </span>
@@ -193,9 +193,9 @@ class Node extends React.Component {
         <span style={styles.tagText}>
           <span style={styles.openTag}>
             <span style={tagStyle}>&lt;{'' + node.get('name')}</span>
-            {node.get('key') && <Props key='key' props={{'key': node.get('key')}}/>}
-            {node.get('ref') && <Props key='ref' props={{'ref': node.get('ref')}}/>}
-            {node.get('props') && <Props key='props' props={node.get('props')}/>}
+            {node.get('key') && <Props key="key" props={{'key': node.get('key')}}/>}
+            {node.get('ref') && <Props key="ref" props={{'ref': node.get('ref')}}/>}
+            {node.get('props') && <Props key="props" props={node.get('props')}/>}
             <span style={tagStyle}>&gt;</span>
           </span>
           {collapsed && '…'}

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -144,9 +144,9 @@ class Node extends React.Component {
             <span style={styles.tagText}>
               <span style={styles.openTag}>
                 <span style={tagStyle}>&lt;{name}</span>
-                {node.get('key') && <Props props={{'key': node.get('key')}}/>}
-                {node.get('ref') && <Props props={{'ref': node.get('ref')}}/>}
-                {node.get('props') && <Props props={node.get('props')}/>}
+                {node.get('key') && <Props key='key' props={{'key': node.get('key')}}/>}
+                {node.get('ref') && <Props key='ref' props={{'ref': node.get('ref')}}/>}
+                {node.get('props') && <Props key='props' props={node.get('props')}/>}
                 {!content && '/'}
                 <span style={tagStyle}>&gt;</span>
               </span>

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -14,6 +14,7 @@ var BlurInput = require('./BlurInput');
 var DataView = require('./DataView/DataView');
 var DetailPane = require('./detail_pane/DetailPane');
 var DetailPaneSection = require('./detail_pane/DetailPaneSection');
+var PropVal = require('./PropVal');
 var React = require('react');
 
 var decorate = require('./decorate');
@@ -74,8 +75,24 @@ class PropState extends React.Component {
       <DetailPane
         header={'<' + this.props.node.get('name') + '>'}
         hint="($r in the console)">
-        {key && <DetailPaneSection title="Key" hint={key}/>}
-        {ref && <DetailPaneSection title="Ref" hint={ref}/>}
+        {key &&
+          <DetailPaneSection
+            title="Key"
+            key={this.props.id + '-key'}>
+            <PropVal
+              val={key}
+            />
+          </DetailPaneSection>
+        }
+        {ref &&
+          <DetailPaneSection
+            title="Ref"
+            key={this.props.id + '-ref'}>
+            <PropVal
+              val={ref}
+            />
+          </DetailPaneSection>
+        }
         {editTextContent}
         <DetailPaneSection
           hint={propsReadOnly ? 'read-only' : null}

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -64,6 +64,8 @@ class PropState extends React.Component {
       }
     }
 
+    var key = this.props.node.get('key');
+    var ref = this.props.node.get('ref');
     var state = this.props.node.get('state');
     var context = this.props.node.get('context');
     var propsReadOnly = !this.props.node.get('canUpdate');
@@ -72,6 +74,8 @@ class PropState extends React.Component {
       <DetailPane
         header={'<' + this.props.node.get('name') + '>'}
         hint="($r in the console)">
+        {key && <DetailPaneSection title="Key" hint={key}/>}
+        {ref && <DetailPaneSection title="Ref" hint={ref}/>}
         {editTextContent}
         <DetailPaneSection
           hint={propsReadOnly ? 'read-only' : null}

--- a/frontend/detail_pane/DetailPaneSection.js
+++ b/frontend/detail_pane/DetailPaneSection.js
@@ -20,7 +20,7 @@ class DetailPaneSection extends React.Component {
     } = this.props;
     return (
       <div style={styles.section}>
-        <strong>{this.props.title}</strong>
+        <strong style={styles.title}>{this.props.title}</strong>
         {hint ? ' ' + hint : null}
         {children}
       </div>
@@ -32,6 +32,9 @@ var styles = {
   section: {
     marginBottom: 10,
     flexShrink: 0,
+  },
+  title: {
+    marginRight: 5,
   },
 };
 


### PR DESCRIPTION
Fixes #148.
Fixes #226.

If a `key` or `ref` is set on the React element, it's displayed before
the `props` in the tree view and in the `PropState` sidebar.

If none is set, nothing is changed.

Also removed a piece of code `Node.js` that would never run. (condition
is checked in the previous block that `return`s)