### PR TITLE
Fix issue #472: Stack checkboxes in settings pane

### DIFF
--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -167,7 +167,7 @@ var styles = {
   input: {
     flex: 1,
     fontSize: '18px',
-    padding: '5px 10px',
+    padding: '5px 0px 5px 10px',
     border: 'none',
     transition: 'border-top-color .2s ease, background-color .2s ease',
     borderTop: '1px solid #ccc',

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -31,6 +31,7 @@ var styles = {
     backgroundColor: '#efefef',
     padding: '2px 4px',
     display: 'flex',
+    flexWrap: 'wrap',
     flexShrink: 0,
     position: 'relative',
   },

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -102,7 +102,7 @@ var styles = {
   leftPane: {
     display: 'flex',
     marginRight: -3,
-    minWidth: 0,
+    minWidth: '255px',
     flex: 1,
   },
 };


### PR DESCRIPTION
Before:
![8afb9c04-dbfb-11e6-8b79-36e9d0203b97](https://cloud.githubusercontent.com/assets/1720093/23001930/d87a93aa-f3b5-11e6-8fb0-3ec6cb0a2780.png)

After:
![Items now stack when you resize window](https://cloud.githubusercontent.com/assets/1720093/23001884/6b0a10a2-f3b5-11e6-9075-3df667ad89da.gif)
)

Wasn't certain what y'alls wanted to happen here/how important being able to expand the sidebar to 100% was important, so I threw on a `min-width` and a `flex-wrap`.