### PR TITLE
Add react keys to ContextMenu items

### DIFF
--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -63,12 +63,14 @@ var DEFAULT_MENU_ITEMS = {
     var items = [];
     if (node.get('name')) {
       items.push({
+        key: 'showNodesOfType',
         title: 'Show all ' + node.get('name'),
         action: () => store.changeSearch(node.get('name')),
       });
     }
     if (store.capabilities.scroll) {
       items.push({
+        key: 'scrollToNode',
         title: 'Scroll to Node',
         action: () => store.scrollToNode(id),
       });
@@ -77,6 +79,7 @@ var DEFAULT_MENU_ITEMS = {
   },
   attr: (id, node, val, path, name, store) => {
     var items = [{
+      key: 'storeAsGlobal',
       title: 'Store as global variable',
       action: () => store.makeGlobal(id, path),
     }];

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -18,6 +18,7 @@ var assign = require('object-assign');
 var decorate = require('./decorate');
 
 export type MenuItem = {
+  key: string,
   title: string,
   action: () => void
 };
@@ -85,7 +86,7 @@ class ContextMenu extends React.Component {
       <ul style={containerStyle}>
         {!this.props.items.length && <li style={styles.empty}>No actions</li>}
         {this.props.items.map((item, i) => item && (
-          <li onClick={evt => this.onClick(i, evt)}>
+          <li key={item.key} onClick={evt => this.onClick(i, evt)}>
             <HighlightHover style={styles.item}>
               {item.title}
             </HighlightHover>

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -251,10 +251,12 @@ class Panel extends React.Component {
               return undefined;
             }
             return [this.props.showAttrSource && {
+              key: 'showSource',
               title: 'Show Source',
               // $FlowFixMe showAttrSource is provided
               action: () => this.props.showAttrSource(path),
             }, this.props.executeFn && {
+              key: 'executeFunction',
               title: 'Execute function',
               // $FlowFixMe executeFn is provided
               action: () => this.props.executeFn(path),
@@ -262,9 +264,11 @@ class Panel extends React.Component {
           },
           tree: (id, node) => {
             return [this.props.showComponentSource && node.get('nodeType') === 'Composite' && {
+              key: 'showSource',
               title: 'Show Source',
               action: () => this.viewSource(id),
             }, this.props.selectElement && this._store.capabilities.dom && {
+              key: 'showInElementsPane',
               title: 'Show in Elements Pane',
               action: () => this.sendSelection(id),
             }];


### PR DESCRIPTION
Currently, there's a warning emitted because the items of the ContextMenu do not have keys associated with them.