### PR TITLE
(WIP) Try to make FF faster when paused

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -22,9 +22,11 @@ var cancelIdleCallback = window.cancelIdleCallback || clearTimeout;
 var requestIdleCallback = window.requestIdleCallback || function(cb, options) {
   // Magic numbers determined by tweaking in Firefox.
   // There is no special meaning to them.
-  var delayMS = 3000 * lastRunTimeMS;
-  if (delayMS > 500) {
-    delayMS = 500;
+  var timeoutMS = options && options.timeout || 500;
+  if (timeoutMS < 1000) {
+    // We don't have a lot of time so let's just do it asap.
+    // Again, magic numbers are determined by tweaking in FF.
+    timeoutMS = Math.min(timeoutMS, 3000 * lastRunTimeMS);
   }
 
   return setTimeout(() => {
@@ -37,7 +39,7 @@ var requestIdleCallback = window.requestIdleCallback || function(cb, options) {
     });
     var endTime = performanceNow();
     lastRunTimeMS = (endTime - startTime) / 1000;
-  }, delayMS);
+  }, timeoutMS);
 };
 
 type AnyFn = (...x: any) => any;

--- a/shells/firefox/main/PanelVisibilityListener.js
+++ b/shells/firefox/main/PanelVisibilityListener.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+const {Class} = require('sdk/core/heritage');
+const {Disposable} = require('sdk/core/disposable');
+const {emit} = require('sdk/event/core');
+const {EventTarget} = require('sdk/event/target');
+const {Cu} = require('chrome');
+const {gDevTools} = Cu.import('resource://devtools/client/framework/gDevTools.jsm', {});
+
+const toolboxes = new WeakMap();
+const toolboxFor = target => toolboxes.get(target);
+
+const ToolboxListener = Class({
+  extends: Disposable,
+  implements: [EventTarget],
+
+  initialize() {
+    this.onToolboxReady = this.onToolboxReady.bind(this);
+    this.onToolboxDestroyed = this.onToolboxDestroyed.bind(this);
+    this.onSelect = this.onSelect.bind(this);
+
+    gDevTools.on('toolbox-ready', this.onToolboxReady);
+    gDevTools.on('toolbox-destroyed', this.onToolboxDestroyed);
+  },
+
+  dispose() {
+    for (let toolbox of toolboxes.values()) { // eslint-disable-line prefer-const
+      toolbox.off('select', this.onSelect);
+    }
+    gDevTools.off('toolbox-ready', this.onToolboxReady);
+    gDevTools.off('toolbox-destroyed', this.onToolboxDestroyed);
+  },
+
+  onToolboxReady(evt, toolbox) {
+    toolboxes.set(toolbox.target, toolbox);
+    toolbox.on('select', this.onSelect);
+  },
+
+  onToolboxDestroyed(evt, target) {
+    const toolbox = toolboxFor(target);
+    if (toolbox) {
+      toolbox.off('select', this.onSelect);
+    }
+  },
+
+  onSelect(evt, id) {
+    emit(this, 'panel-selected', id);
+  },
+});
+
+const toolboxListener = new ToolboxListener();
+
+const PanelVisibilityListener = Class({
+  implements: [Disposable],
+
+  initialize() {
+    this.panels = new Set();
+    this.visiblePanels = new WeakSet();
+    this.onPanelSelected = this.onPanelSelected.bind(this);
+    toolboxListener.on('panel-selected', this.onPanelSelected);
+  },
+
+  dispose() {
+    toolboxListener.off('panel-selected', this.onPanelSelected);
+    this.panels.clear();
+    this.visiblePanels = null;
+  },
+
+  onPanelSelected(id) {
+    for (let panel of this.panels) { // eslint-disable-line prefer-const
+      if (id == panel.id) {
+        this.visiblePanels.add(panel);
+        emit(panel, 'show');
+      } else if (this.visiblePanels.has(panel)) {
+        this.visiblePanels.delete(panel);
+        emit(panel, 'hide');
+      }
+    }
+  },
+
+  addPanel(panel) {
+    this.panels.add(panel);
+  },
+
+  removePanel(panel) {
+    this.panels.delete(panel);
+  },
+});
+
+exports.PanelVisibilityListener = PanelVisibilityListener;

--- a/shells/firefox/main/trackSelection.js
+++ b/shells/firefox/main/trackSelection.js
@@ -10,16 +10,7 @@
 'use strict';
 
 const { Cu } = require('chrome');
-
-// The path to this file was moved in Firefox 44 and later.
-// See https://bugzil.la/912121 and https://bugzil.la/1203159 for more details.
-let gDevTools;
-try {
-  ({ gDevTools } = Cu.import('resource://devtools/client/framework/' +
-                             'gDevTools.jsm', {}));
-} catch (e) {
-  ({ gDevTools } = Cu.import('resource:///modules/devtools/gDevTools.jsm', {}));
-}
+const { gDevTools } = Cu.import('resource://devtools/client/framework/gDevTools.jsm', {});
 
 /**
  * Whenever the devtools inspector panel selection changes, pass that node to

--- a/shells/firefox/package.json
+++ b/shells/firefox/package.json
@@ -6,7 +6,7 @@
   "main": "main/index.js",
   "author": "Facebook",
   "engines": {
-    "firefox": ">=38.0a1"
+    "firefox": ">=44.0"
   },
   "license": "BSD-3-Clause",
   "permissions": {


### PR DESCRIPTION
I’m dropping this because I couldn’t finish this and I don’t even know if it would result in an improvement.

The idea was to do pass `pause` and `resume` messages to the bridge (like we do for Chrome) so that it could do work less intensely when DevTools are paused. This worked great in Chrome but I don’t know if we can really reap the same benefits in FF.

Debugging FF extensions is a nightmare because:
1. Debugger often hangs
2. Breakpoints don’t consistently break
3. It’s super slow

If you want to pick this up, you’ll want to:
1. Make sure we actually track visibility change correctly—I’m not sure it works in all cases, especially since we don’t get an event on first open with this approach
2. Make sure we actually pass event to the bridge. I don’t understand the port system and I have no idea how to correctly send the message to it from the panel.
3. Make sure we use `this._isPaused` in the bridge wisely. The current handling works great for Chrome but I’m not sure if same heuristics work for FF, especially considering we use that hacky `requestIdleCallback` “polyfill”.
