### PR TITLE
[Electron] Don't reconnect inactive apps

### DIFF
--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -59,7 +59,7 @@
                 <h2>Waiting for React to connect…</h2>
                 <div>
                     <h4>React Native</h4>
-                    <div>Your app will connect automatically in a few seconds.</div>
+                    <div>The active app will automatically connect in a few seconds.</div>
                     <br />
                     <h4>React DOM</h4>
                     <div>


### PR DESCRIPTION
I noticed two apps running on the same simulator were fighting for the shell.
The symptom is abrupt reconnection right after establishing a connection.

The problem was that both apps were retrying websocket connection every two seconds, and thus potentially stealing the DevTools from each other, depending on who did it first.

While in a perfect world we might want to reconnect to the active app immediately, for now I'm taking a simpler approach of letting the host environment specify whether the app is active so that we can use this information to bail out early (but still try to reconnect later in case we "win" the next time).