### PR TITLE
Fix "Invalid weak map key" error #198

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -325,7 +325,7 @@ class Agent extends EventEmitter {
   }
 
   getId(element: OpaqueNodeHandle): ElementID {
-    if (typeof element !== 'object') {
+    if (typeof element !== 'object' || !element) {
       return element;
     }
     if (!this.ids.has(element)) {


### PR DESCRIPTION
This is a longstanding bug that I finally tracked down.

When a child is `null`, its `typeof` === `"object"` :facepalm:
And `null` is an invalid WeakMap key.

See repro from [this comment](https://github.com/facebook/react-devtools/issues/198#issuecomment-237571581)