### PR TITLE
[Electron] Install Relay hook

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -25,12 +25,14 @@ if (!window.performance) {
 
 var Agent = require('../../../agent/Agent');
 var Bridge = require('../../../agent/Bridge');
-var installGlobalHook = require('../../../backend/installGlobalHook.js');
+var installGlobalHook = require('../../../backend/installGlobalHook');
+var installRelayHook = require('../../../plugins/Relay/installRelayHook');
 var inject = require('../../../agent/inject');
 var setupRNStyle = require('../../../plugins/ReactNativeStyle/setupBackend');
 var setupRelay = require('../../../plugins/Relay/backend');
 
 installGlobalHook(window);
+installRelayHook(window);
 
 if (window.document) {
   window.__REACT_DEVTOOLS_GLOBAL_HOOK__.on('react-devtools', agent => {


### PR DESCRIPTION
@frantic noticed Relay apps are crashing the Electron version of DevTools. Seems like Relay assigns the internals, but they are never wrapped because we haven't installed the hook.

This should fix it by injecting the Relay hook, like we do in Chrome and FF backends.