### PR TITLE
Fix rendering 0

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -50,7 +50,8 @@ function getData(element: Object): DataType {
     props = element._currentElement.props;
   }
 
-  if (element._currentElement) {
+  // != used deliberately here to catch undefined and null
+  if (element._currentElement != null) {
     type = element._currentElement.type;
     if (typeof type === 'string') {
       name = type;


### PR DESCRIPTION
When a component renders a numerical `0`, the `_currentElement` property
is set to numerical `0`. The check for a "raw" element was inside a
truthy check for `_currentElement`, which in the case of `0` is
obviously false. In the devtools, a rendered `{0}` shows up as `</>`.