### PR TITLE
Add installation information for Opera users

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The official extensions represent the current stable release.
 - [Firefox extension](https://addons.mozilla.org/firefox/addon/react-devtools/)
 - Standalone app (coming soon)
 
+Opera users can [enable Chrome extensions](https://addons.opera.com/extensions/details/download-chrome-extension-9/) and then install the [Chrome extension](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi).
+
 If you inspect an element or launch the developer tools on a React page, you
 should see an extra tab called **React** in the inspector.
 


### PR DESCRIPTION
All Chrome extensions work natively on Opera, but the Chrome webstore checks the useragent string before it shows the download button. This instructs Opera users how they can enable the Chrome webstore for Opera, and thus use the official Chrome release.

Auto-updating and everything works.

I quickly wrote this down while #178 seems to have a low priority.