### PR TITLE
Support specify maximum connection attempt

### DIFF
--- a/packages/react-devtools-core/README.md
+++ b/packages/react-devtools-core/README.md
@@ -1,18 +1,18 @@
 # `react-devtools-core`
 
-A standalone React DevTools implementation.  
+A standalone React DevTools implementation.
 
-This is a low-level package.  
+This is a low-level package.
 **If you're looking for the Electron app you can run, use `react-devtools` package instead.**
 
 ## Exports
 
 ## `require('react-devtools-core').connectToDevTools(options)`
 
-This is similar to `require('react-devtools')` in another package but providing more control.  
+This is similar to `require('react-devtools')` in another package but providing more control.
 Unlike `require('react-devtools')`, it doesn't connect immediately, but exports a function.
 
-Run `connectToDevTools()` in the same context as React to set up a connection to DevTools.  
+Run `connectToDevTools()` in the same context as React to set up a connection to DevTools.
 Make sure this runs *before* any `react`, `react-dom`, or `react-native` imports.
 
 The `options` object may contain:
@@ -20,6 +20,7 @@ The `options` object may contain:
 * `host` (string), defaults to `'localhost'`.
 * `port` (number), defaults to `8097`.
 * `resolveRNStyle` (function), used by RN and `null` by default.
+* `maxConnectAttempt` (number), defaults to Number.POSITIVE_INFINITY
 
 None of the options are required.
 

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -15,6 +15,7 @@ type ConnectOptions = {
   port?: number,
   resolveRNStyle?: (style: number) => ?Object,
   isAppActive?: () => boolean,
+  maxConnectAttempt?: number
 };
 
 // TODO: why?
@@ -48,6 +49,7 @@ function connectToDevTools(options: ?ConnectOptions) {
     port = 8097,
     resolveRNStyle = null,
     isAppActive = () => true,
+    maxConnectAttempt = Number.POSITIVE_INFINITY
   } = options || {};
 
   function scheduleRetry() {
@@ -88,7 +90,9 @@ function connectToDevTools(options: ?ConnectOptions) {
   function handleClose() {
     if (!hasClosed) {
       hasClosed = true;
-      scheduleRetry();
+      if (maxConnectAttempt-- > 0) {
+        scheduleRetry();
+      }
       closeListeners.forEach(fn => fn());
     }
   }


### PR DESCRIPTION
This PR expands options for `connectToDevTools()` to support `maxConnectAttempt`, allows to specify number to retry when web socket connection attempt doesn't succeed.

This is for usecases like who doesn't install react devtools extension but use Electron based react devtools application only - those user'll see console log is filled with continuing connection attempt if devtools are not executed. In my case our application itself is Electron-based application not able to use devtools extension due to certain circumstances, would like to selectively use electron standalone devtools but also wanted to avoid repeated connection attempt as needed.
