### PR TITLE
Guard window.addEventListener call

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -118,8 +118,10 @@ class Agent extends EventEmitter {
       editTextContent: false,
     }, capabilities);
 
-    this._updateScroll = this._updateScroll.bind(this);
-    window.addEventListener('scroll', this._onScroll.bind(this), true);
+    if (isReactDOM) {
+      this._updateScroll = this._updateScroll.bind(this);
+      window.addEventListener('scroll', this._onScroll.bind(this), true);
+    }
   }
 
   // returns an "unsubscribe" function


### PR DESCRIPTION
When upgrading Nuclide's build of the devtools and testing in RN, this was causing an error (since `window.addEventListener` isn't defined for RN).

lmk if I should check `capabilities.scroll` instead.