### PR TITLE
fixes 'npm start' for 'packages/react-devtools'

### DIFF
--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -17,7 +17,7 @@
     "icons"
   ],
   "scripts": {
-    "start": "./bin.js"
+    "start": "node bin.js"
   },
   "author": "Jared Forsyth",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
was getting this error on windows
```
'.' is not recognized as an internal or external command,
operable program or batch file.

npm ERR! Windows_NT 6.3.9600
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "start"
npm ERR! node v7.4.0
npm ERR! npm  v4.0.5
npm ERR! code ELIFECYCLE
npm ERR! react-devtools@2.0.12 start: `./bin.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the react-devtools@2.0.12 start script './bin.js'.
```