### PR TITLE
Differentiate between empty arrays and an empty objects in `DataView`

### DIFF
--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -41,7 +41,11 @@ class DataView extends React.Component {
     }
     var path = this.props.path;
     if (!names.length) {
-      return <span style={styles.empty}>Empty object</span>;
+      return (
+        <span style={styles.empty}>
+          {Array.isArray(data) ? 'Empty array' : 'Empty object'}
+        </span>
+      );
     }
 
     return (


### PR DESCRIPTION
When inspecting an empty array in the "props and state inspection panel" it currently says `Empty object`. Even though this is technically correct since all arrays in JS are objects this commit changes the label to `Empty array`.