### PR TITLE
[Electron] Add missing ws server.close()

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -154,6 +154,7 @@ function startServer(port = 8097) {
       connected = false;
       onDisconnected();
       clearTimeout(restartTimeout);
+      server.close();
       httpServer.close();
     },
   };


### PR DESCRIPTION
Currently the client socket not closed when called `standalone.close()`, it only closed http.