### PR TITLE
Chrome dark theme compatibility

### DIFF
--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -89,6 +89,7 @@ var styles = {
     flex: 1,
     display: 'flex',
     minWidth: 0,
+    backgroundColor: '#fff',
   },
 };
 


### PR DESCRIPTION
## What's up?

This PR is in reference to #108. It will make react-devtools usable with Chrome's dark theme by adding a white background color to `frontend/Container.js`.

#### Before: 

![react-devtools-before](https://cloud.githubusercontent.com/assets/1007571/15797570/0c9db120-29d2-11e6-88ef-03c1bd3df445.png)

#### After:

![react-devtools-after](https://cloud.githubusercontent.com/assets/1007571/15797572/16369760-29d2-11e6-902f-d275f5062eb6.png)

