### PR TITLE
Removed duplicated css margin property in plain shell index.html file

### DIFF
--- a/shells/plain/index.html
+++ b/shells/plain/index.html
@@ -22,7 +22,6 @@
                 left: 0;
                 right: 0;
                 bottom: 0;
-                margin: 0;
                 padding: 0;
             }
         </style>

--- a/shells/plain/index.html
+++ b/shells/plain/index.html
@@ -14,7 +14,6 @@
                 height: 400px;
             }
             body {
-                margin: 0;
                 display: flex;
                 flex-direction: column;
                 position: absolute;
@@ -22,6 +21,7 @@
                 left: 0;
                 right: 0;
                 bottom: 0;
+                margin: 0;
                 padding: 0;
             }
         </style>


### PR DESCRIPTION
It's my first (hopefully not last) contribution to react-devtools so it has to be a massive change, right?

Anyway, there was a duplicated `margin` in `shells/plain/index.html` and it's gone now. All is well.