### PR TITLE
Fix NativeWrapper check in nodeMatchesText

### DIFF
--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -15,7 +15,8 @@ import type Store from './Store';
 
 function nodeMatchesText(node: Map, needle: string, key: string, store: Store): boolean {
   var name = node.get('name');
-  if (node.get('nodeType') === 'Native' && store.get(store.getParent(key)).get('nodeType') === 'NativeWrapper') {
+  var wrapper = store.get(store.getParent(key));
+  if (node.get('nodeType') === 'Native' && wrapper && wrapper.get('nodeType') === 'NativeWrapper') {
     return false;
   }
   if (name) {


### PR DESCRIPTION
The DevTools will get undefined for `store.getParent(key)` when reproduce following steps:

1. Keep search text `Use redux` on DevTools
2. Add new todo `Use redux` on app
3. It will broken when I changed search text on DevTools

![2016-07-12 8 15 56](https://cloud.githubusercontent.com/assets/3001525/16751041/ef5dd522-4808-11e6-9f79-4a770f62fb80.png)