### PR TITLE
[Electron] Don't attach highlighter on React Native

### DIFF
--- a/shells/electron/src/embed.js
+++ b/shells/electron/src/embed.js
@@ -13,9 +13,12 @@
 var globalHook = require('../../../backend/installGlobalHook');
 globalHook(window);
 var websocketConnect = require('../../../backend/websocketConnect');
-var setupHighlighter = require('../../../frontend/Highlighter/setup');
 
 websocketConnect('ws://localhost:8097/');
-window.__REACT_DEVTOOLS_GLOBAL_HOOK__.on('react-devtools', agent => {
-  setupHighlighter(agent);
-});
+
+if (window.document) {
+  window.__REACT_DEVTOOLS_GLOBAL_HOOK__.on('react-devtools', agent => {
+    var setupHighlighter = require('../../../frontend/Highlighter/setup');
+    setupHighlighter(agent);
+  });
+}


### PR DESCRIPTION
This fixes an issue I'm seeing trying to hook up electron DevTools to RN.

<img width="432" alt="screen shot 2017-02-04 at 21 13 15" src="https://cloud.githubusercontent.com/assets/810438/22621602/49d8ae64-eb1f-11e6-8d9d-3f61273fbf0f.png">
