### PR TITLE
Avoid `forward slash` key handle when typing on contentEditable element

### DIFF
--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -57,6 +57,7 @@ class SearchPane extends React.Component {
     if (
       e.keyCode === 191 && // forward slash
       e.target.nodeName !== 'INPUT' &&
+      !e.target.isContentEditable &&
       this.input
     ) {
       this.input.focus();


### PR DESCRIPTION
It's not affect the current extension. In case of I use `contentEditable` div and  `react-devtools-core/standalone` together, it will break the `/` input on div.