### PR TITLE
Don't overwrite global $r if it is already set

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -88,7 +88,7 @@ class Agent extends EventEmitter {
   elementData: Map<ElementID, DataType>;
   roots: Set<ElementID>;
   reactInternals: {[key: RendererID]: Helpers};
-  capabilities: {[key: string]: boolean|string};
+  capabilities: {[key: string]: boolean};
   renderers: Map<ElementID, RendererID>;
   _prevSelected: ?NativeType;
   _scrollUpdate: boolean;
@@ -103,12 +103,12 @@ class Agent extends EventEmitter {
     this.elementData = new Map();
     this.roots = new Set();
     this.reactInternals = {};
-
-    var $r: string = this._getGlobalRName();
+    var lastSelected;
     this.on('selected', id => {
       var data = this.elementData.get(id);
-      if (data && data.publicInstance) {
-        this.global[$r] = data.publicInstance;
+      if (data && data.publicInstance && this.global.$r === lastSelected) {
+        this.global.$r = data.publicInstance;
+        lastSelected = data.publicInstance;
       }
     });
     this._prevSelected = null;
@@ -118,7 +118,6 @@ class Agent extends EventEmitter {
       scroll: isReactDOM && typeof window.document.body.scrollIntoView === 'function',
       dom: isReactDOM,
       editTextContent: false,
-      $r,
     }, capabilities);
 
     if (isReactDOM) {
@@ -405,15 +404,6 @@ class Agent extends EventEmitter {
     this.emit('refreshMultiOverlay');
     this._scrollUpdate = false;
   }
-
-  _getGlobalRName(): string {
-    var name: string = '$r';
-    while (typeof this.global[name] !== 'undefined') {
-      name = '$' + name;
-    }
-    return name;
-  }
-
 }
 
 function getIn(base, path) {

--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -88,7 +88,7 @@ class Agent extends EventEmitter {
   elementData: Map<ElementID, DataType>;
   roots: Set<ElementID>;
   reactInternals: {[key: RendererID]: Helpers};
-  capabilities: {[key: string]: boolean};
+  capabilities: {[key: string]: boolean|string};
   renderers: Map<ElementID, RendererID>;
   _prevSelected: ?NativeType;
   _scrollUpdate: boolean;
@@ -103,10 +103,12 @@ class Agent extends EventEmitter {
     this.elementData = new Map();
     this.roots = new Set();
     this.reactInternals = {};
+
+    var $r: string = this._getGlobalRName();
     this.on('selected', id => {
       var data = this.elementData.get(id);
       if (data && data.publicInstance) {
-        this.global.$r = data.publicInstance;
+        this.global[$r] = data.publicInstance;
       }
     });
     this._prevSelected = null;
@@ -116,6 +118,7 @@ class Agent extends EventEmitter {
       scroll: isReactDOM && typeof window.document.body.scrollIntoView === 'function',
       dom: isReactDOM,
       editTextContent: false,
+      $r,
     }, capabilities);
 
     if (isReactDOM) {
@@ -402,6 +405,15 @@ class Agent extends EventEmitter {
     this.emit('refreshMultiOverlay');
     this._scrollUpdate = false;
   }
+
+  _getGlobalRName(): string {
+    var name: string = '$r';
+    while (typeof this.global[name] !== 'undefined') {
+      name = '$' + name;
+    }
+    return name;
+  }
+
 }
 
 function getIn(base, path) {

--- a/agent/__tests__/Agent-test.js
+++ b/agent/__tests__/Agent-test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+jest.dontMock('../Agent');
+var Agent = require('../Agent');
+
+describe('Agent', () => {
+
+  it('does not overwrite existing global $r', () => {
+    const instance = new Agent({
+      $r: 'exists',
+    });
+    const expected = '$$r';
+    const actual = instance._getGlobalRName();
+    expect(actual).toBe(expected);
+  });
+
+  it('it finds a suitable $r name when there are multiple conflicts', () => {
+    const instance = new Agent({
+      $r: 'exists',
+      $$r: 'exists',
+      $$$r: 'exists',
+    });
+    const expected = '$$$$r';
+    const actual = instance._getGlobalRName();
+    expect(actual).toBe(expected);
+  });
+
+});

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -92,7 +92,7 @@ class PropState extends React.Component {
     return (
       <DetailPane
         header={'<' + this.props.node.get('name') + '>'}
-        hint={'(' + this.props.$r + ' in the console)'}>
+        hint="($r in the console)">
         {key &&
           <DetailPaneSection
             title="Key"
@@ -187,7 +187,6 @@ var WrappedPropState = decorate({
         store.showContextMenu('attr', e, store.selected, node, val, path, name);
       },
       inspect: store.inspect.bind(store, store.selected),
-      $r: store.capabilities.$r,
     };
   },
 }, PropState);

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -92,7 +92,7 @@ class PropState extends React.Component {
     return (
       <DetailPane
         header={'<' + this.props.node.get('name') + '>'}
-        hint="($r in the console)">
+        hint={'(' + this.props.$r + ' in the console)'}>
         {key &&
           <DetailPaneSection
             title="Key"
@@ -187,6 +187,7 @@ var WrappedPropState = decorate({
         store.showContextMenu('attr', e, store.selected, node, val, path, name);
       },
       inspect: store.inspect.bind(store, store.selected),
+      $r: store.capabilities.$r,
     };
   },
 }, PropState);


### PR DESCRIPTION
Thought I would try to get the ball rolling on #316.

Seems like there are two parts to this:
- Detect global $r and assign a different variable if it exists
- Pass this variable name to the view so it can display it in the sidebar

The `capabilities` object is passed to the frontend store as part of the initial connection handshake so this seemed like an easy place to pass through the name of the `$r` variable to the view but I'm not sure you can really say it's a capability so maybe it wants it's own way of being passed instead?