### PR TITLE
Fix Electron shell to work on new versions of Electron

### DIFF
--- a/shells/electron/index.js
+++ b/shells/electron/index.js
@@ -8,8 +8,8 @@
  */
 'use strict';
 
-var app = require('app');  // Module to control application life.
-var BrowserWindow = require('browser-window');  // Module to create native browser window.
+var app = require('electron').app;  // Module to control application life.
+var BrowserWindow = require('electron').BrowserWindow;  // Module to create native browser window.
 
 var mainWindow = null;
 
@@ -22,7 +22,7 @@ app.on('ready', function() {
   mainWindow = new BrowserWindow({width: 800, height: 600});
 
   // and load the index.html of the app.
-  mainWindow.loadUrl('file://' + __dirname + '/index.html'); // eslint-disable-line no-path-concat
+  mainWindow.loadURL('file://' + __dirname + '/index.html'); // eslint-disable-line no-path-concat
 
   // Open the devtools.
   // mainWindow.openDevTools();


### PR DESCRIPTION
Electron v1.0.0+ deprecated a few APIs
http://electron.atom.io/blog/2015/11/17/electron-api-changes
https://github.com/electron/electron/releases/tag/v1.0.0

<img width="820" alt="" src="https://cloud.githubusercontent.com/assets/6135313/15460070/7fa248c2-20de-11e6-984e-a99c33524bbf.png">
