### PR TITLE
Fix `forward slash` key listen for typing on another input

### DIFF
--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -53,8 +53,10 @@ class SearchPane extends React.Component {
   }
 
   onDocumentKeyDown(e) {
-    if (e.keyCode === 191 && // forward slash
-      this.input && e.target && e.target.nodeName !== 'INPUT'
+    if (
+      e.keyCode === 191 && // forward slash
+      e.target.nodeName !== 'INPUT' &&
+      this.input
     ) {
       this.input.focus();
       e.preventDefault();

--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -53,11 +53,9 @@ class SearchPane extends React.Component {
   }
 
   onDocumentKeyDown(e) {
-    if (e.keyCode === 191) { // forward slash
-      var doc = ReactDOM.findDOMNode(this).ownerDocument;
-      if (!this.input || doc.activeElement === this.input) {
-        return;
-      }
+    if (e.keyCode === 191 && // forward slash
+      this.input && e.target && e.target.nodeName !== 'INPUT'
+    ) {
       this.input.focus();
       e.preventDefault();
     }


### PR DESCRIPTION
Currently it will broken typing `/` on another input, like component props / state:

![2016-11-17 05_37_46](https://cloud.githubusercontent.com/assets/3001525/20366878/014f47d2-ac88-11e6-867e-d5bab257316c.gif)
