### PR TITLE
Revert "Modify for-in loop to use Object.getOwnPropertyNames, surfacing enume…"

### DIFF
--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -83,15 +83,9 @@ function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<str
     };
   }
   var res = {};
-  var names = Object.getOwnPropertyNames(data);
-  var name;
-
-  for (var nameIndex = 0; nameIndex < names.length; nameIndex++) {
-    name = names[nameIndex];
-
+  for (var name in data) {
     res[name] = dehydrate(data[name], cleaned, path.concat([name]), level + 1);
   }
-
   return res;
 }
 


### PR DESCRIPTION
Reverts facebook/react-devtools#376

This is causing issues for React users because `this.props.ref` and `this.props.key` are implemented as non-enumerable getters that show warnings. This code triggers those warnings.

A reasonable path forward is not to evaluate getters until requested (I think Chrome does that?)
For now, I'm reverting to solve the immediate issue.