### PR TITLE
Enable multiprocess mode in Firefox

### DIFF
--- a/shells/firefox/package.json
+++ b/shells/firefox/package.json
@@ -10,6 +10,7 @@
   },
   "license": "BSD-3-Clause",
   "permissions": {
-    "private-browsing": true
+    "private-browsing": true,
+    "multiprocess": true
   }
 }


### PR DESCRIPTION
See #429 for discussion.

Not supporting multiprocess mode literally means "Firefox UI and all tabs run on the same CPU" which is really bad. The comments suggest that the add-on seems to work fine if multiprocess mode is forcefully enabled so this change should not break anything.