### PR TITLE
Allow reassignment of the relay install hook

### DIFF
--- a/plugins/Relay/installRelayHook.js
+++ b/plugins/Relay/installRelayHook.js
@@ -132,6 +132,7 @@ function installRelayHook(window: Object) {
 
   var _relayInternals = null;
   Object.defineProperty(hook, '_relayInternals', ({
+    writable: true,
     set: function(relayInternals) {
       _relayInternals = instrumentRelayRequests(relayInternals);
     },


### PR DESCRIPTION
Lets the property be reassigned, so other consumers beside the devtools can instrument relay.

I realize this is mostly secret, but It's super helpful as a general instrumentation hook. In particular I'm tying into this to improve e2e testing. Moving tests along when Relay is done making requests is a good bit nicer then arbitrary `.sleep()` commands.

:)