### PR TITLE
Ensured that Inifnity value will be properly displayed in react dev tools

### DIFF
--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -200,6 +200,8 @@ function textToValue(txt) {
 function valueToText(value) {
   if (value === undefined) {
     return 'undefined';
+  } else if (value === Infinity) {
+    return 'Infinity';
   }
   return JSON.stringify(value);
 }

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -200,8 +200,8 @@ function textToValue(txt) {
 function valueToText(value) {
   if (value === undefined) {
     return 'undefined';
-  } else if (value === Infinity) {
-    return 'Infinity';
+  } else if (typeof value === 'number') {
+    return value.toString();
   }
   return JSON.stringify(value);
 }


### PR DESCRIPTION
This fixes the issue reported in https://github.com/facebook/react-devtools/issues/572, which is caused by the fact that `JSON.stringify(Infinity)` returns `null`.