### PR TITLE
Fix Firefox message source validation

### DIFF
--- a/shells/firefox/src/backend.js
+++ b/shells/firefox/src/backend.js
@@ -28,7 +28,7 @@ if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__.reactDevtoolsAgent) {
 
 window.addEventListener('message', welcome);
 function welcome(evt) {
-  if (evt.source !== window || evt.data && evt.data.source !== 'react-devtools-reporter') {
+  if (evt.source !== document.defaultView || evt.data && evt.data.source !== 'react-devtools-reporter') {
     return;
   }
 

--- a/shells/firefox/src/contentScript.js
+++ b/shells/firefox/src/contentScript.js
@@ -36,7 +36,7 @@ function connectToBackend() {
   });
 
   window.addEventListener('message', function(evt) {
-    if (evt.source !== window || !evt.data || evt.data.source !== 'react-devtools-bridge') {
+    if (evt.source !== document.defaultView || !evt.data || evt.data.source !== 'react-devtools-bridge') {
       return;
     }
 


### PR DESCRIPTION
#561 is too strict and doesn’t work in Debug mode for Firefox since it stubs out `window`.

We can get around it by checking against `document.defaultView` instead.
This gives us the real window.

It shouldn’t matter for other `window` references since this is the only place where we rely on referential equality.

See the discussion in https://github.com/facebook/react-devtools/pull/561#issuecomment-295364114 for more context.