### PR TITLE
Fix line highlighting when scrolling horizontally

### DIFF
--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -298,6 +298,7 @@ var styles = {
   // in case we need them later, and the corresponding divs refernce them. But
   // I could remove them if desired.
   container: {
+    flexShrink: 0,
   },
 
   children: {

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -73,7 +73,7 @@ class Node extends React.Component {
 
     if (node.get('nodeType') === 'Wrapper') {
       return (
-        <span style={styles.wrappedNodeContainer}>
+        <span>
           {children.map(child =>
             <WrappedNode key={child} id={child} depth={this.props.depth} />
           )}
@@ -297,12 +297,7 @@ var styles = {
   // TODO(jared): how do people feel about empty style rules? I put them here
   // in case we need them later, and the corresponding divs refernce them. But
   // I could remove them if desired.
-  wrappedNodeContainer: {
-    display: 'flex',
-  },
-
   container: {
-    flex: '1',
   },
 
   children: {

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -54,13 +54,15 @@ class TreeView extends React.Component {
       } else {
         return (
           <div style={styles.container}>
-            <span>
+            <div ref={n => this.node = n} style={styles.scroll}>
+              <div style={styles.scrollContents}>
               Waiting for roots to load...
               {this.props.reload &&
                 <span>
                   to reload the inspector <button onClick={this.props.reload}> click here</button>
                 </span>}
-            </span>
+              </div>
+            </div>
           </div>
         );
       }
@@ -69,10 +71,14 @@ class TreeView extends React.Component {
     if (this.props.searching && this.props.roots.count() > MAX_SEARCH_ROOTS) {
       return (
         <div style={styles.container}>
-          {this.props.roots.slice(0, MAX_SEARCH_ROOTS).map(id => (
-            <Node key={id} id={id} depth={0} />
-          )).toJS()}
-          <span>Some results not shown. Narrow your search criteria to find them</span>
+          <div ref={n => this.node = n} style={styles.scroll}>
+            <div style={styles.scrollContents}>
+              {this.props.roots.slice(0, MAX_SEARCH_ROOTS).map(id => (
+                <Node key={id} id={id} depth={0} />
+              )).toJS()}
+              <span>Some results not shown. Narrow your search criteria to find them</span>
+            </div>
+          </div>
         </div>
       );
     }
@@ -80,9 +86,11 @@ class TreeView extends React.Component {
     return (
       <div style={styles.container}>
         <div ref={n => this.node = n} style={styles.scroll}>
-          {this.props.roots.map(id => (
-            <Node key={id} id={id} depth={0} />
-          )).toJS()}
+          <div style={styles.scrollContents}>
+            {this.props.roots.map(id => (
+              <Node key={id} id={id} depth={0} />
+            )).toJS()}
+          </div>
         </div>
         <Breadcrumb />
       </div>
@@ -108,11 +116,21 @@ var styles = {
     MozUserSelect: 'none',
     userSelect: 'none',
   },
+
   scroll: {
     padding: '3px 0',
     overflow: 'auto',
     minHeight: 0,
     flex: 1,
+    display: 'flex',
+    alignItems: 'flex-start',
+  },
+
+  scrollContents: {
+    flexDirection: 'column',
+    flex: 1,
+    display: 'flex',
+    alignItems: 'stretch',
   },
 };
 


### PR DESCRIPTION
Fixes #240, replaces #513.

Turns out flexbox in the presence of scrolling is a weird beast.
Having "flex-direction: column" doesn't mix well with filling the width while
horizontally scrolling.
Therefore, we use `flex-direction: row` with a `flex: 1` child, and the child
has `flex-direction: column` and `align-items: stretch`.

### Test Plan:
rebuild in `shells/plain`, get it running (open up `shells/plain/index.html`),
and shrink the tree view's width to be small enough that you get some
horizontal scrolling when things are expanded.

Verify that:
- when all is collapsed & there's not horizontal scrolling, the highlight is
  full-width
- when things are expanded and there's horizontal scrolling, the highlight
  extends all the way to the right of the inner content.

For good measure, go into `tests/example/target.js` and add another react root at the bottom.

![image](https://cloud.githubusercontent.com/assets/112170/23005341/307b3bf6-f3b9-11e6-8ce2-24aa9fc0681a.png)

![image](https://cloud.githubusercontent.com/assets/112170/23005358/45aa8bda-f3b9-11e6-8341-d1cd9f9da503.png)
