### PR TITLE
Adds missing library and documentation for electron stand-alone shell.

### DIFF
--- a/shells/electron/Readme.md
+++ b/shells/electron/Readme.md
@@ -4,12 +4,14 @@ This is useful for working on a React Native app *without* debugging in
 chrome. The js runs in jscore, and the devtools talk to it through a
 websocket.
 
-You'll need webpack, and [electron](http://electron.atom.io/#get-started) (`npm install electron-prebuilt -g`).
+You'll need [webpack](https://webpack.github.io/)(`npm install webpack -g`),
+and [electron](http://electron.atom.io/#get-started) (`npm install electron-prebuilt -g`).
+** Make sure to run `npm install` in the root directory of this project. **
 
+Then inn `./shells/electron` (this directory) run:
 - `npm install`
 - `npm run build`
 - `electron .`
 
 Start up the packager, start up your app, and things *should* just connect
 happily.
-

--- a/shells/electron/package.json
+++ b/shells/electron/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "electron-prebuilt": "^1.4.2",
+    "ip": "1.1.4",
     "ws": "1.1.0"
   }
 }


### PR DESCRIPTION
The ip library was not installed and in addition the build scripts would call node_modules at the root level.

Changes
-Added ip package to package.json
-Extended, formatted Readme.md for clarity on startup instructions.

@jaredly @kassens @spicyj 