### PR TITLE
Add option to highlight all searched components

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -179,6 +179,7 @@ class Agent extends EventEmitter {
     });
     bridge.on('scrollToNode', id => this.scrollToNode(id));
     bridge.on('bananaslugchange', value => this.emit('bananaslugchange', value));
+    bridge.on('colorizerchange', value => this.emit('colorizerchange', value));
 
     /** Events sent to the frontend **/
     this.on('root', id => bridge.send('root', id));

--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -380,19 +380,15 @@ class Agent extends EventEmitter {
   }
 
   _onScroll() {
-    this._requestScrollUpdate();
+    if (!this._scrollUpdate) {
+      this._scrollUpdate = true;
+      window.requestAnimationFrame(this._updateScroll.bind(this));
+    }
   }
 
   _updateScroll() {
-    this._scrollUpdate = false;
     this.emit('refreshMultiOverlay');
-  }
-
-  _requestScrollUpdate() {
-    if (!this._scrollUpdate) {
-      window.requestAnimationFrame(this._updateScroll.bind(this));
-    }
-    this._scrollUpdate = true;
+    this._scrollUpdate = false;
   }
 }
 

--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -92,6 +92,7 @@ class Agent extends EventEmitter {
   renderers: Map<ElementID, RendererID>;
   _prevSelected: ?NativeType;
   _scrollUpdate: boolean;
+  _updateScroll: () => void;
 
   constructor(global: Object, capabilities?: Object) {
     super();
@@ -117,6 +118,7 @@ class Agent extends EventEmitter {
       editTextContent: false,
     }, capabilities);
 
+    this._updateScroll = this._updateScroll.bind(this);
     window.addEventListener('scroll', this._onScroll.bind(this), true);
   }
 
@@ -382,7 +384,7 @@ class Agent extends EventEmitter {
   _onScroll() {
     if (!this._scrollUpdate) {
       this._scrollUpdate = true;
-      window.requestAnimationFrame(this._updateScroll.bind(this));
+      window.requestAnimationFrame(this._updateScroll);
     }
   }
 

--- a/frontend/Highlighter/Highlighter.js
+++ b/frontend/Highlighter/Highlighter.js
@@ -79,6 +79,13 @@ class Highlighter {
     this.removeMultiOverlay();
   }
 
+  refreshMultiOverlay() {
+    if (!this._multiOverlay) {
+      return;
+    }
+    this._multiOverlay.refresh();
+  }
+
   removeOverlay() {
     if (!this._overlay) {
       return;

--- a/frontend/Highlighter/MultiOverlay.js
+++ b/frontend/Highlighter/MultiOverlay.js
@@ -37,7 +37,7 @@ class MultiOverlay {
         border: '2px dotted rgba(200, 100, 100, .8)',
         boxSizing: 'border-box',
         backgroundColor: 'rgba(200, 100, 100, .2)',
-        position: 'fixed',
+        position: 'absolute',
         zIndex: 10000000,
         pointerEvents: 'none',
       });

--- a/frontend/Highlighter/MultiOverlay.js
+++ b/frontend/Highlighter/MultiOverlay.js
@@ -29,12 +29,22 @@ class MultiOverlay {
   highlightMany(nodes: Array<DOMNode>) {
     this._currentNodes = nodes;
     this.container.innerHTML = '';
+    var documentTop = window.pageYOffset || document.documentElement.scrollTop;
+    var scrollAmt =
+      document.documentElement.scrollTop || document.body.scrollTop;
+
     nodes.forEach(node => {
       var div = this.win.document.createElement('div');
       if (typeof node.getBoundingClientRect !== 'function') {
         return;
       }
       var box = node.getBoundingClientRect();
+      if (
+        box.bottom + scrollAmt < documentTop ||
+        box.top + scrollAmt > documentTop + window.innerHeight
+      ) {
+        return;
+      }
       assign(div.style, {
         top: box.top + 'px',
         left: box.left + 'px',
@@ -43,7 +53,7 @@ class MultiOverlay {
         border: '2px dotted rgba(200, 100, 100, .8)',
         boxSizing: 'border-box',
         backgroundColor: 'rgba(200, 100, 100, .2)',
-        position: 'absolute',
+        position: 'fixed',
         zIndex: 10000000,
         pointerEvents: 'none',
       });

--- a/frontend/Highlighter/MultiOverlay.js
+++ b/frontend/Highlighter/MultiOverlay.js
@@ -16,18 +16,24 @@ import type {DOMNode} from '../types';
 class MultiOverlay {
   win: Object;
   container: DOMNode;
+  _currentNodes: ?Array<DOMNode>;
 
   constructor(window: Object) {
     this.win = window;
     var doc = window.document;
     this.container = doc.createElement('div');
     doc.body.appendChild(this.container);
+    this._currentNodes = null;
   }
 
   highlightMany(nodes: Array<DOMNode>) {
+    this._currentNodes = nodes;
     this.container.innerHTML = '';
     nodes.forEach(node => {
       var div = this.win.document.createElement('div');
+      if (typeof node.getBoundingClientRect !== 'function') {
+        return;
+      }
       var box = node.getBoundingClientRect();
       assign(div.style, {
         top: box.top + 'px',
@@ -45,9 +51,16 @@ class MultiOverlay {
     });
   }
 
+  refresh() {
+    if (this._currentNodes) {
+      this.highlightMany(this._currentNodes);
+    }
+  }
+
   remove() {
     if (this.container.parentNode) {
       this.container.parentNode.removeChild(this.container);
+      this._currentNodes = null;
     }
   }
 }

--- a/frontend/Highlighter/MultiOverlay.js
+++ b/frontend/Highlighter/MultiOverlay.js
@@ -29,9 +29,6 @@ class MultiOverlay {
   highlightMany(nodes: Array<DOMNode>) {
     this._currentNodes = nodes;
     this.container.innerHTML = '';
-    var documentTop = window.pageYOffset || document.documentElement.scrollTop;
-    var scrollAmt =
-      document.documentElement.scrollTop || document.body.scrollTop;
 
     nodes.forEach(node => {
       var div = this.win.document.createElement('div');
@@ -39,10 +36,7 @@ class MultiOverlay {
         return;
       }
       var box = node.getBoundingClientRect();
-      if (
-        box.bottom + scrollAmt < documentTop ||
-        box.top + scrollAmt > documentTop + window.innerHeight
-      ) {
+      if (box.bottom < 0 || box.top > window.innerHeight) {
         return;
       }
       assign(div.style, {

--- a/frontend/Highlighter/setup.js
+++ b/frontend/Highlighter/setup.js
@@ -21,6 +21,7 @@ module.exports = function setup(agent: Agent) {
   agent.on('highlight', data => hl.highlight(data.node, data.name));
   agent.on('highlightMany', nodes => hl.highlightMany(nodes));
   agent.on('hideHighlight', () => hl.hideHighlight());
+  agent.on('refreshMultiOverlay', () => hl.refreshMultiOverlay());
   agent.on('startInspecting', () => hl.startInspecting());
   agent.on('stopInspecting', () => hl.stopInspecting());
   agent.on('shutdown', () => {

--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -101,7 +101,7 @@ class SearchPane extends React.Component {
             onFocus={() => this.setState({focused: true})}
             onBlur={() => this.setState({focused: false})}
             onKeyDown={e => this.onKeyDown(e.key)}
-            placeholder="Search by Component Name"
+            placeholder={this.props.placeholderText}
             onChange={e => this.props.onChangeSearch(e.target.value)}
           />
           {!!this.props.searchText && <div onClick={this.cancel.bind(this)} style={styles.cancelButton}>
@@ -116,18 +116,20 @@ class SearchPane extends React.Component {
 SearchPane.propTypes = {
   reload: PropTypes.func,
   searchText: PropTypes.string,
-  onChangeSearch: PropTypes.func,
   selectFirstSearchResult: PropTypes.func,
+  onChangeSearch: PropTypes.func,
+  placeholderText: PropTypes.string,
 };
 
 var Wrapped = decorate({
   listeners(props) {
-    return ['searchText'];
+    return ['searchText', 'placeholderchange'];
   },
   props(store) {
     return {
-      searchText: store.searchText,
       onChangeSearch: text => store.changeSearch(text),
+      placeholderText: store.placeholderText,
+      searchText: store.searchText,
       selectFirstSearchResult: store.selectFirstSearchResult.bind(store),
     };
   },

--- a/frontend/SettingsCheckbox.js
+++ b/frontend/SettingsCheckbox.js
@@ -87,7 +87,7 @@ var styles = {
     fontSize: '12px',
     outline: 'none',
     userSelect: 'none',
-    margin: '0px 4px 0px 4px',
+    margin: '0px 4px',
   },
 };
 

--- a/frontend/SettingsCheckbox.js
+++ b/frontend/SettingsCheckbox.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+const immutable = require('immutable');
+
+import type {ControlState} from './types.js';
+
+type Props = {
+  state: any,
+  text: string,
+  onChange: (v: ControlState) => void,
+};
+
+type State = StateRecord;
+
+type DefaultProps = {};
+
+const StateRecord = immutable.Record({
+  enabled: false,
+});
+
+class SettingsCheckbox extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+
+  _defaultState: ControlState;
+  _toggle: (b: boolean) => void;
+
+  constructor(props: Props) {
+    super(props);
+    this._toggle = this._toggle.bind(this);
+    this._defaultState = new StateRecord();
+  }
+
+  componentDidMount(): void {
+    if (!this.props.state !== this._defaultState) {
+      this.props.onChange(this._defaultState);
+    }
+  }
+
+  render() {
+    var state = this.props.state || this._defaultState;
+    return (
+      <div style={styles.container} onClick={this._toggle} tabIndex={0}>
+        <input
+          style={styles.checkbox}
+          type="checkbox"
+          checked={state.enabled}
+          readOnly={true}
+        />
+        <span>{this.props.text}</span>
+      </div>
+    );
+  }
+
+  _toggle() {
+    var state = this.props.state || this._defaultState;
+    var nextState = state.merge({
+      enabled: !state.enabled,
+    });
+
+    this.props.onChange(nextState);
+  }
+}
+
+var styles = {
+  checkbox: {
+    pointerEvents: 'none',
+  },
+  container: {
+    WebkitUserSelect: 'none',
+    cursor: 'pointer',
+    display: 'inline-block',
+    fontFamily: 'arial',
+    fontSize: '12px',
+    outline: 'none',
+    userSelect: 'none',
+    margin: '0px 4px 0px 4px',
+  },
+};
+
+module.exports = SettingsCheckbox;

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -10,15 +10,15 @@
 'use strict';
 
 var BananaSlugFrontendControl = require('../plugins/BananaSlug/BananaSlugFrontendControl');
+var ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
 var React = require('react');
-
-var decorate = require('./decorate');
 
 class SettingsPane extends React.Component {
   render() {
     return (
       <div style={styles.container}>
         <BananaSlugFrontendControl {...this.props} />
+        <ColorizerFrontendControl {...this.props} />
       </div>
     );
   }
@@ -34,16 +34,4 @@ var styles = {
   },
 };
 
-var Wrapped = decorate({
-  listeners() {
-    return ['bananaslugchange'];
-  },
-  props(store) {
-    return {
-      state: store.bananaslugState,
-      onChange: state => store.changeBananaSlug(state),
-    };
-  },
-}, SettingsPane);
-
-module.exports = Wrapped;
+module.exports = SettingsPane;

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -11,6 +11,7 @@
 
 var BananaSlugFrontendControl = require('../plugins/BananaSlug/BananaSlugFrontendControl');
 var ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
+var RegexFrontendControl = require('../plugins/Regex/RegexFrontendControl');
 var React = require('react');
 
 class SettingsPane extends React.Component {
@@ -19,6 +20,7 @@ class SettingsPane extends React.Component {
       <div style={styles.container}>
         <BananaSlugFrontendControl {...this.props} />
         <ColorizerFrontendControl {...this.props} />
+        <RegexFrontendControl {...this.props} />
       </div>
     );
   }

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -473,7 +473,6 @@ class Store extends EventEmitter {
       : DEFAULT_PLACEHOLDER;
     this.emit('placeholderchange');
     this.emit('colorizerchange');
-    invariant(state.toJS);
     this._bridge.send('colorizerchange', state.toJS());
     this.highlightSearch();
     this.hideHighlight();

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -18,7 +18,7 @@ var consts = require('../agent/consts');
 var invariant = require('./invariant');
 
 import type Bridge from '../agent/Bridge';
-import type {DOMEvent, ElementID} from './types';
+import type {ControlState, DOMEvent, ElementID} from './types';
 
 type ListenerFunction = () => void;
 type DataType = Map;
@@ -28,6 +28,8 @@ type ContextMenu = {
   y: number,
   args: Array<any>,
 };
+
+const DEFAULT_PLACEHOLDER = 'Search by Component Name';
 
 /**
  * This is the main frontend [fluxy?] Store, responsible for taking care of
@@ -85,10 +87,12 @@ class Store extends EventEmitter {
   _eventTimer: ?number;
 
   // Public state
-  bananaslugState: ?Object;
+  bananaslugState: ?ControlState;
+  colorizerState: ?ControlState;
   contextMenu: ?ContextMenu;
   hovered: ?ElementID;
   isBottomTagSelected: boolean;
+  placeholderText: string;
   roots: List;
   searchRoots: ?List;
   searchText: string;
@@ -119,6 +123,8 @@ class Store extends EventEmitter {
     this.searchText = '';
     this.capabilities = {};
     this.bananaslugState = null;
+    this.colorizerState = null;
+    this.placeholderText = DEFAULT_PLACEHOLDER;
 
     // for debugging
     window.store = this;
@@ -419,10 +425,23 @@ class Store extends EventEmitter {
     });
   }
 
-  changeBananaSlug(state: Object) {
+  changeBananaSlug(state: ControlState) {
     this.bananaslugState = state;
     this.emit('bananaslugchange');
+    invariant(state.toJS);
     this._bridge.send('bananaslugchange', state.toJS());
+  }
+
+  changeColorizer(state: ControlState) {
+    this.colorizerState = state;
+    this.placeholderText = this.colorizerState.enabled
+      ? 'Highlight by Component Name'
+      : DEFAULT_PLACEHOLDER;
+    this.emit('placeholderchange');
+
+    this.emit('colorizerchange');
+    invariant(state.toJS);
+    this._bridge.send('colorizerchange', state.toJS());
   }
 
   // Private stuff

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -218,8 +218,7 @@ class Store extends EventEmitter {
       if (
         this.searchRoots &&
         needle.indexOf(this.searchText.toLowerCase()) === 0 &&
-        this.regexState &&
-        !this.regexState.enabled
+        (!this.regexState || !this.regexState.enabled)
       ) {
         this.searchRoots = this.searchRoots
           .filter(item => {
@@ -258,6 +257,7 @@ class Store extends EventEmitter {
   }
 
   highlight(id: string): void {
+    // Individual highlighting is disabled while colorizer is active
     if (!this.colorizerState || !this.colorizerState.enabled) {
       this._bridge.send('highlight', id);
     }
@@ -474,8 +474,11 @@ class Store extends EventEmitter {
     this.emit('placeholderchange');
     this.emit('colorizerchange');
     this._bridge.send('colorizerchange', state.toJS());
-    this.highlightSearch();
-    this.hideHighlight();
+    if (this.colorizerState && this.colorizerState.enabled) {
+      this.highlightSearch();
+    } else {
+      this.hideHighlight();
+    }
   }
 
   changeRegex(state: ControlState) {

--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -18,20 +18,29 @@ function nodeMatchesText(node: Map, needle: string, key: string, store: Store): 
   if (node.get('nodeType') === 'Native' && store.get(store.getParent(key)).get('nodeType') === 'NativeWrapper') {
     return false;
   }
+  var useRegex = !!store.regexState && store.regexState.enabled;
   if (name) {
-    if (node.get('nodeType') !== 'Wrapper' && name.toLowerCase().indexOf(needle) !== -1) {
-      return true;
+    if (node.get('nodeType') !== 'Wrapper') {
+      return validString(name, needle, useRegex);
     }
   }
   var text = node.get('text');
-  if (text && text.toLowerCase().indexOf(needle) !== -1) {
-    return true;
+  if (text) {
+    return validString(text, needle, useRegex);
   }
   var children = node.get('children');
-  if (typeof children === 'string' && children.toLowerCase().indexOf(needle) !== -1) {
-    return true;
+  if (typeof children === 'string') {
+    return validString(children, needle, useRegex);
   }
   return false;
+}
+
+function validString(str: string, needle: string, regex: boolean): boolean {
+  if (regex) {
+    var re = new RegExp(needle);
+    return re.test(str.toLowerCase());
+  }
+  return str.toLowerCase().indexOf(needle) !== -1;
 }
 
 module.exports = nodeMatchesText;

--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -37,7 +37,7 @@ function nodeMatchesText(node: Map, needle: string, key: string, store: Store): 
 
 function validString(str: string, needle: string, regex: boolean): boolean {
   if (regex) {
-    var re = new RegExp(needle);
+    var re = new RegExp(needle, 'i');
     return re.test(str.toLowerCase());
   }
   return str.toLowerCase().indexOf(needle) !== -1;

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+var {Record} = require('immutable');
+
 export type Dir = 'up' | 'down' | 'left' | 'right';
 export type Dest = 'firstChild' | 'lastChild' | 'prevSibling' | 'nextSibling' | 'collapse' | 'uncollapse' | 'parent' | 'parentBottom';
 
@@ -17,6 +19,7 @@ export type ElementID = string;
 
 export type DOMNode = {
   appendChild: (child: DOMNode) => void,
+  childNodes: Array<DOMNode>,
   getBoundingClientRect: () => {
     top: number,
     left: number,
@@ -60,4 +63,4 @@ export type DOMEvent = {
 
 export type ControlState = {
   enabled: boolean,
-};
+} & Record;

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -57,3 +57,7 @@ export type DOMEvent = {
   stopPropagation: () => void,
   target: DOMNode,
 };
+
+export type ControlState = {
+  enabled: boolean,
+};

--- a/plugins/BananaSlug/BananaSlugBackendManager.js
+++ b/plugins/BananaSlug/BananaSlugBackendManager.js
@@ -23,6 +23,8 @@ import type {
   Presenter,
 } from './BananaSlugTypes';
 
+import type {ControlState} from '../../frontend/types.js';
+
 const NODE_TYPE_COMPOSITE = 'Composite';
 
 class BananaSlugBackendManager {
@@ -71,7 +73,7 @@ class BananaSlugBackendManager {
     this._presenter.present(measurement);
   }
 
-  _onBananaSlugChange(state: Object): void {
+  _onBananaSlugChange(state: ControlState): void {
     this._presenter.setEnabled(state.enabled);
   }
 

--- a/plugins/BananaSlug/BananaSlugFrontendControl.js
+++ b/plugins/BananaSlug/BananaSlugFrontendControl.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-const React = require('react');
-
 var decorate = require('../../frontend/decorate');
 var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
 

--- a/plugins/BananaSlug/BananaSlugFrontendControl.js
+++ b/plugins/BananaSlug/BananaSlugFrontendControl.js
@@ -12,85 +12,9 @@
 'use strict';
 
 const React = require('react');
-const immutable = require('immutable');
 
 var decorate = require('../../frontend/decorate');
-
-import type {ControlState} from '../../frontend/types.js';
-
-type Props = {
-  state: any,
-  onChange: (v: ControlState) => void,
-};
-
-type State = StateRecord;
-
-type DefaultProps = {};
-
-const StateRecord = immutable.Record({
-  enabled: false,
-});
-
-class BananaSlugFrontendControl extends React.Component {
-  props: Props;
-  defaultProps: DefaultProps;
-  state: State;
-
-  _defaultState: ControlState;
-  _toggle: (b: boolean) => void;
-
-  constructor(props: Props) {
-    super(props);
-    this._toggle = this._toggle.bind(this);
-    this._defaultState = new StateRecord();
-  }
-
-  componentDidMount(): void {
-    if (!this.props.state !== this._defaultState) {
-      this.props.onChange(this._defaultState);
-    }
-  }
-
-  render() {
-    var state = this.props.state || this._defaultState;
-    return (
-      <div style={styles.container} onClick={this._toggle} tabIndex={0}>
-        <input
-          style={styles.checkbox}
-          type="checkbox"
-          checked={state.enabled}
-          readOnly={true}
-        />
-        <span>Trace React updates</span>
-      </div>
-    );
-  }
-
-  _toggle() {
-    var state = this.props.state || this._defaultState;
-    var nextState = state.merge({
-      enabled: !state.enabled,
-    });
-
-    this.props.onChange(nextState);
-  }
-}
-
-var styles = {
-  checkbox: {
-    pointerEvents: 'none',
-  },
-  container: {
-    WebkitUserSelect: 'none',
-    cursor: 'pointer',
-    display: 'inline-block',
-    fontFamily: 'arial',
-    fontSize: '12px',
-    outline: 'none',
-    userSelect: 'none',
-    margin: '0px 4px',
-  },
-};
+var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
 
 var Wrapped = decorate({
   listeners() {
@@ -99,9 +23,10 @@ var Wrapped = decorate({
   props(store) {
     return {
       state: store.bananaslugState,
+      text: 'Trace React Updates',
       onChange: state => store.changeBananaSlug(state),
     };
   },
-}, BananaSlugFrontendControl);
+}, SettingsCheckbox);
 
 module.exports = Wrapped;

--- a/plugins/BananaSlug/BananaSlugTypes.js
+++ b/plugins/BananaSlug/BananaSlugTypes.js
@@ -37,7 +37,3 @@ export type Presenter = {
   present: (m: Measurement) => void,
   setEnabled: (b: boolean) => void,
 };
-
-export type ControlState = {
-  enabled: boolean,
-};

--- a/plugins/Colorizer/ColorizerFrontendControl.js
+++ b/plugins/Colorizer/ColorizerFrontendControl.js
@@ -11,8 +11,6 @@
 
 'use strict';
 
-const React = require('react');
-
 var decorate = require('../../frontend/decorate');
 var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
 

--- a/plugins/Colorizer/ColorizerFrontendControl.js
+++ b/plugins/Colorizer/ColorizerFrontendControl.js
@@ -12,85 +12,9 @@
 'use strict';
 
 const React = require('react');
-const immutable = require('immutable');
 
 var decorate = require('../../frontend/decorate');
-
-import type {ControlState} from '../../frontend/types.js';
-
-type Props = {
-  state: any,
-  onChange: (v: ControlState) => void,
-};
-
-type State = StateRecord;
-
-type DefaultProps = {};
-
-const StateRecord = immutable.Record({
-  enabled: false,
-});
-
-class ColorizerFrontendControl extends React.Component {
-  props: Props;
-  defaultProps: DefaultProps;
-  state: State;
-
-  _defaultState: ControlState;
-  _toggle: (b: boolean) => void;
-
-  constructor(props: Props) {
-    super(props);
-    this._toggle = this._toggle.bind(this);
-    this._defaultState = new StateRecord();
-  }
-
-  componentDidMount(): void {
-    if (!this.props.state !== this._defaultState) {
-      this.props.onChange(this._defaultState);
-    }
-  }
-
-  render() {
-    var state = this.props.state || this._defaultState;
-    return (
-      <div style={styles.container} onClick={this._toggle} tabIndex={0}>
-        <input
-          style={styles.checkbox}
-          type="checkbox"
-          checked={state.enabled}
-          readOnly={true}
-        />
-        <span>Highlight Search</span>
-      </div>
-    );
-  }
-
-  _toggle() {
-    var state = this.props.state || this._defaultState;
-    var nextState = state.merge({
-      enabled: !state.enabled,
-    });
-
-    this.props.onChange(nextState);
-  }
-}
-
-var styles = {
-  checkbox: {
-    pointerEvents: 'none',
-  },
-  container: {
-    WebkitUserSelect: 'none',
-    cursor: 'pointer',
-    display: 'inline-block',
-    fontFamily: 'arial',
-    fontSize: '12px',
-    outline: 'none',
-    userSelect: 'none',
-    margin: '0px 4px 0px 4px',
-  },
-};
+var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
 
 var Wrapped = decorate({
   listeners() {
@@ -99,9 +23,10 @@ var Wrapped = decorate({
   props(store) {
     return {
       state: store.colorizerState,
+      text: 'Highlight Search',
       onChange: state => store.changeColorizer(state),
     };
   },
-}, ColorizerFrontendControl);
+}, SettingsCheckbox);
 
 module.exports = Wrapped;

--- a/plugins/Colorizer/ColorizerFrontendControl.js
+++ b/plugins/Colorizer/ColorizerFrontendControl.js
@@ -31,7 +31,7 @@ const StateRecord = immutable.Record({
   enabled: false,
 });
 
-class BananaSlugFrontendControl extends React.Component {
+class ColorizerFrontendControl extends React.Component {
   props: Props;
   defaultProps: DefaultProps;
   state: State;
@@ -61,7 +61,7 @@ class BananaSlugFrontendControl extends React.Component {
           checked={state.enabled}
           readOnly={true}
         />
-        <span>Trace React updates</span>
+        <span>Highlight Search</span>
       </div>
     );
   }
@@ -88,20 +88,20 @@ var styles = {
     fontSize: '12px',
     outline: 'none',
     userSelect: 'none',
-    margin: '0px 4px',
+    margin: '0px 4px 0px 4px',
   },
 };
 
 var Wrapped = decorate({
   listeners() {
-    return ['bananaslugchange'];
+    return ['colorizerchange'];
   },
   props(store) {
     return {
-      state: store.bananaslugState,
-      onChange: state => store.changeBananaSlug(state),
+      state: store.colorizerState,
+      onChange: state => store.changeColorizer(state),
     };
   },
-}, BananaSlugFrontendControl);
+}, ColorizerFrontendControl);
 
 module.exports = Wrapped;

--- a/plugins/Regex/RegexFrontendControl.js
+++ b/plugins/Regex/RegexFrontendControl.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+var decorate = require('../../frontend/decorate');
+var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
+
+var Wrapped = decorate({
+  listeners() {
+    return ['regexchange'];
+  },
+  props(store) {
+    return {
+      state: store.regexState,
+      text: 'Use Regular Expressions',
+      onChange: state => store.changeRegex(state),
+    };
+  },
+}, SettingsCheckbox);
+
+module.exports = Wrapped;


### PR DESCRIPTION
I added a simple checkbox in the settings pane for the colorizer. When this option is enabled, all of the components that fit the search are highlighted using the `MultiOverlay`. Also, I modified the `SearchPane`, so that the placeholder text changes as well to indicate the different options.

I had to separate some of the event handling within the search panel. I double checked the _Trace React Updates_ option still works the same as before.

Selecting the _Highlight Search_ option disables all individual component highlighting. Now hovering over any search option will not do anything while it is enabled.

Without Selection: 
![screen shot 2016-07-22 at 1 20 11 pm](https://cloud.githubusercontent.com/assets/6119851/17070212/865cf008-500f-11e6-84e2-978517f00775.png)


With Selection (changed placeholder):
![screen shot 2016-07-22 at 1 20 18 pm](https://cloud.githubusercontent.com/assets/6119851/17070224/91bb3b76-500f-11e6-9957-fba0476f3f6b.png)


Highlighting:
![screen shot 2016-07-22 at 1 20 47 pm](https://cloud.githubusercontent.com/assets/6119851/17070229/96950cbc-500f-11e6-97e6-2509c2a0630f.png)

