### PR TITLE
Fix #248, when an <option> contains raw strings

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -30,7 +30,7 @@ function getData(element: Object): DataType {
   // If the parent is a native node without rendered children, but with
   // multiple string children, then the `element` that gets passed in here is
   // a plain value -- a string or number.
-  if (typeof element !== "object") {
+  if (typeof element !== 'object') {
     nodeType = 'Text';
     text = element + '';
   } else if (element._currentElement === null || element._currentElement === false) {

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -27,7 +27,11 @@ function getData(element: Object): DataType {
   var text = null;
   var publicInstance = null;
   var nodeType = 'Native';
-  if (element._currentElement === null || element._currentElement === false) {
+  // Sometimes element is just a string or number
+  if (typeof element !== "object") {
+    nodeType = 'Text';
+    text = element + '';
+  } else if (element._currentElement === null || element._currentElement === false) {
     nodeType = 'Empty';
   } else if (element._renderedComponent) {
     nodeType = 'NativeWrapper';
@@ -40,7 +44,7 @@ function getData(element: Object): DataType {
     }
   } else if (element._renderedChildren) {
     children = childrenList(element._renderedChildren);
-  } else if (element._currentElement.props) {
+  } else if (element._currentElement && element._currentElement.props) {
     // This is a native node without rendered children -- meaning the children
     // prop is just a string.
     children = element._currentElement.props.children;

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -27,7 +27,9 @@ function getData(element: Object): DataType {
   var text = null;
   var publicInstance = null;
   var nodeType = 'Native';
-  // Sometimes element is just a string or number
+  // If the parent is a native node without rendered children, but with
+  // multiple string children, then the `element` that gets passed in here is
+  // a plain value -- a string or number.
   if (typeof element !== "object") {
     nodeType = 'Text';
     text = element + '';
@@ -46,7 +48,8 @@ function getData(element: Object): DataType {
     children = childrenList(element._renderedChildren);
   } else if (element._currentElement && element._currentElement.props) {
     // This is a native node without rendered children -- meaning the children
-    // prop is just a string.
+    // prop is just a string or (in the case of the <option>) a list of
+    // strings & numbers.
     children = element._currentElement.props.children;
   }
 


### PR DESCRIPTION
[awkward that this was a bug for so long...]

The bug is easily replicable (see https://github.com/facebook/react-devtools/issues/248), and the problem is
that `element` is just a string in that case, such that there is no
`element._currentElement`.

Test Plan:
Go to a page with `<option>some text {1}</option>`, see that devtools doesn't
break.