### PR TITLE
Ensured that ellipsis will be added to very long prop names

### DIFF
--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -199,12 +199,12 @@ class DataItem extends React.Component {
             style={assign({}, styles.name, complex && styles.complexName)}
             onClick={this.toggleOpen.bind(this)}
           >
-            {this.props.name}:
+            {name}:
           </div>
           <div
             onContextMenu={e => {
               if (typeof this.props.showMenu === 'function') {
-                this.props.showMenu(e, this.props.value, this.props.path, this.props.name);
+                this.props.showMenu(e, this.props.value, this.props.path, name);
               }
             }}
             style={styles.preview}


### PR DESCRIPTION
I've noticed a bit of dead code while going through the codebase - an ellipsis was supposed to be added at the end of very long prop names, but the `name` variable created as a result of

```
     var name = this.props.name;
     if (name.length > 50) {
       name = name.slice(0, 50) + '…';
     }
```

was never used anywhere.

Before:
<img width="1118" alt="screen shot 2017-03-04 at 17 28 57" src="https://cloud.githubusercontent.com/assets/16646517/23580378/f8a1af1c-0100-11e7-9269-d0a434163fed.png">

After:
<img width="1103" alt="screen shot 2017-03-04 at 17 30 15" src="https://cloud.githubusercontent.com/assets/16646517/23580379/ff167288-0100-11e7-80bf-9d537ec7f8ac.png">

