### PR TITLE
Improved styling of Context Menu, added zIndex to prevent overlap

### DIFF
--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -136,17 +136,23 @@ var styles = {
   container: {
     position: 'fixed',
     backgroundColor: 'white',
-    boxShadow: '0 3px 5px #ccc',
+    boxShadow: '0 1px 6px rgba(0,0,0,0.3)',
     listStyle: 'none',
     margin: 0,
-    padding: 0,
-    fontFamily: 'sans-serif',
-    fontSize: 14,
+    padding: '4px 0',
+    fontSize: 13,
+    borderRadius: '3px',
+    overflow: 'hidden',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", "Ubuntu", "Helvetica Neue", sans-serif',
+    zIndex:1,
   },
 
   item: {
-    padding: '5px 10px',
-    cursor: 'pointer',
+    padding: '3px 10px',
+    cursor: 'default',
+    WebkitUserSelect: 'none',
+    MozUserSelect: 'none',
+    userSelect: 'none',
   },
 
   empty: {


### PR DESCRIPTION
UI improvements as discussed in #416. This PR 

![group](https://cloud.githubusercontent.com/assets/8946207/18024948/1be14c40-6c36-11e6-8265-8e5317c4a275.png)
- fixes zIndex issues ( context menu opening behind the line that separates the treeview from sidepanel)
- Font styling to better mimic the OS context menu
