### PR TITLE
Generic support for third-party data objects inspection (ImmutableJS, BackboneJS, etc)

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -410,14 +410,4 @@ function getIn(base, path) {
   }, base);
 }
 
-function addInnerStateInspector(Ctor, getInnerState) {
-  Object.defineProperty( Ctor.prototype, '__inner_state__', {
-    get : function() {
-      return getInnerState( this );
-    },
-  });
-}
-
-window.__REACT_DEVTOOLS_GLOBAL_HOOK__.addInnerStateInspector = addInnerStateInspector;
-
 module.exports = Agent;

--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -410,4 +410,14 @@ function getIn(base, path) {
   }, base);
 }
 
+function addInnerStateInspector(Ctor, getInnerState) {
+  Object.defineProperty( Ctor.prototype, '__inner_state__', {
+    get : function() {
+      return getInnerState( this );
+    },
+  });
+}
+
+window.__REACT_DEVTOOLS_GLOBAL_HOOK__.addInnerStateInspector = addInnerStateInspector;
+
 module.exports = Agent;

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -404,23 +404,27 @@ class Bridge {
     if (inspectable) {
       var val = getIn(inspectable, path);
 
-
-      var protod = false;
+      var protod = false, isWrapper = false;
       var isFn = typeof val === 'function';
-      var data = val._state || val;
 
-      Object.getOwnPropertyNames( data ).forEach(name => {
-        if (name === '__proto__') {
+      if( val && val._state ){
+          val = val._state;
+          isWrapper = true;
+      }
+
+      Object.getOwnPropertyNames( val ).forEach(name => {
+        if (name === '__proto__' && !isWrapper ) {
           protod = true;
         }
+
         if (isFn && (name === 'arguments' || name === 'callee' || name === 'caller')) {
           return;
         }
-        result[name] = dehydrate( data[name], cleaned, [name]);
+        result[name] = dehydrate( val[name], cleaned, [name]);
       });
 
       /* eslint-disable no-proto */
-      if (!protod && val.__proto__ && val.constructor.name !== 'Object') {
+      if (!protod && val.__proto__ && val.constructor.name !== 'Object' && !isWrapper ) {
         var newProto = {};
         var pIsFn = typeof val.__proto__ === 'function';
         Object.getOwnPropertyNames(val.__proto__).forEach(name => {
@@ -447,7 +451,7 @@ class Bridge {
 
 function getIn(base, path) {
   return path.reduce((obj, attr) => {
-    return obj ? ( ( obj._state || obj )[ attr ] ): null;
+    return obj ? ( ( obj._state || obj : obj )[ attr ] ): null;
   }, base);
 }
 

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -426,7 +426,7 @@ class Bridge {
         var newProto = {};
         var pIsFn = typeof val.__proto__ === 'function';
         Object.getOwnPropertyNames(val.__proto__).forEach(name => {
-          if( pIsFn && (name === 'arguments' || name === 'callee' || name === 'caller') ){
+          if (pIsFn && (name === 'arguments' || name === 'callee' || name === 'caller') ) {
             return;
           }
 
@@ -452,22 +452,24 @@ function getIn(base, path) {
   let isPrototypeChain = false;
 
   return path.reduce((obj, attr) => {
-    if( !obj ) return null;
-
-    // Mark the beginning of the prototype chain...
-    if( attr === "__proto__" ){
-      isPrototypeChain = true;
-      return obj.__proto__;
+    if (!obj) {
+      return null;
     }
 
-    if( isPrototypeChain ){
+    // Mark the beginning of the prototype chain...
+    if (attr === '__proto__') {
+      isPrototypeChain = true;
+      return obj[attr];
+    }
+
+    if (isPrototypeChain) {
       // Avoid calling calculated properties on prototype.
       const property = Object.getOwnPropertyDescriptor( obj, attr );
       return property.get || property.value;
     }
 
     // Traverse inner state of the third-party data frameworks objects...
-    return ( obj._innerState || obj )[ attr ];
+    return ( obj._innerState || obj )[attr];
   }, base);
 }
 

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -426,7 +426,7 @@ class Bridge {
         var newProto = {};
         var pIsFn = typeof val.__proto__ === 'function';
         Object.getOwnPropertyNames(val.__proto__).forEach(name => {
-          if (pIsFn && (name === 'arguments' || name === 'callee' || name === 'caller') ) {
+          if ( name === '__inner_state__' || ( pIsFn && (name === 'arguments' || name === 'callee' || name === 'caller') ) ) {
             return;
           }
 

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -404,27 +404,25 @@ class Bridge {
     if (inspectable) {
       var val = getIn(inspectable, path);
 
-      var protod = false, isWrapper = false;
+      var protod = false;
       var isFn = typeof val === 'function';
 
-      if( val && val._state ){
-          val = val._state;
-          isWrapper = true;
-      }
+      // Extract inner state of the third-party frameworks data objects...
+      var source = ( val && val._innerState ) || val;
 
-      Object.getOwnPropertyNames( val ).forEach(name => {
-        if (name === '__proto__' && !isWrapper ) {
+      Object.getOwnPropertyNames( source ).forEach(name => {
+        if (name === '__proto__' ) {
           protod = true;
         }
 
         if (isFn && (name === 'arguments' || name === 'callee' || name === 'caller')) {
           return;
         }
-        result[name] = dehydrate( val[name], cleaned, [name]);
+        result[name] = dehydrate( source[name], cleaned, [name]);
       });
 
       /* eslint-disable no-proto */
-      if (!protod && val.__proto__ && val.constructor.name !== 'Object' && !isWrapper ) {
+      if (!protod && val.__proto__ && val.constructor.name !== 'Object' ) {
         var newProto = {};
         var pIsFn = typeof val.__proto__ === 'function';
         Object.getOwnPropertyNames(val.__proto__).forEach(name => {
@@ -432,6 +430,7 @@ class Bridge {
             return;
           }
 
+          // Calculated properties should not be evaluated on prototype.
           var prop = Object.getOwnPropertyDescriptor( val.__proto__, name );
 
           newProto[name] = dehydrate( prop.get ? prop.get : val.__proto__[name], protoclean, [name]);
@@ -450,8 +449,25 @@ class Bridge {
 }
 
 function getIn(base, path) {
+  let isPrototypeChain = false;
+
   return path.reduce((obj, attr) => {
-    return obj ? ( ( obj._state || obj : obj )[ attr ] ): null;
+    if( !obj ) return null;
+
+    // Mark the beginning of the prototype chain...
+    if( attr === "__proto__" ){
+      isPrototypeChain = true;
+      return obj.__proto__;
+    }
+
+    if( isPrototypeChain ){
+      // Avoid calling calculated properties on prototype.
+      const property = Object.getOwnPropertyDescriptor( obj, attr );
+      return property.get || property.value;
+    }
+
+    // Traverse inner state of the third-party data frameworks objects...
+    return ( obj._innerState || obj )[ attr ];
   }, base);
 }
 

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -408,7 +408,6 @@ class Bridge {
       var isFn = typeof val === 'function';
 
       // Extract inner state of the third-party frameworks data objects...
-      var source = ( val && val._innerState ) || val;
 
       Object.getOwnPropertyNames( source ).forEach(name => {
         if (name === '__proto__' ) {
@@ -469,7 +468,6 @@ function getIn(base, path) {
     }
 
     // Traverse inner state of the third-party data frameworks objects...
-    return ( obj._innerState || obj )[attr];
   }, base);
 }
 

--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -408,6 +408,7 @@ class Bridge {
       var isFn = typeof val === 'function';
 
       // Extract inner state of the third-party frameworks data objects...
+      var source = ( val && val.__inner_state__ ) || val;
 
       Object.getOwnPropertyNames( source ).forEach(name => {
         if (name === '__proto__' ) {
@@ -468,6 +469,7 @@ function getIn(base, path) {
     }
 
     // Traverse inner state of the third-party data frameworks objects...
+    return ( obj.__inner_state__ || obj )[attr];
   }, base);
 }
 

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -31,8 +31,9 @@
  * and cleaned = [["some", "attr"], ["other"]]
  */
 function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<string>, level?: number): string | Object {
-  if( data && data._state && path[ path.length - 1 ] === 'state' ){
-    data = data._state;
+  // Support third-party frameworks data objects in react component state.
+  if( data && data._innerState && path[ path.length - 1 ] === 'state' ){
+    data = data._innerState;
   }
 
   level = level || 0;

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -32,7 +32,7 @@
  */
 function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<string>, level?: number): string | Object {
   // Support third-party frameworks data objects in react component state.
-  if( data && data._innerState && path[ path.length - 1 ] === 'state' ){
+  if (data && data._innerState && path[path.length - 1] === 'state') {
     data = data._innerState;
   }
 

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -32,6 +32,8 @@
  */
 function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<string>, level?: number): string | Object {
   // Support third-party frameworks data objects in react component state.
+  if (data && data.__inner_state__ && path && path[path.length - 1] === 'state') {
+    data = data.__inner_state__;
   }
 
   level = level || 0;

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -31,6 +31,10 @@
  * and cleaned = [["some", "attr"], ["other"]]
  */
 function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<string>, level?: number): string | Object {
+  if( data && data._state && path[ path.length - 1 ] === 'state' ){
+    data = data._state;
+  }
+
   level = level || 0;
   path = path || [];
   if (typeof data === 'function') {

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -32,7 +32,7 @@
  */
 function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<string>, level?: number): string | Object {
   // Support third-party frameworks data objects in react component state.
-  if (data && data._innerState && path[path.length - 1] === 'state') {
+  if (data && data._innerState && path && path[path.length - 1] === 'state') {
     data = data._innerState;
   }
 

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -32,8 +32,6 @@
  */
 function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<string>, level?: number): string | Object {
   // Support third-party frameworks data objects in react component state.
-  if (data && data._innerState && path && path[path.length - 1] === 'state') {
-    data = data._innerState;
   }
 
   level = level || 0;

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -24,10 +24,13 @@
 'use strict';
 
 import type {Hook} from './types';
+import attachInnerStateInspectors from './innerStateInspectors';
 
 var attachRenderer = require('./attachRenderer');
 
 module.exports = function setupBackend(hook: Hook): boolean {
+  attachInnerStateInspectors( hook );
+
   var oldReact = window.React && window.React.__internals;
   if (oldReact && Object.keys(hook._renderers).length === 0) {
     hook.inject(oldReact);

--- a/backend/innerStateInspectors.js
+++ b/backend/innerStateInspectors.js
@@ -1,0 +1,18 @@
+/**
+ * @flow
+ *
+ * Inner state inspectors for the built in JS data types.
+ */
+
+'use strict';
+
+import type {Hook} from './types';
+
+export default
+function attachInnerStateInspectors({ addInnerStateInspector } : Hook ) {
+  addInnerStateInspector( Date, ( x : Date ) => ({
+    local : `${ x.toDateString() } ${ x.toTimeString() }`,
+    iso : x.toISOString(),
+    timestamp : x.getTime(),
+  }), true );
+}

--- a/backend/installGlobalHook.js
+++ b/backend/installGlobalHook.js
@@ -59,12 +59,12 @@ function installGlobalHook(window: Object) {
       },
       addInnerStateInspector: function(Ctor, getInnerState) {
         Object.defineProperty( Ctor.prototype, '__inner_state__', ({
-            get : function() {
-                return getInnerState( this );
-            },
+          get : function() {
+            return getInnerState( this );
+          },
         } : Object ));
-      }
-}: Hook),
+      },
+    }: Hook),
   });
 }
 

--- a/backend/installGlobalHook.js
+++ b/backend/installGlobalHook.js
@@ -57,12 +57,16 @@ function installGlobalHook(window: Object) {
           this._listeners[evt].map(fn => fn(data));
         }
       },
-      addInnerStateInspector: function(Ctor, getInnerState) {
-        Object.defineProperty( Ctor.prototype, '__inner_state__', ({
-          get : function() {
-            return getInnerState( this );
-          },
-        } : Object ));
+      addInnerStateInspector: function(Ctor, getInnerState, skipIfDefined) {
+        if ( !( skipIfDefined && Ctor.prototype.hasOwnProperty( '__inner_state__' ) ) ) {
+          Object.defineProperty(Ctor.prototype, '__inner_state__', ({
+            get: function() {
+              return getInnerState(this);
+            },
+            enumerable: false,
+            configurable: true,
+          } : Object ));
+        }
       },
     }: Hook),
   });

--- a/backend/installGlobalHook.js
+++ b/backend/installGlobalHook.js
@@ -57,7 +57,14 @@ function installGlobalHook(window: Object) {
           this._listeners[evt].map(fn => fn(data));
         }
       },
-    }: Hook),
+      addInnerStateInspector: function(Ctor, getInnerState) {
+        Object.defineProperty( Ctor.prototype, '__inner_state__', {
+            get : function() {
+                return getInnerState( this );
+            },
+        });
+      }
+}: Hook),
   });
 }
 

--- a/backend/installGlobalHook.js
+++ b/backend/installGlobalHook.js
@@ -58,11 +58,11 @@ function installGlobalHook(window: Object) {
         }
       },
       addInnerStateInspector: function(Ctor, getInnerState) {
-        Object.defineProperty( Ctor.prototype, '__inner_state__', {
+        Object.defineProperty( Ctor.prototype, '__inner_state__', ({
             get : function() {
                 return getInnerState( this );
             },
-        });
+        } : Object ));
       }
 }: Hook),
   });

--- a/backend/types.js
+++ b/backend/types.js
@@ -80,6 +80,7 @@ export type Helpers = {
 };
 
 export type Handler = (data: any) => void;
+export type InnerStateInspector = (data: any) => any;
 
 export type Hook = {
   _renderers: {[key: string]: ReactRenderer},
@@ -91,4 +92,5 @@ export type Hook = {
   on: (evt: string, handler: Handler) => void,
   off: (evt: string, handler: Handler) => void,
   reactDevtoolsAgent?: ?Object,
+  addInnerStateInspector: ( Ctor : Function, handler : InnerStateInspector ) => void;
 };

--- a/backend/types.js
+++ b/backend/types.js
@@ -92,5 +92,5 @@ export type Hook = {
   on: (evt: string, handler: Handler) => void,
   off: (evt: string, handler: Handler) => void,
   reactDevtoolsAgent?: ?Object,
-  addInnerStateInspector: ( Ctor : Function, handler : InnerStateInspector ) => void;
+  addInnerStateInspector: ( Ctor : Function, handler : InnerStateInspector, skipIfDefined? : boolean ) => void;
 };


### PR DESCRIPTION
General problem is that sometimes developers are using data objects which are more sophisticated than raw JS objects and arrays. Typically, these objects are represented as some facade class at the top level holding an actual state inside. Navigating through such an objects in props as well as in state is clumsy and the property inspector is almost unusable.

There is a number of issues on this topic (https://github.com/facebook/react-devtools/issues/83, https://github.com/facebook/react-devtools/issues/52). And there was an attempt to solve it in the PR specifically for ImmutableJS: https://github.com/facebook/react-devtools/pull/149

In this PR I attempt to solve the problem in the way that it would be easy for data framework developers to customize the appearance of data objects in the inspector. I'm doing it to make [NestedReact](https://github.com/Volicon/NestedReact) models and collections look good in the inspector, but it's trivial to do it for any other data library including ImmutableJS (which I can do as well to resolve that pool of duplicate issues as soon as this PR will be accepted).

Idea is to attach state inspector functions to the object's prototype, which will take an object instance and return plain JS object or array (whatever is appropriate for the particular case). Whenever an object has state inspector it will be used to transform its state. Using BackboneJS as an example, something like this needs to be done to make models and collections look good:

```javascript
if (__REACT_DEVTOOLS_GLOBAL_HOOK__) {
  const { addInnerStateInspector } = __REACT_DEVTOOLS_GLOBAL_HOOK__;
  if (typeof addInnerStateInspector === 'function') {
    addInnerStateInspector( Backbone.Model, x => x.attributes );
    addInnerStateInspector( Backbone.Collection, x => x.models );
  }
}
```

Another example - `Date` instances currently appears as an empty object (https://github.com/facebook/react-devtools/issues/388). Which is [fixed by this PR](https://github.com/facebook/react-devtools/pull/469/files#diff-2b80787c27b4170cbf31cebaa24ced44R13) in the following way:

```javascript
addInnerStateInspector( Date, ( x : Date ) => ({
   local : `${ x.toDateString() } ${ x.toTimeString() }`,
   iso : x.toISOString(),
   timestamp : x.getTime(),
});
```

This API can be used [internally to improve the appearance of built-in JS classes](https://github.com/facebook/react-devtools/pull/469/files#diff-2b80787c27b4170cbf31cebaa24ced44R12), by data framework developers to make their custom classes appear well, and by regular developers as well.

In the case of the more sophisticated data structure, the corresponding raw JS representation can be calculated inside of the inspector functions and memorized in the data object's instance (which will work perfectly in case of ImmutableJS).

P.S.: One more issue this PR resolves (https://github.com/facebook/react-devtools/issues/390) is an exception being thrown when you're trying to inspect an object with `get prop(){...}` calculated properties defined on the prototype.