### PR TITLE
Breadcrump - adding scroll and max-height

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -72,6 +72,8 @@ var styles = {
     listStyle: 'none',
     padding: 0,
     margin: 0,
+    maxHeight: '80px',
+    overflow: 'scroll',
   },
 
   selected: {


### PR DESCRIPTION
Fix for https://github.com/facebook/react-devtools/issues/481
This approach is the simplest. There will be a maximum of 4 breadcrumb rows and scroll will appear if needed.
For testing I used this [branch](https://github.com/mskec/react-devtools/tree/example-breadcrumb-scroll). I'm not sure if it makes sense to commit that example in master.

More complicated approach would be to create top/bottom `SplitPane` similar like there is left/right.