### PR TITLE
[Electron] Fix plugin cleanup

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -116,6 +116,8 @@ function setupBackend(wall, resolveRNStyle) {
     if (agent) {
       agent.emit('shutdown');
     }
+    // This appears necessary for plugin (e.g. Relay) cleanup.
+    window.__REACT_DEVTOOLS_GLOBAL_HOOK__.emit('shutdown');
     bridge = null;
     agent = null;
     console.log('closing devtools');


### PR DESCRIPTION
This appears necessary for plugin (e.g. Relay) cleanup.
Otherwise I'm getting this error if I refresh the Electron shell while the app is running:

<img width="310" alt="screen shot 2017-02-10 at 16 56 39" src="https://cloud.githubusercontent.com/assets/810438/22837800/10d57de6-efba-11e6-9d49-cf6ec748bafe.png">
