### PR TITLE
use idiomatic syntax for npm scripts commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "BSD-3-Clause",
   "repository": "facebook/react-devtools",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
+    "lint": "eslint .",
     "test": "node --harmony ./node_modules/.bin/jest",
     "typecheck": "flow check"
   },


### PR DESCRIPTION
An insignificant change, but it kind of confused me when I glanced at the `scripts` section. Made me wonder if there was any reason for writing out command paths explicitly, but as I see these commands are just for linting and testing within the repository itself, so the current code is superfluous. An idiomatic npm way is to just use the names of the commands and the local package will be used by default.