### PR TITLE
UI improvements, behaviour closer to native dev tools

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -18,23 +18,40 @@ var assign = require('object-assign');
 var decorate = require('./decorate');
 
 class Breadcrumb extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = { hovered: null };
+  }
+  handleCrumbMouseOver(id) {
+    this.setState({ hovered: id });
+    this.props.hover(id, true);
+  }
+
+  handleCrumbMouseOut(id) {
+    this.setState({ hovered: null });
+    this.props.hover(id, false);
+  }
+
   render() {
     return (
       <ul style={styles.container}>
-        {this.props.path.map(({id, node}) => {
+        {this.props.path.map(({ id, node }) => {
           var isSelected = id === this.props.selected;
+          var isHovered = id === this.state.hovered;
           var style = assign(
             {},
             styles.item,
             node.get('nodeType') === 'Composite' && styles.composite,
-            isSelected && styles.selected
+            isHovered && styles.hovered,
+            isSelected && styles.selected,
           );
           return (
             <li
               style={style}
               key={id}
-              onMouseOver={() => this.props.hover(id, true)}
-              onMouseOut={() => this.props.hover(id, false)}
+              onMouseOver={() => this.handleCrumbMouseOver(id)}
+              onMouseOut={() => this.handleCrumbMouseOut(id)}
               onClick={isSelected ? null : () => this.props.select(id)}
             >
               {node.get('name') || '"' + node.get('text') + '"'}
@@ -50,6 +67,7 @@ var styles = {
   container: {
     borderTop: '1px solid #ccc',
     backgroundColor: 'white',
+    fontFamily: 'sans-serif',
     listStyle: 'none',
     padding: 0,
     margin: 0,
@@ -61,13 +79,20 @@ var styles = {
     color: 'white',
   },
 
+  hovered: {
+    backgroundColor: '#d8d8d8',
+  },
+
   composite: {
     color: 'rgb(136, 18, 128)',
   },
 
   item: {
     padding: '3px 7px',
-    cursor: 'pointer',
+    WebkitUserSelect: 'none',
+    MozUserSelect: 'none',
+    userSelect: 'none',
+    cursor: 'default',
     display: 'inline-block',
   },
 };

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -18,6 +18,7 @@ var assign = require('object-assign');
 var decorate = require('./decorate');
 
 class Breadcrumb extends React.Component {
+  state: {hovered: ?string};
 
   constructor(props) {
     super(props);

--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -69,7 +69,7 @@ var DEFAULT_MENU_ITEMS = {
     }
     if (store.capabilities.scroll) {
       items.push({
-        title: 'Scroll to Node',
+        title: 'Scroll to node',
         action: () => store.scrollToNode(id),
       });
     }

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -136,17 +136,23 @@ var styles = {
   container: {
     position: 'fixed',
     backgroundColor: 'white',
-    boxShadow: '0 3px 5px #ccc',
+    boxShadow: '0 1px 6px rgba(0,0,0,0.3)',
     listStyle: 'none',
     margin: 0,
-    padding: 0,
-    fontFamily: 'sans-serif',
-    fontSize: 14,
+    padding: '4px 0',
+    fontSize: 13,
+    borderRadius: '3px',
+    overflow: 'hidden',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Ubuntu", "Helvetica Neue", sans-serif',
+    zIndex:1,
   },
 
   item: {
-    padding: '5px 10px',
-    cursor: 'pointer',
+    padding: '3px 10px',
+    cursor: 'default',
+    WebkitUserSelect: 'none',
+    MozUserSelect: 'none',
+    userSelect: 'none',
   },
 
   empty: {

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -254,7 +254,7 @@ var styles = {
   },
 
   opener: {
-    cursor: 'pointer',
+    cursor: 'default',
     marginLeft: -8,
     paddingRight: 3,
     position: 'absolute',
@@ -262,7 +262,7 @@ var styles = {
   },
 
   collapsedArrow: {
-    borderColor: 'transparent transparent transparent #555',
+    borderColor: 'transparent transparent transparent #6e6e6e',
     borderStyle: 'solid',
     borderWidth: '4px 0 4px 7px',
     display: 'inline-block',
@@ -271,7 +271,7 @@ var styles = {
   },
 
   expandedArrow: {
-    borderColor: '#555 transparent transparent transparent',
+    borderColor: '#6e6e6e transparent transparent transparent',
     borderStyle: 'solid',
     borderWidth: '7px 4px 0 4px',
     display: 'inline-block',
@@ -285,12 +285,12 @@ var styles = {
   },
 
   name: {
-    color: '#666',
+    color: '#881391',
     margin: '2px 3px',
   },
 
   complexName: {
-    cursor: 'pointer',
+    cursor: 'default',
   },
 
   preview: {

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -162,18 +162,20 @@ var styles = {
   },
 
   editable: {
-    cursor: 'pointer',
+    cursor: 'text',
   },
 
   input: {
     flex: 1,
-    minWidth: 50,
-    boxSizing: 'border-box',
-    border: 'none',
-    padding: 0,
+    WebkitUserSelect: 'text',
+    userSelect: 'text',
+    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.2)',
+    textOverflow: 'clip !important',
+    padding: '0 2px',
+    margin: '0 -2px -1px -2px',
     outline: 'none',
-    boxShadow: '0 0 3px #ccc',
-    fontFamily: 'monospace',
+    border: '1px solid #ccc',
+    fontFamily: 'Menlo, Consolas, monospace',
     fontSize: 'inherit',
   },
 };

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -45,6 +45,9 @@ class Simple extends React.Component {
   onKeyDown(e: DOMEvent) {
     if (e.key === 'Enter') {
       this.onSubmit(true);
+      this.setState({
+        editing: false,
+      });
     }
     if (e.key === 'Escape') {
       this.setState({

--- a/frontend/HighlightHover.js
+++ b/frontend/HighlightHover.js
@@ -38,7 +38,8 @@ class HighlightHover extends React.Component {
         onMouseOver={() => !this.state.hover && this.setState({hover: true})}
         onMouseOut={() => this.state.hover && this.setState({hover: false})}
         style={assign({}, this.props.style, {
-          backgroundColor: this.state.hover ? '#eee' : 'transparent',
+          backgroundColor: this.state.hover ? 'rgb(56, 121, 217)' : 'transparent',
+          color: this.state.hover ? 'white' : 'rgb(48, 57, 66)',
         })}>
         {this.props.children}
       </div>

--- a/frontend/Highlighter/Overlay.js
+++ b/frontend/Highlighter/Overlay.js
@@ -45,25 +45,28 @@ class Overlay {
 
     this.tip = doc.createElement('div');
     assign(this.tip.style, {
-      border: '1px solid #aaa',
-      backgroundColor: 'rgb(255, 255, 178)',
-      fontFamily: 'sans-serif',
+      backgroundColor: 'rgba(0, 0, 0, 0.85)',
+      fontFamily: 'Menlo, Consolas, monospace',
       color: 'orange',
-      padding: '3px 5px',
+      padding: '6px 8px',
       position: 'fixed',
-      fontSize: '10px',
+      fontSize: '11px',
+      borderRadius: '2px',
     });
 
     this.nameSpan = doc.createElement('span');
     this.tip.appendChild(this.nameSpan);
     assign(this.nameSpan.style, {
-      color:   'rgb(136, 18, 128)',
-      marginRight: '5px',
+      color:   '#ce75c3',
+      paddingRight: '5px',
+      fontWeight: 'bold',
+      borderRight: '1px solid #666',
     });
     this.dimSpan = doc.createElement('span');
     this.tip.appendChild(this.dimSpan);
     assign(this.dimSpan.style, {
-      color: '#888',
+      paddingLeft: '5px',
+      color: '#CCC',
     });
 
     this.container.style.zIndex = 10000000;
@@ -107,7 +110,7 @@ class Overlay {
     });
 
     this.nameSpan.textContent = (name || node.nodeName.toLowerCase());
-    this.dimSpan.textContent = box.width + 'px × ' + box.height + 'px';
+    this.dimSpan.textContent = box.width + ' × ' + box.height;
 
     var tipPos = findTipPos({
       top: box.top - dims.marginTop,

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -336,7 +336,7 @@ var styles = {
   },
 
   headSelect: {
-    backgroundColor: '#ccc',
+    backgroundColor: '#cddef7',
   },
 
   collapser: {
@@ -345,7 +345,7 @@ var styles = {
   },
 
   collapsedArrow: {
-    borderColor: 'transparent transparent transparent #555',
+    borderColor: 'transparent transparent transparent #6e6e6e',
     borderStyle: 'solid',
     borderWidth: '4px 0 4px 7px',
     display: 'inline-block',
@@ -353,11 +353,11 @@ var styles = {
     verticalAlign: 'top',
   },
   collapsedArrowStateful: {
-    borderColor: 'transparent transparent transparent #e55',
+    borderColor: 'transparent transparent transparent #985189',
   },
 
   expandedArrow: {
-    borderColor: '#555 transparent transparent transparent',
+    borderColor: '#6e6e6e transparent transparent transparent',
     borderStyle: 'solid',
     borderWidth: '7px 4px 0 4px',
     display: 'inline-block',
@@ -365,11 +365,11 @@ var styles = {
     verticalAlign: 'top',
   },
   expandedArrowStateful: {
-    borderColor: '#e55 transparent transparent transparent',
+    borderColor: '#985189 transparent transparent transparent',
   },
 
   headHover: {
-    backgroundColor: '#eee',
+    backgroundColor: 'rgba(56, 121, 217, 0.1)',
   },
 };
 

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -332,7 +332,6 @@ var styles = {
 
   tagText: {
     flex: 1,
-    whiteSpace: 'nowrap',
   },
 
   headSelect: {

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -52,6 +52,7 @@ class Props extends React.Component {
 
 var styles = {
   prop: {
+    display: 'inline-block',
     paddingLeft: 5,
   },
 

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -56,7 +56,7 @@ var styles = {
   },
 
   propName: {
-    color: 'rgb(165, 103, 42)',
+    color: '#994500',
   },
 };
 

--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -88,17 +88,13 @@ class SearchPane extends React.Component {
   }
 
   render() {
-    var inputStyle = styles.input;
-    if (this.props.searchText || this.state.focused) {
-      inputStyle = { ...inputStyle, ...styles.highlightedInput };
-    }
     return (
       <div style={styles.container}>
         <SettingsPane />
         <div style={styles.searchBox}>
           <div style={styles.searchInputBox}>
             <input
-              style={inputStyle}
+              style={styles.input}
               ref={i => this.input = i}
               value={this.props.searchText}
               onFocus={() => this.setState({ focused: true })}

--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -16,7 +16,10 @@ var React = require('react');
 var ReactDOM = require('react-dom');
 var SettingsPane = require('./SettingsPane');
 var TreeView = require('./TreeView');
-var {PropTypes} = React;
+var { PropTypes } = React;
+
+var ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
+var RegexFrontendControl = require('../plugins/Regex/RegexFrontendControl');
 
 var decorate = require('./decorate');
 
@@ -37,7 +40,7 @@ class SearchPane extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = {focused: false};
+    this.state = { focused: false };
   }
 
   componentDidMount() {
@@ -87,27 +90,33 @@ class SearchPane extends React.Component {
   render() {
     var inputStyle = styles.input;
     if (this.props.searchText || this.state.focused) {
-      inputStyle = {...inputStyle, ...styles.highlightedInput};
+      inputStyle = { ...inputStyle, ...styles.highlightedInput };
     }
     return (
       <div style={styles.container}>
         <SettingsPane />
-        <TreeView reload={this.props.reload} />
         <div style={styles.searchBox}>
-          <input
-            style={inputStyle}
-            ref={i => this.input = i}
-            value={this.props.searchText}
-            onFocus={() => this.setState({focused: true})}
-            onBlur={() => this.setState({focused: false})}
-            onKeyDown={e => this.onKeyDown(e.key)}
-            placeholder={this.props.placeholderText}
-            onChange={e => this.props.onChangeSearch(e.target.value)}
-          />
-          {!!this.props.searchText && <div onClick={this.cancel.bind(this)} style={styles.cancelButton}>
-            &times;
-          </div>}
+          <div style={styles.searchInputBox}>
+            <input
+              style={inputStyle}
+              ref={i => this.input = i}
+              value={this.props.searchText}
+              onFocus={() => this.setState({ focused: true })}
+              onBlur={() => this.setState({ focused: false })}
+              onKeyDown={e => this.onKeyDown(e.key)}
+              placeholder={this.props.placeholderText}
+              onChange={e => this.props.onChangeSearch(e.target.value)}
+            />
+            {!!this.props.searchText && <div onClick={this.cancel.bind(this)} style={styles.cancelButton}>
+              &times;
+            </div>}
+          </div>
+          <div style={styles.searchControls}>
+            <RegexFrontendControl />
+            <ColorizerFrontendControl />
+          </div>
         </div>
+        <TreeView reload={this.props.reload} />
       </div>
     );
   }
@@ -143,39 +152,50 @@ var styles = {
     minWidth: 0,
   },
 
-  searchBox: {
-    display: 'flex',
-    flexShrink: 0,
+  searchInputBox: {
     position: 'relative',
+    display: 'inline-block',
+  },
+
+  searchBox: {
+    background: '#f3f3f3',
+    borderBottom: '1px solid #dadada',
+    padding: '4px',
+  },
+
+  searchControls: {
+    display: 'inline-block',
   },
 
   cancelButton: {
-    fontSize: '13px',
-    padding: '0 4px',
-    borderRadius: '10px',
-    height: '17px',
+    fontSize: '11px',
+    lineHeight: '11px',
+    borderRadius: '50%',
     position: 'absolute',
-    cursor: 'pointer',
-    right: '7px',
-    top: '8px',
+    cursor: 'default',
+    height: '12px',
+    width: '12px',
+    right: '4px',
+    bottom: 0,
+    top: 0,
+    margin: 'auto',
     color: 'white',
-    backgroundColor: 'rgb(255, 137, 137)',
+    backgroundColor: '#949494',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 
   input: {
-    flex: 1,
-    fontSize: '18px',
-    padding: '5px 10px',
-    border: 'none',
+    fontSize: '12px',
     transition: 'border-top-color .2s ease, background-color .2s ease',
-    borderTop: '1px solid #ccc',
-    borderTopColor: '#ccc',
+    border: '1px solid #a3a3a3',
     outline: 'none',
-  },
-
-  highlightedInput: {
-    borderTopColor: 'aqua',
-    backgroundColor: '#EEFFFE',
+    padding: '1px 3px 0',
+    margin: '0 0 0 1px',
+    borderRadius: '2px',
+    lineHeight: '1.5',
+    width: '200px',
   },
 };
 

--- a/frontend/SettingsCheckbox.js
+++ b/frontend/SettingsCheckbox.js
@@ -13,6 +13,7 @@
 
 const React = require('react');
 const immutable = require('immutable');
+const assign = require('object-assign');
 
 import type {ControlState} from './types.js';
 
@@ -54,13 +55,22 @@ class SettingsCheckbox extends React.Component {
     var state = this.props.state || this._defaultState;
     return (
       <div style={styles.container} onClick={this._toggle} tabIndex={0}>
-        <input
-          style={styles.checkbox}
-          type="checkbox"
-          checked={state.enabled}
-          readOnly={true}
-        />
-        <span>{this.props.text}</span>
+        {
+          this.props.record ? (
+            <div
+              style={ assign(styles.recordButton,
+                state.enabled ? styles.recordingState : styles.defaultState) }>
+            </div>
+          ) : (
+            <input
+              style={styles.checkbox}
+              type="checkbox"
+              checked={state.enabled}
+              readOnly={true}
+            />
+          )
+        }
+        <span style={styles.checkboxText}>{this.props.text}</span>
       </div>
     );
   }
@@ -79,15 +89,36 @@ var styles = {
   checkbox: {
     pointerEvents: 'none',
   },
+  recordButton: {
+    width: '11px',
+    height: '11px',
+    borderRadius: '50%',
+    display: 'inline-block',
+    marginRight: '3px',
+    verticalAlign: 'middle',
+  },
+  defaultState: {
+    backgroundColor: '#5a5a5a',
+    boxShadow: 'none',
+  },
+  recordingState: {
+    backgroundColor: '#00d8ff',
+    boxShadow: '0 0 2px 2px rgba(0, 215, 255, 0.35)',
+  },
   container: {
     WebkitUserSelect: 'none',
-    cursor: 'pointer',
+    cursor: 'default',
     display: 'inline-block',
     fontFamily: 'arial',
     fontSize: '12px',
+    lineHeight: 1.5,
     outline: 'none',
     userSelect: 'none',
     margin: '0px 4px',
+  },
+  checkboxText: {
+    marginLeft: '3px',
+    color: '#5a5a5a',
   },
 };
 

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -10,17 +10,13 @@
 'use strict';
 
 var BananaSlugFrontendControl = require('../plugins/BananaSlug/BananaSlugFrontendControl');
-var ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
-var RegexFrontendControl = require('../plugins/Regex/RegexFrontendControl');
 var React = require('react');
 
-class SettingsPane extends React.Component {
+class ControlsPane extends React.Component {
   render() {
     return (
       <div style={styles.container}>
         <BananaSlugFrontendControl {...this.props} />
-        <ColorizerFrontendControl {...this.props} />
-        <RegexFrontendControl {...this.props} />
       </div>
     );
   }
@@ -28,12 +24,13 @@ class SettingsPane extends React.Component {
 
 var styles = {
   container: {
-    backgroundColor: '#efefef',
-    padding: '2px 4px',
-    display: 'flex',
-    flexShrink: 0,
+    borderBottom: '1px solid #dadada',
+    color: 'rgb(48, 57, 66)',
+    padding: '5px 6px',
+    display: 'flexbox',
+    alignItems: 'center',
     position: 'relative',
   },
 };
 
-module.exports = SettingsPane;
+module.exports = ControlsPane;

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -29,7 +29,7 @@ type ContextMenu = {
   args: Array<any>,
 };
 
-const DEFAULT_PLACEHOLDER = 'Search by Component Name';
+const DEFAULT_PLACEHOLDER = 'Search by component name';
 
 /**
  * This is the main frontend [fluxy?] Store, responsible for taking care of
@@ -477,7 +477,7 @@ class Store extends EventEmitter {
   changeColorizer(state: ControlState) {
     this.colorizerState = state;
     this.placeholderText = this.colorizerState.enabled
-      ? 'Highlight by Component Name'
+      ? 'Highlight by component name'
       : DEFAULT_PLACEHOLDER;
     this.emit('placeholderchange');
     this.emit('colorizerchange');

--- a/frontend/value-styles.js
+++ b/frontend/value-styles.js
@@ -20,28 +20,28 @@ module.exports = {
   },
 
   object: {
-    color: '#666',
+    color: 'rgb(33, 33, 33)',
   },
 
   array: {
-    color: '#666',
+    color: 'rgb(33, 33, 33)',
   },
 
   symbol: {
-    color: '#22a',
+    color: '#1c00cf',
   },
 
   number: {
-    color: '#a11',
+    color: '#1c00cf',
   },
 
   string: {
-    color: '#22a',
+    color: '#c41a16',
     wordBreak: 'break-word',
   },
 
   bool: {
-    color: '#a11',
+    color: '#1c00cf',
   },
 
   empty: {

--- a/plugins/BananaSlug/BananaSlugFrontendControl.js
+++ b/plugins/BananaSlug/BananaSlugFrontendControl.js
@@ -21,7 +21,8 @@ var Wrapped = decorate({
   props(store) {
     return {
       state: store.bananaslugState,
-      text: 'Trace React Updates',
+      text: 'Trace updates',
+      record: true,
       onChange: state => store.changeBananaSlug(state),
     };
   },

--- a/plugins/Colorizer/ColorizerFrontendControl.js
+++ b/plugins/Colorizer/ColorizerFrontendControl.js
@@ -21,7 +21,7 @@ var Wrapped = decorate({
   props(store) {
     return {
       state: store.colorizerState,
-      text: 'Highlight Search',
+      text: 'Highlight search',
       onChange: state => store.changeColorizer(state),
     };
   },

--- a/plugins/Regex/RegexFrontendControl.js
+++ b/plugins/Regex/RegexFrontendControl.js
@@ -21,7 +21,7 @@ var Wrapped = decorate({
   props(store) {
     return {
       state: store.regexState,
-      text: 'Use Regular Expressions',
+      text: 'Regex',
       onChange: state => store.changeRegex(state),
     };
   },


### PR DESCRIPTION
I've tried to introduce a few minor UX / UI improvements  to issues that I found in devtools over the weekend. These include : 

1) Rearranged controls and tweaked UI for a cleaner look.
![image](https://cloud.githubusercontent.com/assets/8946207/17839352/b7254018-6802-11e6-9690-105e7a39d30a.png)

2) Breadcrumbs are now highlighted on hover.
![image](https://cloud.githubusercontent.com/assets/8946207/17839285/65872c7c-6801-11e6-8a96-8ef4f1f49939.png)

2) Replaced `cursor:pointer` with `cursor:default`. Pointers are usually a thing of webpages.

3) Syntax highlighting and colors are tweaked a bit to chrome's design. 

4) Tooltips are now closer to how chrome does them — more readable.
![image](https://cloud.githubusercontent.com/assets/8946207/17839301/dee2ef52-6801-11e6-97eb-65ffaf4a60f4.png)

5) Code wrapping works in tree-view - better usability when devtools is docked towards the right.
![image](https://cloud.githubusercontent.com/assets/8946207/17839374/3f1b8ff4-6803-11e6-8883-b684cb171b6e.png)

6) Hitting `enter` after a editing a field in DataView now closes the field in addition to applying changes (standard behaviour).

If these changes seem to go a lot in one PR, I could break them down into multiple.
