### PR TITLE
Avoid unnecessary measurements

### DIFF
--- a/plugins/BananaSlug/BananaSlugBackendManager.js
+++ b/plugins/BananaSlug/BananaSlugBackendManager.js
@@ -54,6 +54,7 @@ class BananaSlugBackendManager {
 
   _onUpdate(agent: Agent, obj: any) {
     if (
+      !this._isActive ||
       !obj.publicInstance ||
       !obj.id ||
       obj.nodeType !== NODE_TYPE_COMPOSITE
@@ -74,10 +75,12 @@ class BananaSlugBackendManager {
   }
 
   _onBananaSlugChange(state: ControlState): void {
+    this._isActive = state.enabled;
     this._presenter.setEnabled(state.enabled);
   }
 
   _shutdown(): void {
+    this._isActive = false;
     this._presenter.setEnabled(false);
   }
 }


### PR DESCRIPTION
If "Trace React Updates" is disabled, don't spend time measuring nodes.
This gives significant perf improvements in DEV on pages with many nodes.

Before:

<img width="448" alt="screen shot 2016-08-18 at 21 19 21" src="https://cloud.githubusercontent.com/assets/810438/17789775/9cb5ab4c-658b-11e6-87e3-ff2db48278c3.png">

After:

<img width="438" alt="screen shot 2016-08-18 at 21 29 22" src="https://cloud.githubusercontent.com/assets/810438/17789786/a1c1ce0e-658b-11e6-81a4-5344ea617dae.png">

When I toggle "Trace React Updates" the updates show up so it seems like feature still works.