### PR TITLE
Fixes issue with TabbedPane not scrolling

### DIFF
--- a/frontend/TabbedPane.js
+++ b/frontend/TabbedPane.js
@@ -58,6 +58,7 @@ var styles = {
     display: 'flex',
     flexDirection: 'column',
     width: '100%',
+    maxWidth: '100%',
   },
   tabs: {
     display: 'flex',


### PR DESCRIPTION
Can be seen when the Relay tab is present.

Especially apparent when there are a great number of properties.

When viewing components, would push the right pane outside the viewport and it would be unreachable by scrolling.

Before:
![image](https://cloud.githubusercontent.com/assets/289053/13610099/b383599a-e521-11e5-9b55-0dad282398fc.png)

After:
![image](https://cloud.githubusercontent.com/assets/289053/13610122/d29a0a9a-e521-11e5-8d61-78f59eb3d23e.png)
