### PR TITLE
Don’t allow expansion of empty arrays or objects

### DIFF
--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -139,8 +139,8 @@ class DataItem extends React.Component {
   isEmpty(value) {
     return (
       (Array.isArray(value) && !value.length) ||
-      (value === Object(value) && Object.keys(value).length === 0)
-    )
+      (!value[consts.type] && Object.keys(value).length === 0)
+    );
   }
 
   render() {
@@ -148,7 +148,7 @@ class DataItem extends React.Component {
     var otype = typeof data;
 
     var complex = true;
-    var isEmptyComplexValue = this.isEmpty(data)
+    var isEmptyComplexValue = this.isEmpty(data);
     var preview;
     if (otype === 'number' || otype === 'string' || data == null /* null or undefined */ || otype === 'boolean' || isEmptyComplexValue) {
       preview = (

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -136,16 +136,24 @@ class DataItem extends React.Component {
     });
   }
 
+  isEmpty(value) {
+    return (
+      (Array.isArray(value) && !value.length) ||
+      (value === Object(value) && Object.keys(value).length === 0)
+    )
+  }
+
   render() {
     var data = this.props.value;
     var otype = typeof data;
 
     var complex = true;
+    var isEmptyComplexValue = this.isEmpty(data)
     var preview;
-    if (otype === 'number' || otype === 'string' || data == null /* null or undefined */ || otype === 'boolean') {
+    if (otype === 'number' || otype === 'string' || data == null /* null or undefined */ || otype === 'boolean' || isEmptyComplexValue) {
       preview = (
         <Simple
-          readOnly={this.props.readOnly}
+          readOnly={isEmptyComplexValue || this.props.readOnly}
           path={this.props.path}
           data={data}
         />

--- a/frontend/DataView/previewComplex.js
+++ b/frontend/DataView/previewComplex.js
@@ -17,7 +17,7 @@ var valueStyles = require('../value-styles');
 
 function previewComplex(data: Object) {
   if (Array.isArray(data)) {
-    if(data.length) {
+    if (data.length) {
       return (
         <span style={valueStyles.array}>
           Array[{data.length}]
@@ -29,8 +29,9 @@ function previewComplex(data: Object) {
   }
 
   if (!data[consts.type]) {
-    if(Object.keys(data).length > 0)
+    if (Object.keys(data).length > 0) {
       return '{…}';
+    }
     return '{}';
   }
 

--- a/frontend/DataView/previewComplex.js
+++ b/frontend/DataView/previewComplex.js
@@ -17,15 +17,21 @@ var valueStyles = require('../value-styles');
 
 function previewComplex(data: Object) {
   if (Array.isArray(data)) {
-    return (
-      <span style={valueStyles.array}>
-        Array[{data.length}]
-      </span>
-    );
+    if(data.length) {
+      return (
+        <span style={valueStyles.array}>
+          Array[{data.length}]
+        </span>
+      );
+    }
+
+    return '[]';
   }
 
   if (!data[consts.type]) {
-    return '{…}';
+    if(Object.keys(data).length > 0)
+      return '{…}';
+    return '{}';
   }
 
   var type = data[consts.type];


### PR DESCRIPTION
Previously, we used to allow clicking on empty complex values, only to discover that the value was empty. Now we show it upfront.

<img width="117" alt="screen shot 2017-02-18 at 2 34 11 pm" src="https://cloud.githubusercontent.com/assets/8946207/23091975/67afd32c-f5e7-11e6-88ee-decf4bc439b7.png">
