### PR TITLE
update comparison to props key on props

### DIFF
--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -16,7 +16,7 @@ var PropVal = require('./PropVal');
 class Props extends React.Component {
   props: Object;
   shouldComponentUpdate(nextProps: Object): boolean {
-    return nextProps !== this.props;
+    return nextProps.props !== this.props.props;
   }
 
   render() {


### PR DESCRIPTION
The Props component has a key `props` on its `props`. The previous comparison was for all props passed to the component instead of checking strictly for the `props` key passed on the props object. Given that the values on this key are used in the render method, it seemed safe to assume that was the intended comparison.

This resolves issue #545 