### PR TITLE
allow standlone to listen on custom port

### DIFF
--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -78,7 +78,7 @@
             </div>
         </div>
         <script>
-            var port = 8097;
+            var port = process.env.PORT || 8097;
             var localIp = require('ip').address();
             var $ = document.querySelector.bind(document);
             function selectAll() {


### PR DESCRIPTION
There was a way to make `react-devtools-core` listen on a custom port, but no way for the frontend to start the server on that custom port!
This fixes #600 