### PR TITLE
Compile React for production

### DIFF
--- a/shells/chrome/webpack.config.js
+++ b/shells/chrome/webpack.config.js
@@ -9,6 +9,7 @@
  */
 'use strict';
 
+var webpack = require('webpack');
 var __DEV__ = process.env.NODE_ENV !== 'production';
 
 module.exports = {
@@ -24,7 +25,17 @@ module.exports = {
     path: __dirname + '/build',
     filename: '[name].js',
   },
-
+  plugins: __DEV__ ? [] : [
+    // Ensure we get production React
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': '"production"',
+    }),
+    // Remove dead code but keep it readable:
+    new webpack.optimize.UglifyJsPlugin({
+      mangle: false,
+      beautify: true,
+    }),
+  ],
   module: {
     loaders: [{
       test: /\.js$/,

--- a/shells/electron/webpack.config.js
+++ b/shells/electron/webpack.config.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+var webpack = require('webpack');
+
 module.exports = {
   debug: true,
   devtool: 'source-map',
@@ -21,6 +23,17 @@ module.exports = {
     library: '[name]',
     libraryTarget: 'commonjs2',
   },
+  plugins: __DEV__ ? [] : [
+    // Ensure we get production React
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': '"production"',
+    }),
+    // Remove dead code but keep it readable:
+    new webpack.optimize.UglifyJsPlugin({
+      mangle: false,
+      beautify: true,
+    }),
+  ],
   externals: ['ws'],
   module: {
     loaders: [{

--- a/shells/firefox/webpack.config.js
+++ b/shells/firefox/webpack.config.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+var webpack = require('webpack');
+
 module.exports = {
   // devtool: 'cheap-module-eval-source-map',
   entry: {
@@ -21,7 +23,17 @@ module.exports = {
     path: __dirname + '/data/build',
     filename: '[name].js',
   },
-
+  plugins: __DEV__ ? [] : [
+    // Ensure we get production React
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': '"production"',
+    }),
+    // Remove dead code but keep it readable:
+    new webpack.optimize.UglifyJsPlugin({
+      mangle: false,
+      beautify: true,
+    }),
+  ],
   module: {
     loaders: [{
       test: /\.js$/,


### PR DESCRIPTION
Seems like we weren't doing it before. Also need to update internal release instructions because they currently don’t include `webpack` step for FF.