### PR TITLE
Fix number type input for React Native style editor

### DIFF
--- a/plugins/ReactNativeStyle/StyleEdit.js
+++ b/plugins/ReactNativeStyle/StyleEdit.js
@@ -55,7 +55,10 @@ class StyleEdit extends React.Component {
             :
             <BlurInput
               value={this.props.style[name]}
-              onChange={val => this.props.onChange(name, val)}
+              onChange={val => {
+                var num = Number(val);
+                this.props.onChange(name, num == val ? num : val);
+              }}
             />
           </li>
         ))}


### PR DESCRIPTION
Currently it have `RCTConvert` error on React Native:

<img width="487" alt="2016-06-27 7 42 22" src="https://cloud.githubusercontent.com/assets/3001525/16378591/4de9e4d4-3c9f-11e6-9b52-3aac63c4a899.png">
