### PR TITLE
Hack around displayName issues in FB products (Simple)

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -12,6 +12,7 @@
 
 import type {DataType} from './types';
 var copyWithSet = require('./copyWithSet');
+var getDisplayName = require('./getDisplayName');
 
 /**
  * Convert a react internal instance to a sanitized data object.
@@ -88,7 +89,7 @@ function getData(element: Object): DataType {
       nodeType = 'Text';
       text = element._stringText;
     } else {
-      name = type.displayName || type.name || 'Unknown';
+      name = getDisplayName(type);
     }
   }
 

--- a/backend/getData012.js
+++ b/backend/getData012.js
@@ -12,6 +12,7 @@
 
 import type {DataType} from './types';
 var copyWithSet = require('./copyWithSet');
+var getDisplayName = require('./getDisplayName');
 
 function getData012(element: Object): DataType {
   var children = null;

--- a/backend/getData012.js
+++ b/backend/getData012.js
@@ -12,7 +12,6 @@
 
 import type {DataType} from './types';
 var copyWithSet = require('./copyWithSet');
-var getDisplayName = require('./getDisplayName');
 
 function getData012(element: Object): DataType {
   var children = null;

--- a/backend/getDataFiber.js
+++ b/backend/getDataFiber.js
@@ -12,6 +12,7 @@
 
 import type {DataType} from './types';
 var copyWithSet = require('./copyWithSet');
+var getDisplayName = require('./getDisplayName');
 var {
   FunctionalComponent,
   ClassComponent,
@@ -43,7 +44,7 @@ function getDataFiber(fiber: Object, getOpaqueNode: (fiber: Object) => Object): 
     case FunctionalComponent:
     case ClassComponent:
       nodeType = 'Composite';
-      name = fiber.type.displayName || fiber.type.name;
+      name = getDisplayName(fiber.type);
       publicInstance = fiber.stateNode;
       props = fiber.memoizedProps;
       state = fiber.memoizedState;

--- a/backend/getDisplayName.js
+++ b/backend/getDisplayName.js
@@ -11,15 +11,6 @@
 'use strict';
 
 const FB_MODULE_RE = /^(.*) \[from (.*)\]$/;
-
-// Hack: base class names are hardcoded because of internal FB transform that puts
-// displayName on all modules. It resulted in displayName of React base classes shadowing
-// actual ES6 class names. We can remove the hack if we use flat bundles on www, or
-// if we stop automatically putting displayName on every exported function.
-// We are using a regex because we also want to fix names like
-// Connect(ReactComponent [from ReactComponent]) to be just Connect() for lack of better alternative.
-const BASE_CLASS_NAMES_RE = /React(Pure)?Component \[from React(Pure)?Component\]/g;
-
 const cachedDisplayNames = new WeakMap();
 
 function getDisplayName(type: Function): string {
@@ -27,11 +18,7 @@ function getDisplayName(type: Function): string {
     return cachedDisplayNames.get(type);
   }
 
-  let displayName =
-    (type.displayName || '').replace(BASE_CLASS_NAMES_RE, '') ||
-    type.name ||
-    'Unknown';
-
+  let displayName = type.displayName || type.name || 'Unknown';
   // Facebook-specific hack to turn "Image [from Image.react]" into just "Image".
   // We need displayName with module name for error reports but it clutters the DevTools.
   const match = displayName.match(FB_MODULE_RE);

--- a/backend/getDisplayName.js
+++ b/backend/getDisplayName.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const FB_MODULE_RE = /^(.*) \[from (.*)\]$/;
+const cachedDisplayNames = new WeakMap();
+
+function getDisplayName(type: Function): string {
+  if (cachedDisplayNames.has(type)) {
+    return cachedDisplayNames.get(type);
+  }
+
+  let displayName = (
+    (type.hasOwnProperty('displayName') && type.displayName) ||
+    (type.hasOwnProperty('name') && type.name) ||
+    (type.displayName || type.name) ||
+    'Unknown'
+  );
+  // Facebook-specific hack to turn "Image [from Image.react]" into just "Image".
+  // We need displayName with module name for error reports but it clutters the DevTools.
+  const match = displayName.match(FB_MODULE_RE);
+  if (match) {
+    const componentName = match[1];
+    const moduleName = match[2];
+    if (componentName && moduleName) {
+      if (
+        moduleName === componentName ||
+        moduleName.startsWith(componentName + '.')
+      ) {
+        displayName = componentName;
+      }
+    }
+  }
+
+  cachedDisplayNames.set(type, displayName);
+  return displayName;
+}
+
+module.exports = getDisplayName;


### PR DESCRIPTION
Same purpose as #482, but much less hacky.

This will work best, but it requires that we also move `ReactComponent` and `ReactPureComponent` exports behind an object so that they don't get a `displayName` internally (https://github.com/facebook/react/pull/8918).