### PR TITLE
Check nodeType before attempting to highlight.

### DIFF
--- a/frontend/Highlighter/Overlay.js
+++ b/frontend/Highlighter/Overlay.js
@@ -84,6 +84,11 @@ class Overlay {
   }
 
   inspect(node: DOMNode, name?: ?string) {
+    // We can't get the size of text nodes or comment nodes. React as of v15
+    // heavily uses comment nodes to delimit text.
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+      return;
+    }
     var box = node.getBoundingClientRect();
     var dims = getElementDimensions(node);
 

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -28,6 +28,7 @@ export type DOMNode = {
   innerHTML: string,
   innerText: string,
   nodeName: string,
+  nodeType: number,
   offsetHeight: number,
   offsetLeft: number,
   offsetParent: ?DOMNode,


### PR DESCRIPTION
Since React v15 uses comment nodes to split text (rather than `<span>`s),
this fixes a crashing bug.