### PR TITLE
Incorporate react tags into UI

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -30,6 +30,7 @@ function getData(element: Object): DataType {
   var text = null;
   var publicInstance = null;
   var nodeType = 'Native';
+  var reactTag = null;;
   // If the parent is a native node without rendered children, but with
   // multiple string children, then the `element` that gets passed in here is
   // a plain value -- a string or number.
@@ -111,6 +112,10 @@ function getData(element: Object): DataType {
     }
   }
 
+  if (nodeType === 'Native') {
+    reactTag = element._rootNodeID;
+  }
+
   return {
     nodeType,
     type,
@@ -125,6 +130,7 @@ function getData(element: Object): DataType {
     text,
     updater,
     publicInstance,
+    reactTag,
   };
 }
 

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -79,6 +79,10 @@ class Node extends React.Component {
       children = this.props.wrappedChildren;
     }
 
+    var reactTag = this.props.node.get('reactTag');
+    var name = reactTag == null
+      ? `${this.props.node.get('name')}`
+      : `${this.props.node.get('name')}(${reactTag})`;
     var collapsed = node.get('collapsed');
 
     var leftPad = {
@@ -137,7 +141,6 @@ class Node extends React.Component {
 
     // Single-line tag (collapsed / simple content / no content)
     if (!children || typeof children === 'string' || !children.length) {
-      var name = node.get('name');
       var content = children;
       return (
         <div style={styles.container}>
@@ -166,7 +169,7 @@ class Node extends React.Component {
     var closeTag = (
       <span style={styles.closeTag}>
         <span style={tagStyle}>
-          &lt;/{'' + node.get('name')}&gt;
+          &lt;/{'' + name}&gt;
         </span>
       </span>
     );
@@ -203,7 +206,7 @@ class Node extends React.Component {
         {collapser}
         <span style={styles.tagText}>
           <span style={styles.openTag}>
-            <span style={tagStyle}>&lt;{'' + node.get('name')}</span>
+            <span style={tagStyle}>&lt;{'' + name}</span>
             {node.get('key') && <Props key="key" props={{'key': node.get('key')}}/>}
             {node.get('ref') && <Props key="ref" props={{'ref': node.get('ref')}}/>}
             {node.get('props') && <Props key="props" props={node.get('props')}/>}

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -88,10 +88,14 @@ class PropState extends React.Component {
     var state = this.props.node.get('state');
     var context = this.props.node.get('context');
     var propsReadOnly = !this.props.node.get('canUpdate');
+    var reactTag = this.props.node.get('reactTag');
+    var name = reactTag == null
+      ? `<${this.props.node.get('name')}>`
+      : `<${this.props.node.get('name')}(${reactTag})>`;
 
     return (
       <DetailPane
-        header={'<' + this.props.node.get('name') + '>'}
+        header={name}
         hint="($r in the console)">
         {key &&
           <DetailPaneSection

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -230,7 +230,8 @@ class Store extends EventEmitter {
             var node = this.get(item);
             return (node.get('name') && node.get('name').toLowerCase().indexOf(needle) !== -1) ||
               (node.get('text') && node.get('text').toLowerCase().indexOf(needle) !== -1) ||
-              (typeof node.get('children') === 'string' && node.get('children').toLowerCase().indexOf(needle) !== -1);
+              (typeof node.get('children') === 'string' && node.get('children').toLowerCase().indexOf(needle) !== -1) ||
+              (node.get('reactTag') != null && node.get('reactTag').toString().indexOf(needle) === 0);
           });
       } else {
         this.searchRoots = this._nodes.entrySeq()

--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -19,6 +19,10 @@ function nodeMatchesText(node: Map, needle: string, key: string, store: Store): 
   if (node.get('nodeType') === 'Native' && wrapper && wrapper.get('nodeType') === 'NativeWrapper') {
     return false;
   }
+  var reactTag = node.get('reactTag');
+  if (reactTag != null && reactTag.toString().indexOf(needle) === 0) {
+    return true;
+  }
   var useRegex = !!store.regexState && store.regexState.enabled;
   if (name) {
     if (node.get('nodeType') !== 'Wrapper') {


### PR DESCRIPTION
Fixes #439. For a node that has a react tag, its name is now rendered as `<RCTView(17)>` where "RCTView" is the component type and "17" is the react tag.

React tags are only rendered for native primitives. Changes:
  - React tag is rendered in the right pane when inspecting a node.
  - React tag is rendered next to the component type inside of the TreeView.
  - Search now supports searching by react tag.

### Outstanding Issue: ReactDOM vs React Native

Currently, this feature is always enabled. I want this feature for React Native. Developers who are either debugging React Native internals or writing their own native modules may find this feature to be useful. It helps them to correlate components they are debugging in the native debugger with JS components.

However, I'm not sure if this feature is as useful for ReactDOM. Fewer people will probably be debugging ReactDOM internals than React Native internals + native modules. Also, it may already be easy to correlate nodes in ReactDOM internals with nodes from the app. I wouldn't know, I haven't had to do this before.

If we only want to enable this for React Native, I would appreciate some advice on the best way to do that.