### PR TITLE
Ensured that an empty overlay won't be displayed when hovering over a text node

### DIFF
--- a/frontend/Highlighter/Highlighter.js
+++ b/frontend/Highlighter/Highlighter.js
@@ -59,10 +59,12 @@ class Highlighter {
 
   highlight(node: DOMNode, name?: string) {
     this.removeMultiOverlay();
-    if (!this._overlay) {
-      this._overlay = new Overlay(this._win);
+    if (node.nodeType !== Node.COMMENT_NODE) {
+      if (!this._overlay) {
+        this._overlay = new Overlay(this._win);
+      }
+      this._overlay.inspect(node, name);
     }
-    this._overlay.inspect(node, name);
   }
 
   highlightMany(nodes: Array<DOMNode>) {
@@ -110,7 +112,6 @@ class Highlighter {
     evt.stopPropagation();
     evt.cancelBubble = true;
     this._onSelect(evt.target);
-    return;
   }
 
   onClick(evt: DOMEvent) {


### PR DESCRIPTION
This should solve the issue reported in https://github.com/facebook/react-devtools/issues/566. An empty `Overlay` box was displayed because `Overlay` component has default styles applied when it is created. When hovering over a text node the `inspect` function in `Overlay` component would return without adding any content and because of that user was left with an empty yellow box.

Before:
![before](https://cloud.githubusercontent.com/assets/16646517/24332482/914f8be2-1247-11e7-8ece-02db35935e61.gif)

After:
![after](https://cloud.githubusercontent.com/assets/16646517/24332487/ab06e418-1247-11e7-8a70-a2bd6fea1612.gif)
