### PR TITLE
Ensured that React devtools icon is displayed in color

### DIFF
--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -4,6 +4,9 @@
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
   "version": "2.0.12",
   "minimum_chrome_version": "43",
+  "browser_action": {
+    "default_icon": "icons/icon48.png"
+  },
   "icons": {
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"


### PR DESCRIPTION
This solves one of the issues reported in https://github.com/facebook/react-devtools/issues/580 that is - the React devtools icon in Chrome was always greyed out.

Before:
![screen shot 2017-03-26 at 15 41 53](https://cloud.githubusercontent.com/assets/16646517/24331763/12561812-123b-11e7-958d-2d2e59e9d1a7.png)

After:
![screen shot 2017-03-26 at 15 42 28](https://cloud.githubusercontent.com/assets/16646517/24331766/17804bbe-123b-11e7-8c51-4db66fbbad02.png)
