### PR TITLE
Fix scroll to text node

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -206,10 +206,18 @@ class Agent extends EventEmitter {
       console.warn('unable to get the node for scrolling');
       return;
     }
-    if (node.scrollIntoViewIfNeeded) {
-      node.scrollIntoViewIfNeeded();
+    var element = node.nodeType === Node.ELEMENT_NODE ?
+      node :
+      node.parentElement;
+    if (!element) {
+      console.warn('unable to get the element for scrolling');
+      return;
+    }
+
+    if (element.scrollIntoViewIfNeeded) {
+      element.scrollIntoViewIfNeeded();
     } else {
-      node.scrollIntoView();
+      element.scrollIntoView();
     }
     this.highlight(id);
   }

--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -214,9 +214,9 @@ class Agent extends EventEmitter {
       return;
     }
 
-    if (element.scrollIntoViewIfNeeded) {
+    if (typeof element.scrollIntoViewIfNeeded === 'function') {
       element.scrollIntoViewIfNeeded();
-    } else {
+    } else if (typeof element.scrollIntoView === 'function') {
       element.scrollIntoView();
     }
     this.highlight(id);


### PR DESCRIPTION
This fixes “Scroll to Node” for text nodes.
Test plan: `<div>{'a'}{'b'}</div>`, right-click either and click "Scroll to Node".
Before it used to raise an error, as noted in https://github.com/facebook/react-devtools/pull/361#issuecomment-212703004.