### PR TITLE
Don't call walkNode for null nodes

### DIFF
--- a/backend/attachRenderer.js
+++ b/backend/attachRenderer.js
@@ -175,7 +175,9 @@ function walkRoots(roots, onMount, onRoot, isPre013) {
 function walkNode(element, onMount, isPre013) {
   var data = isPre013 ? getData012(element) : getData(element);
   if (data.children && Array.isArray(data.children)) {
-    data.children.forEach(child => walkNode(child, onMount, isPre013));
+    data.children
+      .filter(child => child !== null)
+      .forEach(child => walkNode(child, onMount, isPre013));
   }
   onMount(element, data);
 }


### PR DESCRIPTION
This fixes #584 , where the React devtools would fatally crash when a node's child was `null`. Examples of impact projects included things like react-select (at least while being rendered by inferno-compat).

Poked around a bit and this looked like the best place to put this check but it's my first exposure to the code base so feel free to send it back for rework.