### PR TITLE
flow 0.23

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@ plugins:
   - react
 
 globals:
-  ReactElement: false
+  React$Element: false
 
 rules:
   brace-style: [2, 1tbs]

--- a/.flowconfig
+++ b/.flowconfig
@@ -15,4 +15,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowIssue
 
 [version]
-0.21.0
+0.23.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,12 @@ script:
   - npm run lint
   - flow check
   - npm test
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+

--- a/frontend/BlurInput.js
+++ b/frontend/BlurInput.js
@@ -12,9 +12,25 @@
 
 var React = require('react');
 
-import type {DOMEvent} from './types';
+import type {DOMEvent, DOMNode} from './types';
+
+type Props = {
+  value?: string,
+  onChange: (text: string) => any,
+};
+
+type DefaultProps = {};
+type State = {
+  text: string,
+};
+
 
 class BlurInput extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+  node: ?DOMNode;
+
   constructor(props: Object) {
     super(props);
     this.state = {text: this.props.value || ''};
@@ -39,7 +55,7 @@ class BlurInput extends React.Component {
     }
   }
 
-  render(): ReactElement {
+  render() {
     return (
       <input
         value={this.state.text}

--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -22,8 +22,8 @@ import type MenuItem from './ContextMenu';
 class Container extends React.Component {
   props: {
     reload: () => void,
-    extraPanes: Array<(node: Object) => ReactElement>,
-    extraTabs: ?{[key: string]: () => ReactElement},
+    extraPanes: Array<(node: Object) => React$Element>,
+    extraTabs: ?{[key: string]: () => React$Element},
     menuItems: {
       tree?: (id: string, node: Object, store: Object) => ?Array<MenuItem>,
       attr?: (
@@ -35,10 +35,10 @@ class Container extends React.Component {
         store: Object
       ) => ?Array<MenuItem>,
     },
-    extraTabs: {[key: string]: () => ReactElement},
+    extraTabs: {[key: string]: () => React$Element},
   };
 
-  render(): ReactElement {
+  render() {
     var tabs = {
       Elements: () => (
         <SplitPane

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -19,18 +19,23 @@ var assign = require('object-assign');
 var consts = require('../../agent/consts');
 var previewComplex = require('./previewComplex');
 
-class DataView extends React.Component {
-  props: {
-    data: Object,
-    path: Array<string>,
-    inspect: (path: Array<string>, cb: () => void) => void,
-    showMenu: (e: DOMEvent, val: any, path: Array<string>, name: string) => void,
-    startOpen: boolean,
-    noSort?: boolean,
-    readOnly: boolean,
-  };
+type Inspect = (path: Array<string>, cb: () => void) => void;
+type ShowMenu = boolean | (e: DOMEvent, val: any, path: Array<string>, name: string) => void;
 
-  render(): ReactElement {
+type DataViewProps = {
+  data: Object,
+  path: Array<string>,
+  inspect: Inspect,
+  showMenu: ShowMenu,
+  startOpen?: boolean,
+  noSort?: boolean,
+  readOnly?: boolean,
+};
+
+class DataView extends React.Component {
+  props: DataViewProps;
+
+  render() {
     var data = this.props.data;
     if (!data) {
       return <div style={styles.missing}>null</div>;
@@ -80,9 +85,22 @@ class DataView extends React.Component {
 }
 
 class DataItem extends React.Component {
+  props: {
+    path: Array<string>,
+    inspect: Inspect,
+    showMenu: ShowMenu,
+    startOpen?: boolean,
+    noSort?: boolean,
+    readOnly?: boolean,
+    name: string,
+    value: any,
+  };
+  defaultProps: {};
+  state: {open: boolean, loading: boolean};
+
   constructor(props) {
     super(props);
-    this.state = {open: this.props.startOpen, loading: false};
+    this.state = {open: !!this.props.startOpen, loading: false};
   }
 
   componentDidMount() {
@@ -182,7 +200,11 @@ class DataItem extends React.Component {
             {this.props.name}:
           </div>
           <div
-            onContextMenu={e => this.props.showMenu(e, this.props.value, this.props.path, this.props.name)}
+            onContextMenu={e => {
+              if (typeof this.props.showMenu === 'function') {
+                return this.props.showMenu(e, this.props.value, this.props.path, this.props.name);
+              }
+            }}
             style={styles.preview}
           >
             {preview}

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -17,12 +17,21 @@ var assign = require('object-assign');
 var flash = require('../flash');
 var valueStyles = require('../value-styles');
 
-import type {DOMEvent} from '../types';
+import type {DOMEvent, DOMNode} from '../types';
+
+type State = {
+  editing: boolean,
+  text: string,
+};
 
 class Simple extends React.Component {
+  state: State;
+  input: DOMNode;
+
   constructor(props: Object) {
     super(props);
     this.state = {
+      text: '',
       editing: false,
     };
   }
@@ -90,7 +99,7 @@ class Simple extends React.Component {
     }
   }
 
-  render(): ReactElement {
+  render() {
     if (this.state.editing) {
       return (
         <input

--- a/frontend/Draggable.js
+++ b/frontend/Draggable.js
@@ -50,7 +50,7 @@ class Draggable extends React.Component {
     this.props.onStop();
   }
 
-  render(): ReactElement {
+  render() {
     return (
       <div
         style={this.props.style}

--- a/frontend/HighlightHover.js
+++ b/frontend/HighlightHover.js
@@ -13,13 +13,26 @@
 var React = require('react');
 var assign = require('object-assign');
 
+type Props = {
+  style: ?Object,
+  children?: any,
+};
+
+type State = {
+  hover: boolean,
+};
+
 class HighlightHover extends React.Component {
+  props: Props;
+  defaultProps: {};
+  state: State;
+
   constructor(props: Object) {
     super(props);
     this.state = {hover: false};
   }
 
-  render(): ReactElement {
+  render() {
     return (
       <div
         onMouseOver={() => !this.state.hover && this.setState({hover: true})}

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -64,7 +64,7 @@ class Node extends React.Component {
     this.context.scrollTo(node.offsetTop, node.offsetHeight);
   }
 
-  render(): ReactElement {
+  render() {
     var node = this.props.node;
     if (!node) {
       return <span>Node was deleted</span>;

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -29,16 +29,25 @@ import type {Wall} from '../agent/Bridge';
 export type Props = {
   alreadyFoundReact: boolean,
   inject: (done: (wall: Wall, onDisconnect?: () => void) => void) => void,
-  checkForReact: (cb: (isReact: boolean) => void) => void,
-  reload: () => void,
+
+
+  // if alreadyFoundReact, then these don’t need to be passed
+  checkForReact?: (cb: (isReact: boolean) => void) => void,
+  reload?: () => void,
 
   // optionals
-  showComponentSource: ?() => void,
-  reloadSubscribe: ?(reloadFn: () => void) => () => void,
-  showAttrSource: ?(path: Array<string>) => void,
-  executeFn: ?(path: Array<string>) => void,
-  selectElement: ?(id: string, bridge: Bridge) => void,
-  getNewSelection: ?(bridge: Bridge) => void,
+  showComponentSource?: () => void,
+  reloadSubscribe?: (reloadFn: () => void) => () => void,
+  showAttrSource?: (path: Array<string>) => void,
+  executeFn?: (path: Array<string>) => void,
+  selectElement?: (id: string, bridge: Bridge) => void,
+  getNewSelection?: (bridge: Bridge) => void,
+};
+
+type DefaultProps = {};
+type State = {
+  loading: boolean,
+  isReact: boolean,
 };
 
 class Panel extends React.Component {
@@ -49,8 +58,12 @@ class Panel extends React.Component {
   _bridge: Bridge;
   _store: Store;
   _unsub: ?() => void;
+  // TODO: typecheck plugin interface
+  plugins: Array<any>;
 
   props: Props;
+  defaultProps: DefaultProps;
+  state: State;
 
   constructor(props: Props) {
     super(props);
@@ -193,6 +206,9 @@ class Panel extends React.Component {
   }
 
   lookForReact() {
+    if (typeof this.props.checkForReact !== 'function') {
+      return;
+    }
     this.props.checkForReact(isReact => {
       if (isReact) {
         this.setState({isReact: true, loading: true});

--- a/frontend/PropVal.js
+++ b/frontend/PropVal.js
@@ -21,7 +21,7 @@ var valueStyles = require('./value-styles');
 class PropVal extends React.Component {
   props: {
     val: any,
-    nested: boolean,
+    nested?: boolean,
   };
   componentDidUpdate(prevProps: Object) {
     if (this.props.val === prevProps.val) {
@@ -34,8 +34,8 @@ class PropVal extends React.Component {
     flash(node, 'rgba(0,255,0,1)', 'transparent', 1);
   }
 
-  render(): ReactElement {
-    return previewProp(this.props.val, this.props.nested);
+  render() {
+    return previewProp(this.props.val, !!this.props.nested);
   }
 }
 

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -22,7 +22,7 @@ class Props extends React.Component {
     return true;
   }
 
-  render(): ReactElement {
+  render() {
     var props = this.props.props;
     if (!props || typeof props !== 'object') {
       return <span/>;

--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -26,9 +26,15 @@ type EventLike = {
   stopPropagation: () => void,
 };
 
+type State = {
+  focused: boolean,
+};
+
 class SearchPane extends React.Component {
   input: ?HTMLElement;
   _key: (evt: EventLike) => void;
+  state: State;
+
   constructor(props) {
     super(props);
     this.state = {focused: false};

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -17,17 +17,28 @@ var Draggable = require('./Draggable');
 var assign = require('object-assign');
 
 type Props = {
-  style: ?{[key: string]: any},
-  left: () => ReactElement,
-  right: () => ReactElement,
+  style?: {[key: string]: any},
+  left: () => React$Element,
+  right: () => React$Element,
   initialWidth: number,
+};
+
+type DefaultProps = {};
+
+type State = {
+  moving: boolean,
+  width: number,
 };
 
 class SplitPane extends React.Component {
   props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+
   constructor(props: Props) {
     super(props);
     this.state = {
+      moving: false,
       width: props.initialWidth,
     };
   }
@@ -39,7 +50,7 @@ class SplitPane extends React.Component {
     });
   }
 
-  render(): ReactElement {
+  render() {
     var dragStyle = styles.dragger;
     if (this.state.moving) {
       dragStyle = assign({}, dragStyle, styles.draggerMoving);

--- a/frontend/TabbedPane.js
+++ b/frontend/TabbedPane.js
@@ -16,7 +16,7 @@ var decorate = require('./decorate');
 
 class TabbedPane extends React.Component {
   props: {
-    tabs: {[key: string]: () => ReactElement},
+    tabs: {[key: string]: () => React$Element},
     selected: string,
     setSelectedTab: (name: string) => void,
   };

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -14,11 +14,15 @@ var Breadcrumb = require('./Breadcrumb');
 var Node = require('./Node');
 var React = require('react');
 
+import type {DOMNode} from './types';
+
 var decorate = require('./decorate');
 
 var MAX_SEARCH_ROOTS = 200;
 
 class TreeView extends React.Component {
+  node: ?DOMNode;
+
   getChildContext() {
     return {
       scrollTo: this.scrollTo.bind(this),

--- a/frontend/decorate.js
+++ b/frontend/decorate.js
@@ -23,6 +23,8 @@ type Options = {
   props: (store: Object, props: Object) => Object,
 };
 
+type State = {};
+
 /**
  * This Higher Order Component decorator function is the way the components
  * communicate with the central Store.
@@ -55,6 +57,7 @@ module.exports = function(options: Options, Component: any): any {
   class Wrapper extends React.Component {
     _listeners: Array<string>;
     _update: () => void;
+    state: State;
 
     constructor(props) {
       super(props);

--- a/frontend/provideStore.js
+++ b/frontend/provideStore.js
@@ -15,7 +15,7 @@ var React = require('react');
 module.exports = function(name: string): Object {
   class Wrapper extends React.Component {
     props: {
-      children: () => ReactElement,
+      children: () => React$Element,
       store: Object,
     };
     getChildContext() {

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -37,6 +37,8 @@ export type DOMNode = {
   parentNode: DOMNode,
   removeChild: (child: DOMNode) => void,
   removeListener: (evt: string, fn: () => void) => void,
+  selectionStart: number,
+  selectionEnd: number,
   scrollLeft: number,
   scrollTop: number,
   style: Object,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10033,9 +10033,9 @@
       }
     },
     "flow-bin": {
-      "version": "0.21.0",
-      "from": "flow-bin@0.21.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.21.0.tgz",
+      "version": "0.23.0",
+      "from": "flow-bin@0.23.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.23.0.tgz",
       "dependencies": {
         "bin-wrapper": {
           "version": "2.1.3",
@@ -10054,37 +10054,30 @@
                   "dependencies": {
                     "meow": {
                       "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
+                      "from": "meow@>=3.1.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.0.0",
+                          "version": "2.1.0",
                           "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.0",
+                              "version": "2.1.1",
                               "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                             }
                           }
                         },
                         "decamelize": {
-                          "version": "1.1.2",
+                          "version": "1.2.0",
                           "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "loud-rejection": {
-                          "version": "1.2.1",
+                          "version": "1.3.0",
                           "from": "loud-rejection@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "dependencies": {
                             "array-find-index": {
                               "version": "1.0.1",
@@ -10105,7 +10098,7 @@
                         },
                         "minimist": {
                           "version": "1.2.0",
-                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "from": "minimist@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "normalize-package-data": {
@@ -10146,9 +10139,9 @@
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-license-ids": {
-                                      "version": "1.2.0",
+                                      "version": "1.2.1",
                                       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                     }
                                   }
                                 },
@@ -10163,9 +10156,9 @@
                                       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                     },
                                     "spdx-license-ids": {
-                                      "version": "1.2.0",
+                                      "version": "1.2.1",
                                       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                     }
                                   }
                                 }
@@ -10179,9 +10172,9 @@
                           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "dependencies": {
                             "find-up": {
-                              "version": "1.1.0",
+                              "version": "1.1.2",
                               "from": "find-up@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                               "dependencies": {
                                 "path-exists": {
                                   "version": "2.1.0",
@@ -10189,9 +10182,9 @@
                                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -10242,9 +10235,9 @@
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -10283,9 +10276,9 @@
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -10311,9 +10304,9 @@
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "dependencies": {
                                 "repeating": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
@@ -10375,9 +10368,9 @@
                           "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                         },
                         "readable-stream": {
-                          "version": "2.0.5",
+                          "version": "2.0.6",
                           "from": "readable-stream@>=2.0.0 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
@@ -10385,9 +10378,9 @@
                               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.6",
@@ -10448,33 +10441,26 @@
                           "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                           "dependencies": {
                             "camelcase-keys": {
-                              "version": "2.0.0",
+                              "version": "2.1.0",
                               "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                               "dependencies": {
                                 "camelcase": {
-                                  "version": "2.1.0",
+                                  "version": "2.1.1",
                                   "from": "camelcase@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                                 }
                               }
                             },
                             "decamelize": {
-                              "version": "1.1.2",
+                              "version": "1.2.0",
                               "from": "decamelize@>=1.1.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                              "dependencies": {
-                                "escape-string-regexp": {
-                                  "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                             },
                             "loud-rejection": {
-                              "version": "1.2.1",
+                              "version": "1.3.0",
                               "from": "loud-rejection@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                              "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                               "dependencies": {
                                 "array-find-index": {
                                   "version": "1.0.1",
@@ -10526,9 +10512,9 @@
                                       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                       "dependencies": {
                                         "spdx-license-ids": {
-                                          "version": "1.2.0",
+                                          "version": "1.2.1",
                                           "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                         }
                                       }
                                     },
@@ -10543,9 +10529,9 @@
                                           "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                         },
                                         "spdx-license-ids": {
-                                          "version": "1.2.0",
-                                          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                          "version": "1.2.1",
+                                          "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                         }
                                       }
                                     }
@@ -10559,9 +10545,9 @@
                               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                               "dependencies": {
                                 "find-up": {
-                                  "version": "1.1.0",
+                                  "version": "1.1.2",
                                   "from": "find-up@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                                   "dependencies": {
                                     "path-exists": {
                                       "version": "2.1.0",
@@ -10569,9 +10555,9 @@
                                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -10622,9 +10608,9 @@
                                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                         },
                                         "pinkie-promise": {
-                                          "version": "2.0.0",
+                                          "version": "2.0.1",
                                           "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                           "dependencies": {
                                             "pinkie": {
                                               "version": "2.0.4",
@@ -10663,9 +10649,9 @@
                                           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                         },
                                         "pinkie-promise": {
-                                          "version": "2.0.0",
+                                          "version": "2.0.1",
                                           "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                           "dependencies": {
                                             "pinkie": {
                                               "version": "2.0.4",
@@ -10691,9 +10677,9 @@
                                   "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                                   "dependencies": {
                                     "repeating": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "repeating@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                                       "dependencies": {
                                         "is-finite": {
                                           "version": "1.0.1",
@@ -10770,7 +10756,7 @@
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "typedarray": {
@@ -10779,9 +10765,9 @@
                       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
                     },
                     "readable-stream": {
-                      "version": "2.0.5",
+                      "version": "2.0.6",
                       "from": "readable-stream@>=2.0.0 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -10789,9 +10775,9 @@
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                         },
                         "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.6",
@@ -10838,9 +10824,9 @@
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                             },
                             "escape-string-regexp": {
-                              "version": "1.0.4",
+                              "version": "1.0.5",
                               "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "0.1.0",
@@ -10849,7 +10835,7 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
@@ -10861,7 +10847,7 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
@@ -10875,7 +10861,7 @@
                         },
                         "is-absolute": {
                           "version": "0.1.7",
-                          "from": "is-absolute@>=0.1.7 <0.2.0",
+                          "from": "is-absolute@>=0.1.5 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                           "dependencies": {
                             "is-relative": {
@@ -10922,9 +10908,9 @@
                           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                           "dependencies": {
                             "readable-stream": {
-                              "version": "1.0.33",
+                              "version": "1.0.34",
                               "from": "readable-stream@>=1.0.26 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
@@ -10970,9 +10956,9 @@
                           }
                         },
                         "readable-stream": {
-                          "version": "1.1.13",
+                          "version": "1.1.14",
                           "from": "readable-stream@>=1.0.27-1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
@@ -11050,9 +11036,9 @@
                               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                             },
                             "escape-string-regexp": {
-                              "version": "1.0.4",
+                              "version": "1.0.5",
                               "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "0.1.0",
@@ -11061,7 +11047,7 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
@@ -11073,7 +11059,7 @@
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "0.2.1",
-                                  "from": "ansi-regex@>=0.2.1 <0.3.0",
+                                  "from": "ansi-regex@>=0.2.0 <0.3.0",
                                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                                 }
                               }
@@ -11087,7 +11073,7 @@
                         },
                         "is-absolute": {
                           "version": "0.1.7",
-                          "from": "is-absolute@>=0.1.7 <0.2.0",
+                          "from": "is-absolute@>=0.1.5 <0.2.0",
                           "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
                           "dependencies": {
                             "is-relative": {
@@ -11134,9 +11120,9 @@
                           "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
                           "dependencies": {
                             "readable-stream": {
-                              "version": "1.0.33",
+                              "version": "1.0.34",
                               "from": "readable-stream@>=1.0.26 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
@@ -11182,9 +11168,9 @@
                           }
                         },
                         "readable-stream": {
-                          "version": "1.1.13",
+                          "version": "1.1.14",
                           "from": "readable-stream@>=1.0.27-1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
@@ -11233,19 +11219,19 @@
                       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
                       "dependencies": {
                         "chalk": {
-                          "version": "1.1.1",
+                          "version": "1.1.3",
                           "from": "chalk@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
-                              "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
-                              "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
@@ -11260,179 +11246,9 @@
                               }
                             },
                             "strip-ansi": {
-                              "version": "3.0.0",
+                              "version": "3.0.1",
                               "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "get-stdin": {
-                          "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                        },
-                        "is-absolute": {
-                          "version": "0.1.7",
-                          "from": "is-absolute@>=0.1.7 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
-                          "dependencies": {
-                            "is-relative": {
-                              "version": "0.1.3",
-                              "from": "is-relative@>=0.1.0 <0.2.0",
-                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
-                            }
-                          }
-                        },
-                        "is-natural-number": {
-                          "version": "2.0.0",
-                          "from": "is-natural-number@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
-                        },
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@>=1.1.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        },
-                        "sum-up": {
-                          "version": "1.0.2",
-                          "from": "sum-up@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "tar-stream": {
-                      "version": "1.3.1",
-                      "from": "tar-stream@>=1.1.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.3.1.tgz",
-                      "dependencies": {
-                        "bl": {
-                          "version": "1.1.2",
-                          "from": "bl@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz"
-                        },
-                        "end-of-stream": {
-                          "version": "1.1.0",
-                          "from": "end-of-stream@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-                          "dependencies": {
-                            "once": {
-                              "version": "1.3.3",
-                              "from": "once@>=1.3.0 <1.4.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "readable-stream": {
-                          "version": "2.0.5",
-                          "from": "readable-stream@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "process-nextick-args": {
-                              "version": "1.0.6",
-                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "util-deprecate": {
-                              "version": "1.0.2",
-                              "from": "util-deprecate@>=1.0.1 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "xtend": {
-                          "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "decompress-unzip": {
-                  "version": "2.1.2",
-                  "from": "decompress-unzip@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-2.1.2.tgz",
-                  "dependencies": {
-                    "is-zip": {
-                      "version": "1.0.0",
-                      "from": "is-zip@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
-                    },
-                    "strip-dirs": {
-                      "version": "1.1.1",
-                      "from": "strip-dirs@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.1",
-                          "from": "chalk@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.0",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
@@ -11476,9 +11292,291 @@
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                         },
                         "sum-up": {
-                          "version": "1.0.2",
+                          "version": "1.0.3",
                           "from": "sum-up@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "tar-stream": {
+                      "version": "1.5.1",
+                      "from": "tar-stream@>=1.1.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.1.tgz",
+                      "dependencies": {
+                        "bl": {
+                          "version": "1.1.2",
+                          "from": "bl@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "2.0.6",
+                              "from": "readable-stream@>=2.0.5 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.2",
+                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "isarray@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.6",
+                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "util-deprecate": {
+                                  "version": "1.0.2",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "end-of-stream": {
+                          "version": "1.1.0",
+                          "from": "end-of-stream@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                          "dependencies": {
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@>=1.3.0 <1.4.0",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "2.1.0",
+                          "from": "readable-stream@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.0.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            },
+                            "inline-process-browser": {
+                              "version": "2.0.1",
+                              "from": "inline-process-browser@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-2.0.1.tgz",
+                              "dependencies": {
+                                "falafel": {
+                                  "version": "1.2.0",
+                                  "from": "falafel@>=1.0.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
+                                  "dependencies": {
+                                    "acorn": {
+                                      "version": "1.2.2",
+                                      "from": "acorn@>=1.0.3 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
+                                    },
+                                    "foreach": {
+                                      "version": "2.0.5",
+                                      "from": "foreach@>=2.0.5 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "object-keys": {
+                                      "version": "1.0.9",
+                                      "from": "object-keys@>=1.0.6 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.9.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.6",
+                              "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "unreachable-branch-transform": {
+                              "version": "0.5.1",
+                              "from": "unreachable-branch-transform@>=0.5.0 <0.6.0",
+                              "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.5.1.tgz",
+                              "dependencies": {
+                                "esmangle-evaluator": {
+                                  "version": "1.0.0",
+                                  "from": "esmangle-evaluator@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.0.tgz"
+                                },
+                                "recast": {
+                                  "version": "0.11.5",
+                                  "from": "recast@>=0.11.4 <0.12.0",
+                                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.5.tgz",
+                                  "dependencies": {
+                                    "ast-types": {
+                                      "version": "0.8.16",
+                                      "from": "ast-types@0.8.16",
+                                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.16.tgz"
+                                    },
+                                    "esprima": {
+                                      "version": "2.7.2",
+                                      "from": "esprima@>=2.7.1 <2.8.0",
+                                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+                                    },
+                                    "private": {
+                                      "version": "0.1.6",
+                                      "from": "private@>=0.1.5 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                                    },
+                                    "source-map": {
+                                      "version": "0.5.3",
+                                      "from": "source-map@>=0.5.0 <0.6.0",
+                                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@>=1.0.1 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "decompress-unzip": {
+                  "version": "2.1.2",
+                  "from": "decompress-unzip@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-2.1.2.tgz",
+                  "dependencies": {
+                    "is-zip": {
+                      "version": "1.0.0",
+                      "from": "is-zip@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                    },
+                    "strip-dirs": {
+                      "version": "1.1.1",
+                      "from": "strip-dirs@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.0.0",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "get-stdin": {
+                          "version": "4.0.1",
+                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                        },
+                        "is-absolute": {
+                          "version": "0.1.7",
+                          "from": "is-absolute@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                          "dependencies": {
+                            "is-relative": {
+                              "version": "0.1.3",
+                              "from": "is-relative@>=0.1.0 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                            }
+                          }
+                        },
+                        "is-natural-number": {
+                          "version": "2.0.0",
+                          "from": "is-natural-number@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                        },
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        },
+                        "sum-up": {
+                          "version": "1.0.3",
+                          "from": "sum-up@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.3.tgz"
                         }
                       }
                     },
@@ -11547,7 +11645,7 @@
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "map-obj@>=1.0.1 <2.0.0",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
@@ -11564,7 +11662,7 @@
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "repeating@>=1.1.3 <2.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
@@ -11585,7 +11683,7 @@
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "from": "minimist@>=1.1.3 <2.0.0",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "object-assign": {
@@ -11623,9 +11721,9 @@
                   }
                 },
                 "request": {
-                  "version": "2.69.0",
+                  "version": "2.72.0",
                   "from": "request@>=2.34.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.69.0.tgz",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.72.0.tgz",
                   "dependencies": {
                     "aws-sign2": {
                       "version": "0.6.0",
@@ -11633,26 +11731,38 @@
                       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
                     },
                     "aws4": {
-                      "version": "1.2.1",
+                      "version": "1.3.2",
                       "from": "aws4@>=1.2.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.3.2.tgz",
                       "dependencies": {
                         "lru-cache": {
-                          "version": "2.7.3",
-                          "from": "lru-cache@>=2.6.5 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+                          "version": "4.0.1",
+                          "from": "lru-cache@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
+                          "dependencies": {
+                            "pseudomap": {
+                              "version": "1.0.2",
+                              "from": "pseudomap@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                            },
+                            "yallist": {
+                              "version": "2.0.0",
+                              "from": "yallist@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
+                            }
+                          }
                         }
                       }
                     },
                     "bl": {
-                      "version": "1.0.3",
-                      "from": "bl@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.3.tgz",
+                      "version": "1.1.2",
+                      "from": "bl@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                       "dependencies": {
                         "readable-stream": {
-                          "version": "2.0.5",
+                          "version": "2.0.6",
                           "from": "readable-stream@>=2.0.5 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                           "dependencies": {
                             "core-util-is": {
                               "version": "1.0.2",
@@ -11665,9 +11775,9 @@
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                             },
                             "process-nextick-args": {
                               "version": "1.0.6",
@@ -11716,13 +11826,13 @@
                       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                     },
                     "form-data": {
-                      "version": "1.0.0-rc3",
+                      "version": "1.0.0-rc4",
                       "from": "form-data@>=1.0.0-rc3 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
                       "dependencies": {
                         "async": {
                           "version": "1.5.2",
-                          "from": "async@>=1.4.0 <2.0.0",
+                          "from": "async@>=1.5.2 <2.0.0",
                           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                         }
                       }
@@ -11733,19 +11843,19 @@
                       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                       "dependencies": {
                         "chalk": {
-                          "version": "1.1.1",
+                          "version": "1.1.3",
                           "from": "chalk@>=1.1.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                           "dependencies": {
                             "ansi-styles": {
-                              "version": "2.1.0",
-                              "from": "ansi-styles@>=2.1.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                             },
                             "escape-string-regexp": {
-                              "version": "1.0.4",
+                              "version": "1.0.5",
                               "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                             },
                             "has-ansi": {
                               "version": "2.0.0",
@@ -11760,9 +11870,9 @@
                               }
                             },
                             "strip-ansi": {
-                              "version": "3.0.0",
+                              "version": "3.0.1",
                               "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                               "dependencies": {
                                 "ansi-regex": {
                                   "version": "2.0.0",
@@ -11791,9 +11901,9 @@
                           }
                         },
                         "is-my-json-valid": {
-                          "version": "2.12.4",
+                          "version": "2.13.1",
                           "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.4.tgz",
+                          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
                           "dependencies": {
                             "generate-function": {
                               "version": "2.0.0",
@@ -11825,9 +11935,9 @@
                           }
                         },
                         "pinkie-promise": {
-                          "version": "2.0.0",
+                          "version": "2.0.1",
                           "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
@@ -11840,7 +11950,7 @@
                     },
                     "hawk": {
                       "version": "3.1.3",
-                      "from": "hawk@>=3.1.0 <3.2.0",
+                      "from": "hawk@>=3.1.3 <3.2.0",
                       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                       "dependencies": {
                         "hoek": {
@@ -11925,9 +12035,9 @@
                               "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                             },
                             "tweetnacl": {
-                              "version": "0.13.3",
+                              "version": "0.14.3",
                               "from": "tweetnacl@>=0.13.0 <1.0.0",
-                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
                             },
                             "jodid25519": {
                               "version": "1.0.2",
@@ -11977,13 +12087,13 @@
                     },
                     "oauth-sign": {
                       "version": "0.8.1",
-                      "from": "oauth-sign@>=0.8.0 <0.9.0",
+                      "from": "oauth-sign@>=0.8.1 <0.9.0",
                       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.1.tgz"
                     },
                     "qs": {
-                      "version": "6.0.2",
-                      "from": "qs@>=6.0.2 <6.1.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.0.2.tgz"
+                      "version": "6.1.0",
+                      "from": "qs@>=6.1.0 <6.2.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.1.0.tgz"
                     },
                     "stringstream": {
                       "version": "0.0.5",
@@ -11991,9 +12101,9 @@
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                     },
                     "tough-cookie": {
-                      "version": "2.2.1",
+                      "version": "2.2.2",
                       "from": "tough-cookie@>=2.2.0 <2.3.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
                     },
                     "tunnel-agent": {
                       "version": "0.4.2",
@@ -12025,9 +12135,9 @@
                   "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                   "dependencies": {
                     "readable-stream": {
-                      "version": "1.0.33",
+                      "version": "1.0.34",
                       "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.2",
@@ -12326,9 +12436,9 @@
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "0.1.0",
@@ -12387,33 +12497,26 @@
                       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.0.0",
+                          "version": "2.1.0",
                           "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.0",
+                              "version": "2.1.1",
                               "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                             }
                           }
                         },
                         "decamelize": {
-                          "version": "1.1.2",
+                          "version": "1.2.0",
                           "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "loud-rejection": {
-                          "version": "1.2.1",
+                          "version": "1.3.0",
                           "from": "loud-rejection@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "dependencies": {
                             "array-find-index": {
                               "version": "1.0.1",
@@ -12475,9 +12578,9 @@
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-license-ids": {
-                                      "version": "1.2.0",
+                                      "version": "1.2.1",
                                       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                     }
                                   }
                                 },
@@ -12492,9 +12595,9 @@
                                       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                     },
                                     "spdx-license-ids": {
-                                      "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                      "version": "1.2.1",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                     }
                                   }
                                 }
@@ -12513,9 +12616,9 @@
                           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "dependencies": {
                             "find-up": {
-                              "version": "1.1.0",
+                              "version": "1.1.2",
                               "from": "find-up@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                               "dependencies": {
                                 "path-exists": {
                                   "version": "2.1.0",
@@ -12523,9 +12626,9 @@
                                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -12576,9 +12679,9 @@
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -12617,9 +12720,9 @@
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -12645,9 +12748,9 @@
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "dependencies": {
                                 "repeating": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",
@@ -12734,7 +12837,7 @@
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "inherits@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "minimatch": {
@@ -12812,33 +12915,26 @@
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
-                      "version": "2.0.0",
+                      "version": "2.1.0",
                       "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "2.1.0",
+                          "version": "2.1.1",
                           "from": "camelcase@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                         }
                       }
                     },
                     "decamelize": {
-                      "version": "1.1.2",
+                      "version": "1.2.0",
                       "from": "decamelize@>=1.1.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                      "dependencies": {
-                        "escape-string-regexp": {
-                          "version": "1.0.4",
-                          "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                     },
                     "loud-rejection": {
-                      "version": "1.2.1",
+                      "version": "1.3.0",
                       "from": "loud-rejection@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                       "dependencies": {
                         "array-find-index": {
                           "version": "1.0.1",
@@ -12900,9 +12996,9 @@
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
-                                  "version": "1.2.0",
+                                  "version": "1.2.1",
                                   "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                 }
                               }
                             },
@@ -12917,9 +13013,9 @@
                                   "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                 },
                                 "spdx-license-ids": {
-                                  "version": "1.2.0",
+                                  "version": "1.2.1",
                                   "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                 }
                               }
                             }
@@ -12933,9 +13029,9 @@
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
-                          "version": "1.1.0",
+                          "version": "1.1.2",
                           "from": "find-up@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
@@ -12943,9 +13039,9 @@
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                             },
                             "pinkie-promise": {
-                              "version": "2.0.0",
+                              "version": "2.0.1",
                               "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
@@ -12996,9 +13092,9 @@
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -13037,9 +13133,9 @@
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -13065,9 +13161,9 @@
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
-                              "version": "2.0.0",
+                              "version": "2.0.1",
                               "from": "repeating@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
@@ -13108,7 +13204,7 @@
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "mkdirp@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
@@ -13124,9 +13220,9 @@
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.2.tgz",
                   "dependencies": {
                     "glob": {
-                      "version": "7.0.0",
+                      "version": "7.0.3",
                       "from": "glob@>=7.0.0 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.3.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.4",
@@ -13287,9 +13383,9 @@
           "resolved": "https://registry.npmjs.org/logalot/-/logalot-2.1.0.tgz",
           "dependencies": {
             "figures": {
-              "version": "1.4.0",
+              "version": "1.5.0",
               "from": "figures@>=1.3.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/figures/-/figures-1.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.5.0.tgz"
             },
             "squeak": {
               "version": "1.3.0",
@@ -13297,19 +13393,19 @@
               "resolved": "https://registry.npmjs.org/squeak/-/squeak-1.3.0.tgz",
               "dependencies": {
                 "chalk": {
-                  "version": "1.1.1",
-                  "from": "chalk@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
+                  "version": "1.1.3",
+                  "from": "chalk@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                   "dependencies": {
                     "ansi-styles": {
-                      "version": "2.1.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                      "version": "2.2.1",
+                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
-                      "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
@@ -13324,9 +13420,9 @@
                       }
                     },
                     "strip-ansi": {
-                      "version": "3.0.0",
+                      "version": "3.0.1",
                       "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
@@ -13369,37 +13465,30 @@
                     },
                     "meow": {
                       "version": "3.7.0",
-                      "from": "meow@>=3.3.0 <4.0.0",
+                      "from": "meow@>=3.1.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                       "dependencies": {
                         "camelcase-keys": {
-                          "version": "2.0.0",
+                          "version": "2.1.0",
                           "from": "camelcase-keys@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                           "dependencies": {
                             "camelcase": {
-                              "version": "2.1.0",
+                              "version": "2.1.1",
                               "from": "camelcase@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.0.tgz"
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
                             }
                           }
                         },
                         "decamelize": {
-                          "version": "1.1.2",
+                          "version": "1.2.0",
                           "from": "decamelize@>=1.1.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
-                          "dependencies": {
-                            "escape-string-regexp": {
-                              "version": "1.0.4",
-                              "from": "escape-string-regexp@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
                         },
                         "loud-rejection": {
-                          "version": "1.2.1",
+                          "version": "1.3.0",
                           "from": "loud-rejection@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.3.0.tgz",
                           "dependencies": {
                             "array-find-index": {
                               "version": "1.0.1",
@@ -13461,9 +13550,9 @@
                                   "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                                   "dependencies": {
                                     "spdx-license-ids": {
-                                      "version": "1.2.0",
+                                      "version": "1.2.1",
                                       "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                     }
                                   }
                                 },
@@ -13478,9 +13567,9 @@
                                       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                     },
                                     "spdx-license-ids": {
-                                      "version": "1.2.0",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
+                                      "version": "1.2.1",
+                                      "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.1.tgz"
                                     }
                                   }
                                 }
@@ -13494,9 +13583,9 @@
                           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                           "dependencies": {
                             "find-up": {
-                              "version": "1.1.0",
+                              "version": "1.1.2",
                               "from": "find-up@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
                               "dependencies": {
                                 "path-exists": {
                                   "version": "2.1.0",
@@ -13504,9 +13593,9 @@
                                   "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                                 },
                                 "pinkie-promise": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.4",
@@ -13557,9 +13646,9 @@
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -13598,9 +13687,9 @@
                                       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                     },
                                     "pinkie-promise": {
-                                      "version": "2.0.0",
+                                      "version": "2.0.1",
                                       "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
+                                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
                                       "dependencies": {
                                         "pinkie": {
                                           "version": "2.0.4",
@@ -13626,9 +13715,9 @@
                               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                               "dependencies": {
                                 "repeating": {
-                                  "version": "2.0.0",
+                                  "version": "2.0.1",
                                   "from": "repeating@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
                                   "dependencies": {
                                     "is-finite": {
                                       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint-plugin-react": "3.12.0",
     "fbjs": "0.5.1",
     "fbjs-scripts": "0.5.0",
-    "flow-bin": "0.21.0",
+    "flow-bin": "0.23.0",
     "immutable": "3.7.6",
     "jest-cli": "0.9.0-fb2",
     "json-loader": "0.5.4",

--- a/plugins/BananaSlug/BananaSlugFrontendControl.js
+++ b/plugins/BananaSlug/BananaSlugFrontendControl.js
@@ -19,10 +19,11 @@ import type {
 } from './BananaSlugTypes';
 
 type Props = {
+  state: any,
   onChange: (v: ControlState) => void,
 };
 
-type State = {};
+type State = StateRecord;
 
 type DefaultProps = {};
 
@@ -30,8 +31,11 @@ const StateRecord = immutable.Record({
   enabled: false,
 });
 
-class BananaSlugFrontendControl extends
-  React.Component<DefaultProps, Props, State> {
+class BananaSlugFrontendControl extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+
   _defaultState: ControlState;
   _toggle: (b: boolean) => void;
 
@@ -47,7 +51,7 @@ class BananaSlugFrontendControl extends
     }
   }
 
-  render(): ReactElement {
+  render() {
     var state = this.props.state || this._defaultState;
     return (
       <div style={styles.container} onClick={this._toggle} tabIndex={0}>

--- a/plugins/ReactNativeStyle/BlurInput.js
+++ b/plugins/ReactNativeStyle/BlurInput.js
@@ -11,9 +11,23 @@
 'use strict';
 
 var React = require('react');
-import type {DOMEvent} from '../../frontend/types';
+import type {DOMEvent, DOMNode} from '../../frontend/types';
+
+type Props = {
+  onChange: (text: string|number) => any;
+  value: string|number;
+};
+type DefaultProps = {};
+type State = {
+  text: string;
+};
 
 class BlurInput extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+  node: ?DOMNode;
+
   constructor(props: Object) {
     super(props);
     this.state = {text: '' + this.props.value};
@@ -44,7 +58,7 @@ class BlurInput extends React.Component {
     }
   }
 
-  render(): ReactElement {
+  render() {
     return (
       <input
         value={this.state.text}

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -21,7 +21,23 @@ function shallowClone(obj) {
   return nobj;
 }
 
+type Props = {
+  // TODO: typecheck bridge interface
+  bridge: any;
+  id: any;
+};
+
+type DefaultProps = {};
+
+type State = {
+  style: ?Object;
+};
+
 class NativeStyler extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+
   constructor(props: Object) {
     super(props);
     this.state = {style: null};
@@ -44,7 +60,9 @@ class NativeStyler extends React.Component {
   }
 
   _handleStyleChange(attr: string, val: string | number) {
-    this.state.style[attr] = val;
+    if (this.state.style) {
+      this.state.style[attr] = val;
+    }
     this.props.bridge.send('rn-style:set', {id: this.props.id, attr, val});
     this.setState({style: this.state.style});
   }

--- a/plugins/ReactNativeStyle/StyleEdit.js
+++ b/plugins/ReactNativeStyle/StyleEdit.js
@@ -13,14 +13,26 @@
 var React = require('react');
 var BlurInput = require('./BlurInput');
 
-class StyleEdit extends React.Component {
-  props: {
-    style: Object,
-    onChange: (attr: string, val: string | number) => void,
-    onRename: (oldName: string, newName: string, val: string | number) => void,
-  };
 
-  constructor(props: Object) {
+type Props = {
+  style: Object,
+  onChange: (attr: string, val: string | number) => void,
+  onRename: (oldName: string, newName: string, val: string | number) => void,
+};
+
+type DefaultProps = {};
+
+type State = {
+  newAttr: string,
+  newValue: string|number,
+};
+
+class StyleEdit extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+
+  constructor(props: Props) {
     super(props);
     this.state = {newAttr: '', newValue: ''};
   }
@@ -30,7 +42,7 @@ class StyleEdit extends React.Component {
     this.setState({newAttr: '', newValue: ''});
   }
 
-  render(): ReactElement {
+  render() {
     var attrs = Object.keys(this.props.style);
     return (
       <ul style={styles.container}>
@@ -38,7 +50,7 @@ class StyleEdit extends React.Component {
           <li style={styles.attr}>
             <BlurInput
               value={name}
-              onChange={newName => this.props.onRename(name, newName, this.props.style[name])}
+              onChange={newName => this.props.onRename(name, '' + newName, this.props.style[name])}
             />
             :
             <BlurInput
@@ -50,7 +62,7 @@ class StyleEdit extends React.Component {
         <li style={styles.attr}>
           <BlurInput
             value={this.state.newAttr}
-            onChange={newAttr => this.setState({newAttr})}
+            onChange={newAttr => this.setState({newAttr: '' + newAttr})}
           />
           :
           {this.state.newAttr && <BlurInput

--- a/plugins/Relay/Query.js
+++ b/plugins/Relay/Query.js
@@ -20,7 +20,7 @@ class Query extends React.Component {
     oddRow: boolean,
     onSelect: () => void,
   };
-  render(): ReactElement {
+  render() {
     var data = this.props.data;
     var containerStyle = styles.container;
     if (this.props.isSelected) {

--- a/plugins/Relay/QueryViewer.js
+++ b/plugins/Relay/QueryViewer.js
@@ -25,7 +25,7 @@ class QueryViewer extends React.Component {
     data: Map,
     inspect: (path: Array<string>, cb: () => void) => void,
   };
-  render(): ReactElement {
+  render() {
     var data = this.props.data;
     var status = data.get('status');
 

--- a/plugins/Relay/RelayPlugin.js
+++ b/plugins/Relay/RelayPlugin.js
@@ -45,7 +45,7 @@ class RelayPlugin {
     }, 1000);
   }
 
-  panes(): Array<(node: Object, id: string) => ReactElement> {
+  panes(): Array<(node: Object, id: string) => React$Element> {
     if (!this.hasRelay) {
       return [];
     }
@@ -61,7 +61,7 @@ class RelayPlugin {
   teardown() {
   }
 
-  tabs(): ?{[key: string]: () => ReactElement} {
+  tabs(): ?{[key: string]: () => React$Element} {
     if (!this.hasRelay) {
       return null;
     }

--- a/plugins/Relay/StoreTab.js
+++ b/plugins/Relay/StoreTab.js
@@ -21,7 +21,7 @@ class StoreTab extends React.Component {
     data: Map,
     inspect: (path: Array<string>, cb: () => void) => void,
   };
-  render(): ReactElement {
+  render() {
     if (!this.props.storeData) {
       return (
         <div style={styles.container}>


### PR DESCRIPTION
Seeing @kassens PRs to this repo was always my notification that a new flow release was available. When first upgrading from flow@0.21 -> flow@0.23 there were ~165 errors (exact number I forget, but it was in that range).

Most of it was that flow now requires the `State` shape to be declared on components that use it and other static properties like `node => this.node = node`. After getting through all those rather mundane changes there were a few other changes that required a bit more work.

Specifically the following warning I couldn’t reconcile with only flow definition changes, so I explicitly converted it to a `string` in the `BlurInput.setState` call.

```sh
plugins/ReactNativeStyle/StyleEdit.js:63
 63:           <BlurInput
               ^ React element `BlurInput`
 65:             onChange={newAttr => this.setState({newAttr})}
                                                     ^^^^^^^ number. This type is incompatible with
 26:   newAttr: string,
                ^^^^^^ string
```

Additionally, the `Panel` was being used by the different shells with a `{...config}` object that didn’t have many of the required props. This was solved by marking more fields as optional and putting in the appropriate checks for it.

Lastly `ReactElement` -> `React$Element` in the flowdef. https://github.com/facebook/flow/blob/master/lib/react.js#L106-L116 Simply renaming it seemed to suffice, but there may be details I’m missing.