### PR TITLE
Validate the source of global messages

### DIFF
--- a/shells/chrome/src/backend.js
+++ b/shells/chrome/src/backend.js
@@ -26,7 +26,7 @@ setInterval(function() {
 
 window.addEventListener('message', welcome);
 function welcome(evt) {
-  if (evt.data.source !== 'react-devtools-content-script') {
+  if (evt.source !== window || evt.data.source !== 'react-devtools-content-script') {
     return;
   }
 
@@ -40,7 +40,7 @@ function setup(hook) {
   var wall = {
     listen(fn) {
       var listener = evt => {
-        if (evt.data.source !== 'react-devtools-content-script' || !evt.data.payload) {
+        if (evt.source !== window || !evt.data || evt.data.source !== 'react-devtools-content-script' || !evt.data.payload) {
           return;
         }
         fn(evt.data.payload);

--- a/shells/chrome/src/contentScript.js
+++ b/shells/chrome/src/contentScript.js
@@ -34,7 +34,7 @@ function handleMessageFromDevtools(message) {
 }
 
 function handleMessageFromPage(evt) {
-  if (evt.data && evt.data.source === 'react-devtools-bridge') {
+  if (evt.source === window && evt.data && evt.data.source === 'react-devtools-bridge') {
     // console.log('page -> rep -> dev', evt.data);
     port.postMessage(evt.data.payload);
   }

--- a/shells/firefox/src/backend.js
+++ b/shells/firefox/src/backend.js
@@ -28,7 +28,7 @@ if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__.reactDevtoolsAgent) {
 
 window.addEventListener('message', welcome);
 function welcome(evt) {
-  if (evt.data && evt.data.source !== 'react-devtools-reporter') {
+  if (evt.source !== window || evt.data && evt.data.source !== 'react-devtools-reporter') {
     return;
   }
 
@@ -42,7 +42,7 @@ function setup() {
   var wall = {
     listen(fn) {
       var listener = evt => {
-        if (evt.data.source !== 'react-devtools-reporter' || !evt.data.payload) {
+        if (evt.source !== window || !evt.data || evt.data.source !== 'react-devtools-reporter' || !evt.data.payload) {
           return;
         }
         fn(evt.data.payload);

--- a/shells/firefox/src/contentScript.js
+++ b/shells/firefox/src/contentScript.js
@@ -36,7 +36,7 @@ function connectToBackend() {
   });
 
   window.addEventListener('message', function(evt) {
-    if (!evt.data || evt.data.source !== 'react-devtools-bridge') {
+    if (evt.source !== window || !evt.data || evt.data.source !== 'react-devtools-bridge') {
       return;
     }
 

--- a/shells/plain/backend.js
+++ b/shells/plain/backend.js
@@ -19,7 +19,11 @@ var inject = require('../../agent/inject');
 
 var wall = {
   listen(fn) {
-    window.addEventListener('message', evt => fn(evt.data));
+    window.addEventListener('message', evt => {
+      if (evt.source === window.parent) {
+        fn(evt.data);
+      }
+    });
   },
   send(data) {
     window.parent.postMessage(data, '*');

--- a/shells/plain/container.js
+++ b/shells/plain/container.js
@@ -40,7 +40,11 @@ var config = {
     inject(devtoolsSrc, () => {
       var wall = {
         listen(fn) {
-          win.parent.addEventListener('message', evt => fn(evt.data));
+          win.parent.addEventListener('message', evt => {
+            if (evt.source === win) {
+              fn(evt.data);
+            }
+          });
         },
         send(data) {
           win.postMessage(data, '*');


### PR DESCRIPTION
The global "message" event can be activated by pages from a different origin. Blindly accepting such messages is a security risk.

A message channel in React Devtools always have exactly two endpoints. At each side, the target of `postMessage` is also the expected source of the global `message` event. To resolve the security risk, I added a check to the message event handler to reject messages from unexpected sources.