### PR TITLE
[React Native] Add box inspect to NativeStyler

### DIFF
--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -239,7 +239,7 @@ class Panel extends React.Component {
     var extraTabs = assign.apply(null, [{}].concat(this.plugins.map(p => p.tabs())));
     var extraPanes = [].concat(...this.plugins.map(p => p.panes()));
     if (this._store.capabilities.rnStyle) {
-      extraPanes.push(panelRNStyle(this._bridge));
+      extraPanes.push(panelRNStyle(this._bridge, this._store.capabilities.rnStyleMeasure));
     }
     return (
       <Container
@@ -284,7 +284,7 @@ Panel.childContextTypes = {
   store: React.PropTypes.object,
 };
 
-var panelRNStyle = bridge => (node, id) => {
+var panelRNStyle = (bridge, measureSupport) => (node, id) => {
   var props = node.get('props');
   if (!props || !props.style) {
     return <strong key="rnstyle">No style</strong>;
@@ -292,7 +292,7 @@ var panelRNStyle = bridge => (node, id) => {
   return (
     <div key="rnstyle">
       <h3>React Native Style Editor</h3>
-      <NativeStyler id={id} bridge={bridge} />
+      <NativeStyler id={id} bridge={bridge} measureSupport={measureSupport} />
     </div>
   );
 };

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -284,7 +284,7 @@ Panel.childContextTypes = {
   store: React.PropTypes.object,
 };
 
-var panelRNStyle = (bridge, measureSupport) => (node, id) => {
+var panelRNStyle = (bridge, supportsMeasure) => (node, id) => {
   var props = node.get('props');
   if (!props || !props.style) {
     return <strong key="rnstyle">No style</strong>;
@@ -292,7 +292,7 @@ var panelRNStyle = (bridge, measureSupport) => (node, id) => {
   return (
     <div key="rnstyle">
       <h3>React Native Style Editor</h3>
-      <NativeStyler id={id} bridge={bridge} measureSupport={measureSupport} />
+      <NativeStyler id={id} bridge={bridge} supportsMeasure={supportsMeasure} />
     </div>
   );
 };

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -104,6 +104,8 @@ class Store extends EventEmitter {
   // an object describing the capabilities of the inspected runtime.
   capabilities: {
     scroll?: boolean,
+    rnStyle?: boolean,
+    rnStyleMeasure?: boolean,
   };
 
   constructor(bridge: Bridge) {

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -14,6 +14,7 @@ type ConnectOptions = {
   host?: string,
   port?: number,
   resolveRNStyle?: (style: number) => ?Object,
+  resolveBoxStyle?: (name: string, style: Object) => ?Object,
   isAppActive?: () => boolean,
 };
 
@@ -47,6 +48,7 @@ function connectToDevTools(options: ?ConnectOptions) {
     host = 'localhost',
     port = 8097,
     resolveRNStyle = null,
+    resolveBoxStyle = null,
     isAppActive = () => true,
   } = options || {};
 
@@ -81,7 +83,7 @@ function connectToDevTools(options: ?ConnectOptions) {
         ws.send(JSON.stringify(data));
       },
     };
-    setupBackend(wall, resolveRNStyle);
+    setupBackend(wall, resolveRNStyle, resolveBoxStyle);
   };
 
   var hasClosed = false;
@@ -123,7 +125,7 @@ function connectToDevTools(options: ?ConnectOptions) {
   }
 }
 
-function setupBackend(wall, resolveRNStyle) {
+function setupBackend(wall, resolveRNStyle, resolveBoxStyle) {
   wall.onClose(() => {
     if (agent) {
       agent.emit('shutdown');
@@ -142,7 +144,7 @@ function setupBackend(wall, resolveRNStyle) {
   agent.addBridge(bridge);
 
   if (resolveRNStyle) {
-    setupRNStyle(bridge, agent, resolveRNStyle);
+    setupRNStyle(bridge, agent, resolveRNStyle, resolveBoxStyle);
   }
 
   setupRelay(bridge, agent, window.__REACT_DEVTOOLS_GLOBAL_HOOK__);

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -14,7 +14,6 @@ type ConnectOptions = {
   host?: string,
   port?: number,
   resolveRNStyle?: (style: number) => ?Object,
-  resolveBoxStyle?: (name: string, style: Object) => ?Object,
   isAppActive?: () => boolean,
 };
 
@@ -48,7 +47,6 @@ function connectToDevTools(options: ?ConnectOptions) {
     host = 'localhost',
     port = 8097,
     resolveRNStyle = null,
-    resolveBoxStyle = null,
     isAppActive = () => true,
   } = options || {};
 
@@ -83,7 +81,7 @@ function connectToDevTools(options: ?ConnectOptions) {
         ws.send(JSON.stringify(data));
       },
     };
-    setupBackend(wall, resolveRNStyle, resolveBoxStyle);
+    setupBackend(wall, resolveRNStyle);
   };
 
   var hasClosed = false;
@@ -125,7 +123,7 @@ function connectToDevTools(options: ?ConnectOptions) {
   }
 }
 
-function setupBackend(wall, resolveRNStyle, resolveBoxStyle) {
+function setupBackend(wall, resolveRNStyle) {
   wall.onClose(() => {
     if (agent) {
       agent.emit('shutdown');
@@ -140,12 +138,12 @@ function setupBackend(wall, resolveRNStyle, resolveBoxStyle) {
   var bridge = new Bridge(wall);
   var agent = new Agent(window, {
     rnStyle: !!resolveRNStyle,
-    rnStyleMeasure: !!resolveBoxStyle,
+    rnStyleMeasure: !!resolveRNStyle,
   });
   agent.addBridge(bridge);
 
   if (resolveRNStyle) {
-    setupRNStyle(bridge, agent, resolveRNStyle, resolveBoxStyle);
+    setupRNStyle(bridge, agent, resolveRNStyle);
   }
 
   setupRelay(bridge, agent, window.__REACT_DEVTOOLS_GLOBAL_HOOK__);

--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -140,6 +140,7 @@ function setupBackend(wall, resolveRNStyle, resolveBoxStyle) {
   var bridge = new Bridge(wall);
   var agent = new Agent(window, {
     rnStyle: !!resolveRNStyle,
+    rnStyleMeasure: !!resolveBoxStyle,
   });
   agent.addBridge(bridge);
 

--- a/plugins/ReactNativeStyle/BoxInspector.js
+++ b/plugins/ReactNativeStyle/BoxInspector.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+
+type Props = {
+  style: Object,
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+  margin: Object,
+  padding: Object,
+};
+
+type DefaultProps = {};
+
+type BoxProps = {
+  title: string,
+  box: {
+    top: number,
+    left: number,
+    right: number,
+    bottom: number,
+  },
+  children: React$Element,
+};
+
+var Box = (props: BoxProps) => {
+  var box = props.box;
+  return (
+    <div style={styles.box}>
+      <div style={styles.row}>
+        <span style={styles.label}>{props.title}</span>
+        <span style={styles.boxText}>{box.top}</span>
+      </div>
+      <div style={styles.row}>
+        <span style={styles.boxText}>{box.left}</span>
+        {props.children}
+        <span style={styles.boxText}>{box.right}</span>
+      </div>
+      <div style={styles.boxText}>{box.bottom}</div>
+    </div>
+  );
+};
+
+class BoxInspector extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+
+  render() {
+    const {left, top, width, height, margin, padding} = this.props;
+    return (
+      <Box title="margin" box={margin}>
+        <Box title="padding" box={padding}>
+          <div style={styles.measureLayout}>
+            <span style={styles.innerText}>
+              ({left}, {top})
+            </span>
+            <span style={styles.innerText}>
+              {width} &times; {height}
+            </span>
+          </div>
+        </Box>
+      </Box>
+    );
+  }
+}
+
+var styles = {
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  label: {
+    flex: 1,
+    color: 'rgb(255,100,0)',
+  },
+  measureLayout: {
+    display: 'flex',
+    flexDirection: 'column',
+    margin: 4,
+  },
+  innerText: {
+    color: 'blue',
+    textAlign: 'center',
+  },
+  box: {
+    padding: 8,
+    margin: 8,
+    width: 200,
+    border: '1px solid grey',
+    alignItems: 'center',
+  },
+  boxText: {
+    textAlign: 'center',
+  },
+};
+
+module.exports = BoxInspector;

--- a/plugins/ReactNativeStyle/BoxInspector.js
+++ b/plugins/ReactNativeStyle/BoxInspector.js
@@ -12,56 +12,51 @@
 
 var React = require('react');
 
-type Props = {
-  style: Object,
-  left: number,
+type BoxMeasurements = {
   top: number,
-  width: number,
-  height: number,
-  margin: Object,
-  padding: Object,
-};
+  left: number,
+  right: number,
+  bottom: number,
+}
 
-type DefaultProps = {};
-
-type BoxProps = {
+type BoxProps = BoxMeasurements & {
   title: string,
-  box: {
-    top: number,
-    left: number,
-    right: number,
-    bottom: number,
-  },
   children: React$Element,
 };
 
 var Box = (props: BoxProps) => {
-  var box = props.box;
+  var {title, children, top, left, right, bottom} = props;
   return (
     <div style={styles.box}>
       <div style={styles.row}>
-        <span style={styles.label}>{props.title}</span>
-        <span style={styles.boxText}>{box.top}</span>
+        <span style={styles.label}>{title}</span>
+        <span style={styles.boxText}>{top}</span>
       </div>
       <div style={styles.row}>
-        <span style={styles.boxText}>{box.left}</span>
-        {props.children}
-        <span style={styles.boxText}>{box.right}</span>
+        <span style={styles.boxText}>{left}</span>
+        {children}
+        <span style={styles.boxText}>{right}</span>
       </div>
-      <div style={styles.boxText}>{box.bottom}</div>
+      <div style={styles.boxText}>{bottom}</div>
     </div>
   );
 };
 
 class BoxInspector extends React.Component {
-  props: Props;
-  defaultProps: DefaultProps;
+  props: {
+    left: number,
+    top: number,
+    width: number,
+    height: number,
+    margin: BoxMeasurements,
+    padding: BoxMeasurements,
+  };
 
   render() {
     const {left, top, width, height, margin, padding} = this.props;
     return (
-      <Box title="margin" box={margin}>
-        <Box title="padding" box={padding}>
+      <Box title="margin" {...margin}>
+        <Box title="padding" {...padding}>
           <div style={styles.measureLayout}>
             <span style={styles.innerText}>
               ({left}, {top})

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -26,19 +26,19 @@ type Props = {
   // TODO: typecheck bridge interface
   bridge: any;
   id: any;
-  measureSupport: boolean;
+  supportsMeasure: boolean;
 };
 
 type DefaultProps = {};
 
 type State = {
   style: ?Object;
-  measureLayout: ?Object;
+  measuredLayout: ?Object;
 };
 
 type StyleResult = {
   style: Object;
-  measureLayout: ?Object;
+  measuredLayout: ?Object;
 };
 
 class NativeStyler extends React.Component {
@@ -49,12 +49,12 @@ class NativeStyler extends React.Component {
 
   constructor(props: Object) {
     super(props);
-    this.state = {style: null, measureLayout: null};
+    this.state = {style: null, measuredLayout: null};
   }
 
   componentWillMount() {
     this._styleGet = this._styleGet.bind(this);
-    if (this.props.measureSupport) {
+    if (this.props.supportsMeasure) {
       this.props.bridge.on('rn-style:measure', this._styleGet);
       this.props.bridge.send('rn-style:measure', this.props.id);
     } else {
@@ -65,7 +65,7 @@ class NativeStyler extends React.Component {
   }
 
   componentWillUnmount() {
-    if (this.props.measureSupport) {
+    if (this.props.supportsMeasure) {
       this.props.bridge.off('rn-style:measure', this._styleGet);
     }
   }
@@ -77,7 +77,7 @@ class NativeStyler extends React.Component {
     this.setState({style: null});
     this.props.bridge.send('rn-style:get', nextProps.id);
 
-    if (this.props.measureSupport) {
+    if (this.props.supportsMeasure) {
       this.props.bridge.send('rn-style:measure', nextProps.id);
     } else {
       this.props.bridge.call('rn-style:get', nextProps.id, style => {
@@ -87,8 +87,8 @@ class NativeStyler extends React.Component {
   }
 
   _styleGet(result: StyleResult) {
-    var {style, measureLayout} = result;
-    this.setState({style, measureLayout});
+    var {style, measuredLayout} = result;
+    this.setState({style, measuredLayout});
   }
 
   _handleStyleChange(attr: string, val: string | number) {
@@ -113,7 +113,7 @@ class NativeStyler extends React.Component {
     }
     return (
       <div style={styles.container}>
-        {this.state.measureLayout && <BoxInspector {...this.state.measureLayout} />}
+        {this.state.measuredLayout && <BoxInspector {...this.state.measuredLayout} />}
         <StyleEdit
           style={this.state.style}
           onRename={this._handleStyleRename.bind(this)}

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -12,6 +12,7 @@
 
 var React = require('react');
 var StyleEdit = require('./StyleEdit');
+var BoxInspector = require('./BoxInspector');
 
 function shallowClone(obj) {
   var nobj = {};
@@ -93,13 +94,24 @@ class NativeStyler extends React.Component {
       return <em>loading</em>;
     }
     return (
-      <StyleEdit
-        style={this.state.style}
-        onRename={this._handleStyleRename.bind(this)}
-        onChange={this._handleStyleChange.bind(this)}
-      />
+      <div style={styles.container}>
+        {this.state.measureLayout && <BoxInspector {...this.state.measureLayout} />}
+        <StyleEdit
+          style={this.state.style}
+          onRename={this._handleStyleRename.bind(this)}
+          onChange={this._handleStyleChange.bind(this)}
+        />
+      </div>
     );
   }
 }
+
+var styles = {
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'column',
+  },
+};
 
 module.exports = NativeStyler;

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -78,7 +78,6 @@ class NativeStyler extends React.Component {
       this.state.style[attr] = val;
     }
     this.props.bridge.send('rn-style:set', {id: this.props.id, attr, val});
-    this.setState({style: this.state.style});
   }
 
   _handleStyleRename(oldName: string, newName: string, val: string | number) {
@@ -86,7 +85,6 @@ class NativeStyler extends React.Component {
     delete style[oldName];
     style[newName] = val;
     this.props.bridge.send('rn-style:rename', {id: this.props.id, oldName, newName, val});
-    this.setState({style});
   }
 
   render() {

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -95,7 +95,7 @@ class NativeStyler extends React.Component {
       this.state.style[attr] = val;
     }
     this.props.bridge.send('rn-style:set', {id: this.props.id, attr, val});
-    this.setState(this.state.style);
+    this.setState({style: this.state.style});
   }
 
   _handleStyleRename(oldName: string, newName: string, val: string | number) {
@@ -103,7 +103,7 @@ class NativeStyler extends React.Component {
     delete style[oldName];
     style[newName] = val;
     this.props.bridge.send('rn-style:rename', {id: this.props.id, oldName, newName, val});
-    this.setState(this.state.style);
+    this.setState({style});
   }
 
   render() {

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -45,6 +45,7 @@ class NativeStyler extends React.Component {
   props: Props;
   defaultProps: DefaultProps;
   state: State;
+  _styleGet: (result: StyleResult) => void;
 
   constructor(props: Object) {
     super(props);
@@ -52,7 +53,7 @@ class NativeStyler extends React.Component {
   }
 
   componentWillMount() {
-    (this:any)._styleGet = this._styleGet.bind(this);
+    this._styleGet = this._styleGet.bind(this);
     if (this.props.measureSupport) {
       this.props.bridge.on('rn-style:measure', this._styleGet);
       this.props.bridge.send('rn-style:measure', this.props.id);

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -80,7 +80,7 @@ class NativeStyler extends React.Component {
     if (this.props.measureSupport) {
       this.props.bridge.send('rn-style:measure', nextProps.id);
     } else {
-      this.props.bridge.call('rn-style:get', nextProps, style => {
+      this.props.bridge.call('rn-style:get', nextProps.id, style => {
         this.setState({style});
       });
     }

--- a/plugins/ReactNativeStyle/resolveBoxStyle.js
+++ b/plugins/ReactNativeStyle/resolveBoxStyle.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+/**
+ * This is mirror from
+ * https://github.com/facebook/react-native/blob/master/Libraries/Inspector/resolveBoxStyle.js
+ *
+ * Resolve a style property into it's component parts, e.g.
+ *
+ * resolveBoxStyle('margin', {margin: 5, marginBottom: 10})
+ * ->
+ * {top: 5, left: 5, right: 5, bottom: 10}
+ *
+ * If none are set, returns false.
+ */
+function resolveBoxStyle(prefix: string, style: Object): ?Object {
+  var res = {};
+  var subs = ['top', 'left', 'bottom', 'right'];
+  var set = false;
+  subs.forEach(sub => {
+    res[sub] = style[prefix] || 0;
+  });
+  if (style[prefix]) {
+    set = true;
+  }
+  if (style[prefix + 'Vertical']) {
+    res.top = res.bottom = style[prefix + 'Vertical'];
+    set = true;
+  }
+  if (style[prefix + 'Horizontal']) {
+    res.left = res.right = style[prefix + 'Horizontal'];
+    set = true;
+  }
+  subs.forEach(sub => {
+    var val = style[prefix + capFirst(sub)];
+    if (val) {
+      res[sub] = val;
+      set = true;
+    }
+  });
+  if (!set) {
+    return null;
+  }
+  return res;
+}
+
+function capFirst(text) {
+  return text[0].toUpperCase() + text.slice(1);
+}
+
+module.exports = resolveBoxStyle;

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -68,12 +68,16 @@ function measureStyle(agent, bridge, resolveRNStyle, id) {
     var margin = (style && resolveBoxStyle('margin', style)) || blank;
     var padding = (style && resolveBoxStyle('padding', style)) || blank;
     bridge.send('rn-style:measure', {
-      id, style,
+      style,
       measureLayout: {
-        x, y,
-        width, height,
-        left, top,
-        margin, padding,
+        x,
+        y,
+        width,
+        height,
+        left,
+        top,
+        margin,
+        padding,
       },
     });
   });

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -56,13 +56,14 @@ var blank = {
 function measureStyle(agent, bridge, resolveRNStyle, resolveBoxStyle, id) {
   var node = agent.elementData.get(id);
   if (!node || !node.props) {
+    bridge.send('rn-style:measure', {});
     return;
   }
   const style = resolveRNStyle(node.props.style);
 
   var instance = node.publicInstance;
   if (!resolveBoxStyle || !instance || !instance.measure) {
-    bridge.send('rn-style:measure', { style });
+    bridge.send('rn-style:measure', {style});
     return;
   }
 

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -25,10 +25,14 @@ module.exports = function setupRNStyle(
 
   bridge.on('rn-style:rename', ({id, oldName, newName, val}) => {
     renameStyle(agent, id, oldName, newName, val);
+    // Remeasure layout
+    getStyle(agent, bridge, resolveRNStyle, resolveBoxStyle, id);
   });
 
   bridge.on('rn-style:set', ({id, attr, val}) => {
     setStyle(agent, id, attr, val);
+    // Remeasure layout
+    getStyle(agent, bridge, resolveRNStyle, resolveBoxStyle, id);
   });
 };
 

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -69,7 +69,7 @@ function measureStyle(agent, bridge, resolveRNStyle, id) {
     var padding = (style && resolveBoxStyle('padding', style)) || blank;
     bridge.send('rn-style:measure', {
       style,
-      measureLayout: {
+      measuredLayout: {
         x,
         y,
         width,

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -34,12 +34,12 @@ module.exports = function setupRNStyle(
 
   bridge.on('rn-style:rename', ({id, oldName, newName, val}) => {
     renameStyle(agent, id, oldName, newName, val);
-    measureStyle(agent, bridge, resolveRNStyle, id);
+    setTimeout(() => measureStyle(agent, bridge, resolveRNStyle, id));
   });
 
   bridge.on('rn-style:set', ({id, attr, val}) => {
     setStyle(agent, id, attr, val);
-    measureStyle(agent, bridge, resolveRNStyle, id);
+    setTimeout(() => measureStyle(agent, bridge, resolveRNStyle, id));
   });
 };
 


### PR DESCRIPTION
In React Native, it have the built-in inspector can show the component width / height / margin / padding information:

<img width="300" src="https://cloud.githubusercontent.com/assets/3001525/24093674/fb84b1ca-0d8f-11e7-80cf-801c8f5f7a3b.png">

The built-in inspector contents will hidden when we use `react-devtools`, this PR made the box inspector showing in React Native Style Editor:

<img width="1177" alt="2017-03-20 5 06 59" src="https://cloud.githubusercontent.com/assets/3001525/24093680/ff537cbe-0d8f-11e7-860d-bcb2dfd42211.png">