### PR TITLE
SearchPane.js: press 'Enter' for keyboard nav

### DIFF
--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -82,6 +82,8 @@ class SearchPane extends React.Component {
 
   onKeyDown(key) {
     if (key === 'Enter' && this.input) {
+      // switch focus to tree view
+      this.input.blur();
       this.props.selectFirstSearchResult();
     }
   }


### PR DESCRIPTION
Before, pressing 'Enter' on the search pane would highlight the first
search result, but wouldn't do anything else. You had to click on the
results in order to navigate them with the arrow keys or hjkl.

Now, pressing 'Enter' on the search pane will select the results,
allowing keyboard navigation without any clicking involved.

----

gif example:

![2](https://cloud.githubusercontent.com/assets/3344958/24090547/866ee25c-0cfe-11e7-95b2-62fc52c863e4.gif)
