### PR TITLE
Added displaying all elements in a sparse array

### DIFF
--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -37,10 +37,11 @@ class DataView extends React.Component {
 
   render() {
     var data = this.props.data;
+    var isArray = Array.isArray(data);
     if (!data) {
       return <div style={styles.missing}>null</div>;
     }
-    var names = Object.keys(data);
+    var names = !isArray ? Object.keys(data) : [...data.keys()];
     if (!this.props.noSort) {
       names.sort(alphanumericSort);
     }
@@ -48,7 +49,7 @@ class DataView extends React.Component {
     if (!names.length) {
       return (
         <div style={styles.empty}>
-          {Array.isArray(data) ? 'Empty array' : 'Empty object'}
+          {isArray ? 'Empty array' : 'Empty object'}
         </div>
       );
     }

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -35,8 +35,8 @@ type DataViewProps = {
 class DataView extends React.Component {
   props: DataViewProps;
 
-  parseSparseArray(arr) {
-    var acc = [];
+  parseSparseArray(arr: Object) {
+    var acc: Array<any> = [];
     var length = arr.length;
     var numOfUndefsInRow = 0;
     var pushUndefValsNumber = () => acc.push('undefined x ' + numOfUndefsInRow);

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -39,17 +39,16 @@ class DataView extends React.Component {
     var acc: Array<any> = [];
     var length = arr.length;
     var numOfUndefsInRow = 0;
-    var pushUndefValsNumber = () => acc.push('undefined x ' + numOfUndefsInRow);
 
     for (var i = 0; i < length; ++i) {
-      if (arr[i] === undefined) {
+      if (!arr.hasOwnProperty(i)) {
         numOfUndefsInRow++;
         if (i === length - 1) {
-          pushUndefValsNumber();
+          acc.push('undefined x ' + numOfUndefsInRow);
         }
       } else {
         if (numOfUndefsInRow) {
-          pushUndefValsNumber();
+          acc.push('undefined x ' + numOfUndefsInRow);
         }
         numOfUndefsInRow = 0;
         acc.push(i);
@@ -66,10 +65,9 @@ class DataView extends React.Component {
 
     var isArray = Array.isArray(data);
     if (isArray) {
-      var itemCounter = 0;
-      data.forEach(() => ++itemCounter);
+        var realItemCount = data.reduce((acc) => {return ++acc});
     }
-    var isSparseArray = isArray && data.length !== itemCounter;
+    var isSparseArray = isArray && data.length !== realItemCount;
     var names = !isSparseArray ? Object.keys(data) : this.parseSparseArray(data);
     if (!this.props.noSort && !isSparseArray) {
       names.sort(alphanumericSort);

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -35,26 +35,30 @@ type DataViewProps = {
 class DataView extends React.Component {
   props: DataViewProps;
 
-  parseSparseArray(arr: Object) {
-    var acc: Array<any> = [];
-    var length = arr.length;
-    var numOfUndefsInRow = 0;
+  renderSparseArrayHole(count: number, key: string) {
+    return (
+      <li key={key}>
+        <div style={styles.head}>
+          <div style={assign({}, styles.name, styles.sparseArrayFiller)}>
+            undefined × {count}
+          </div>
+        </div>
+      </li>
+    );
+  }
 
-    for (var i = 0; i < length; ++i) {
-      if (!arr.hasOwnProperty(i)) {
-        numOfUndefsInRow++;
-        if (i === length - 1) {
-          acc.push('undefined x ' + numOfUndefsInRow);
-        }
-      } else {
-        if (numOfUndefsInRow) {
-          acc.push('undefined x ' + numOfUndefsInRow);
-        }
-        numOfUndefsInRow = 0;
-        acc.push(i);
-      }
-    }
-    return acc;
+  renderItem(name: string, key: string) {
+    return (
+      <DataItem
+        key={key}
+        name={name}
+        path={this.props.path.concat([name])}
+        startOpen={this.props.startOpen}
+        inspect={this.props.inspect}
+        showMenu={this.props.showMenu}
+        readOnly={this.props.readOnly}
+        value={this.props.data[name]} />
+    );
   }
 
   render() {
@@ -64,17 +68,40 @@ class DataView extends React.Component {
     }
 
     var isArray = Array.isArray(data);
+    var elements = [];
     if (isArray) {
-      var realItemCount = data.reduce(acc => ++acc);
-    }
-    var isSparseArray = isArray && data.length !== realItemCount;
-    var names = !isSparseArray ? Object.keys(data) : this.parseSparseArray(data);
-    if (!this.props.noSort && !isSparseArray) {
-      names.sort(alphanumericSort);
+      // Iterate over array, filling holes with special items
+      var lastIndex = -1;
+      data.forEach((item, i) => {
+        if (lastIndex < i - 1) {
+          // Have we skipped over a hole?
+          var holeCount = (i - 1) - lastIndex;
+          elements.push(
+            this.renderSparseArrayHole(holeCount, i + '-hole')
+          );
+        }
+        elements.push(this.renderItem(i, i));
+        lastIndex = i;
+      });
+      if (lastIndex < data.length - 1) {
+        // Is there a hole at the end?
+        var holeCount = (data.length - 1) - lastIndex;
+        elements.push(
+          this.renderSparseArrayHole(holeCount, lastIndex + '-hole')
+        );
+      }
+    } else {
+      // Iterate over a regular object
+      var names = Object.keys(data);
+      if (!this.props.noSort) {
+        names.sort(alphanumericSort);
+      }
+      names.forEach((name, i) => {
+        elements.push(this.renderItem(name, name));
+      });
     }
 
-    var path = this.props.path;
-    if (!names.length) {
+    if (!elements.length) {
       return (
         <div style={styles.empty}>
           {isArray ? 'Empty array' : 'Empty object'}
@@ -86,9 +113,9 @@ class DataView extends React.Component {
       <ul style={styles.container}>
         {data[consts.proto] &&
           <DataItem
-            name={'__proto__'}
-            path={path.concat(['__proto__'])}
             key={'__proto__'}
+            name={'__proto__'}
+            path={this.props.path.concat(['__proto__'])}
             startOpen={this.props.startOpen}
             inspect={this.props.inspect}
             showMenu={this.props.showMenu}
@@ -96,27 +123,7 @@ class DataView extends React.Component {
             value={this.props.data[consts.proto]}
           />}
 
-        {names.map((name, i) => (
-          this.props.data.hasOwnProperty(name) ? (
-            <DataItem
-              name={name}
-              path={path.concat([name])}
-              key={i}
-              startOpen={this.props.startOpen}
-              inspect={this.props.inspect}
-              showMenu={this.props.showMenu}
-              readOnly={this.props.readOnly}
-              value={this.props.data[name]}
-            />
-          ) : (
-            <li>
-              <div style={styles.head}>
-                <div style={assign({}, styles.name, styles.sparseArrayFiller)}>
-                  {name}
-                </div>
-              </div>
-            </li>
-        )))}
+        {elements}
       </ul>
     );
   }

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -65,7 +65,7 @@ class DataView extends React.Component {
 
     var isArray = Array.isArray(data);
     if (isArray) {
-        var realItemCount = data.reduce((acc) => {return ++acc});
+      var realItemCount = data.reduce(acc => ++acc);
     }
     var isSparseArray = isArray && data.length !== realItemCount;
     var names = !isSparseArray ? Object.keys(data) : this.parseSparseArray(data);

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -35,16 +35,42 @@ type DataViewProps = {
 class DataView extends React.Component {
   props: DataViewProps;
 
+  parseSparseArray(arr) {
+    var acc = [];
+    var length = arr.length;
+    var numOfUndefsInRow = 0;
+    var pushUndefValsNumber = () => acc.push('undefined x ' + numOfUndefsInRow);
+
+    for (var i = 0; i < length; ++i) {
+      if (arr[i] === undefined) {
+        numOfUndefsInRow++;
+        if (i === length - 1) {
+          pushUndefValsNumber();
+        }
+      } else {
+        if (numOfUndefsInRow) {
+          pushUndefValsNumber();
+        }
+        numOfUndefsInRow = 0;
+        acc.push(i);
+      }
+    }
+    return acc;
+  }
+
   render() {
     var data = this.props.data;
-    var isArray = Array.isArray(data);
     if (!data) {
-      return <div style={styles.missing}>null</div>;
+        return <div style={styles.missing}>null</div>;
     }
-    var names = !isArray ? Object.keys(data) : [...data.keys()];
-    if (!this.props.noSort) {
+
+    var isArray = Array.isArray(data);
+    var isSparseArray = isArray && data.length !== data.reduce(acc => ++acc);
+    var names = !isSparseArray ? Object.keys(data) : this.parseSparseArray(data);
+    if (!this.props.noSort && !isSparseArray) {
       names.sort(alphanumericSort);
     }
+
     var path = this.props.path;
     if (!names.length) {
       return (
@@ -72,7 +98,7 @@ class DataView extends React.Component {
           <DataItem
             name={name}
             path={path.concat([name])}
-            key={name}
+            key={i}
             startOpen={this.props.startOpen}
             inspect={this.props.inspect}
             showMenu={this.props.showMenu}

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -97,18 +97,26 @@ class DataView extends React.Component {
           />}
 
         {names.map((name, i) => (
-          <DataItem
-            name={name}
-            path={path.concat([name])}
-            key={i}
-            isSparseArrayFiller={isSparseArray && this.props.data[name] === undefined}
-            startOpen={this.props.startOpen}
-            inspect={this.props.inspect}
-            showMenu={this.props.showMenu}
-            readOnly={this.props.readOnly}
-            value={this.props.data[name]}
-          />
-        ))}
+          this.props.data.hasOwnProperty(name) ? (
+            <DataItem
+              name={name}
+              path={path.concat([name])}
+              key={i}
+              startOpen={this.props.startOpen}
+              inspect={this.props.inspect}
+              showMenu={this.props.showMenu}
+              readOnly={this.props.readOnly}
+              value={this.props.data[name]}
+            />
+          ) : (
+            <li>
+              <div style={styles.head}>
+                <div style={assign({}, styles.name, styles.sparseArrayFiller)}>
+                  {name}
+                </div>
+              </div>
+            </li>
+        )))}
       </ul>
     );
   }
@@ -117,7 +125,6 @@ class DataView extends React.Component {
 class DataItem extends React.Component {
   props: {
     path: Array<string>,
-    isSparseArrayFiller?: boolean,
     inspect: Inspect,
     showMenu: ShowMenu,
     startOpen?: boolean,
@@ -227,27 +234,21 @@ class DataItem extends React.Component {
         <div style={styles.head}>
           {opener}
           <div
-            style={assign({},
-              styles.name,
-              complex && styles.complexName,
-              this.props.isSparseArrayFiller && styles.sparseArrayFiller)
-            }
+            style={assign({}, styles.name, complex && styles.complexName)}
             onClick={this.toggleOpen.bind(this)}
           >
-            {this.props.name}{!this.props.isSparseArrayFiller && ':'}
+            {this.props.name}:
           </div>
-          {!this.props.isSparseArrayFiller && (
-            <div
-              onContextMenu={e => {
-                if (typeof this.props.showMenu === 'function') {
-                  this.props.showMenu(e, this.props.value, this.props.path, this.props.name);
-                }
-              }}
-              style={styles.preview}
-            >
-              {preview}
-            </div>
-          )}
+          <div
+            onContextMenu={e => {
+              if (typeof this.props.showMenu === 'function') {
+                this.props.showMenu(e, this.props.value, this.props.path, this.props.name);
+              }
+            }}
+            style={styles.preview}
+          >
+            {preview}
+          </div>
         </div>
         {children}
       </li>
@@ -299,7 +300,7 @@ var styles = {
   },
 
   collapsedArrow: {
-    borderColor: 'transparent transparent transparent #555',
+    borderColor: 'transparent transparent transparent rgb(110, 110, 110)',
     borderStyle: 'solid',
     borderWidth: '4px 0 4px 7px',
     display: 'inline-block',
@@ -308,7 +309,7 @@ var styles = {
   },
 
   expandedArrow: {
-    borderColor: '#555 transparent transparent transparent',
+    borderColor: 'rgb(110, 110, 110) transparent transparent transparent',
     borderStyle: 'solid',
     borderWidth: '7px 4px 0 4px',
     display: 'inline-block',


### PR DESCRIPTION
This fixes the issue described in https://github.com/facebook/react-devtools/issues/349

Currently when inspecting a component which has a sparse array passed in as a prop the user will only see the elements that are defined, the rest is omitted.

I've ensured that the inspector will show the sparse array in its entirety (although I'd argue against using sparse arrays at all), see the gif below for reference:

![react_dev_tools](https://cloud.githubusercontent.com/assets/16646517/23044683/89150e2a-f4a1-11e6-833f-deaf8b501763.gif)
