### PR TITLE
Nicer color scheme

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -119,7 +119,7 @@ module.exports = decorate({
   props(store, props) {
     return {
       select: id => store.selectBreadcrumb(id),
-      hover: (id, isHovered) => store.setHover(id, isHovered),
+      hover: (id, isHovered) => store.setHover(id, isHovered, false),
       selected: store.selected,
       path: getBreadcrumbPath(store),
     };

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -567,7 +567,7 @@ var styles = {
   guidelineSelect: {
     backgroundColor: '#a9c5ef',
     opacity: 1,
-  }
+  },
 
 };
 

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -372,6 +372,11 @@ class Node extends React.Component {
     var guidelineStyle = assign(
       {
         left: leftPad.paddingLeft - 7,
+        // Bring it in front of the hovered children, but make sure
+        // hovering over parents doesn't draw on top of selected
+        // guideline even when we've selected the closing tag.
+        // When unsure, refer to how Chrome does it (it's subtle!)
+        zIndex: selected ? 1 : 0,
       },
       styles.guideline,
       this.props.hovered && styles.guidelineHover,
@@ -381,13 +386,13 @@ class Node extends React.Component {
     return (
       <div style={styles.container}>
         {head}
+        <div style={guidelineStyle} />
         <div style={styles.children}>
           {children.map(id => <WrappedNode key={id} depth={this.props.depth + 1} id={id}/>)}
         </div>
         <div ref={t => this._tail = t} style={tailStyles} {...tagEvents} onMouseDown={this.props.onSelectBottom}>
           {closeTag}
         </div>
-        <div style={guidelineStyle} />
       </div>
     );
   }
@@ -456,7 +461,7 @@ var styles = {
 
   head: {
     cursor: 'default',
-    borderTop: '1px solid #fff',
+    borderTop: '1px solid transparent',
     position: 'relative',
     display: 'flex',
   },
@@ -465,8 +470,6 @@ var styles = {
     borderRadius: 20,
   },
   headSelect: {
-    // Bring it in front of the hover guideline on parents.
-    zIndex: 1,
     borderRadius: 0,
   },
   headSelectInverted: {
@@ -477,7 +480,7 @@ var styles = {
   },
 
   tail: {
-    borderTop: '1px solid #fff',
+    borderTop: '1px solid transparent',
     cursor: 'default',
   },
 

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -75,7 +75,7 @@ class Node extends React.Component {
       return (
         <span>
           {children.map(child =>
-            <WrappedNode key={child} id={child} depth={this.props.depth} />
+            <WrappedNode key={child} id={child} depth={this.props.depth}/>
           )}
         </span>
       );
@@ -86,6 +86,8 @@ class Node extends React.Component {
     }
 
     var collapsed = node.get('collapsed');
+    var selected = this.props.selected;
+    var tagTextStyle = assign({}, styles.tagText, selected && styles.tagTextSelected);
 
     var leftPad = {
       paddingLeft: 3 + (this.props.depth + 1) * 10,
@@ -95,7 +97,7 @@ class Node extends React.Component {
       {},
       styles.head,
       this.props.hovered && styles.headHover,
-      this.props.selected && (collapsed || !this.props.isBottomTagSelected) && styles.headSelect,
+      selected && (collapsed || !this.props.isBottomTagSelected) && styles.headSelect,
       leftPad
     );
 
@@ -113,7 +115,7 @@ class Node extends React.Component {
       if (nodeType === 'Text') {
         var text = node.get('text');
         tag =
-          <span style={styles.tagText}>
+          <span style={tagTextStyle}>
             <span style={styles.openTag}>
               "
             </span>
@@ -124,7 +126,7 @@ class Node extends React.Component {
           </span>;
       } else if (nodeType === 'Empty') {
         tag =
-          <span style={styles.tagText}>
+          <span style={tagTextStyle}>
             <span style={styles.falseyLiteral}>null</span>
           </span>;
       }
@@ -139,7 +141,13 @@ class Node extends React.Component {
 
     var isCustom = nodeType === 'Composite';
 
-    var tagStyle = isCustom ? styles.customTagName : styles.tagName;
+    var topTagStyle = selected && !this.props.isBottomTagSelected ?
+      styles.selectedTagName :
+      (isCustom ? styles.customTagName : styles.tagName);
+
+    var bottomTagStyle = selected && this.props.isBottomTagSelected ?
+      styles.selectedTagName :
+      (isCustom ? styles.customTagName : styles.tagName);
 
     // Single-line tag (collapsed / simple content / no content)
     if (!children || typeof children === 'string' || !children.length) {
@@ -149,19 +157,27 @@ class Node extends React.Component {
       return (
         <div style={styles.container}>
           <div style={headStyles} ref={h => this._head = h} {...tagEvents}>
-            <span style={styles.tagText}>
+            <span style={tagTextStyle}>
               <span style={styles.openTag}>
-                <span style={tagStyle}>&lt;{name}</span>
-                {node.get('key') && <Props key="key" props={{'key': node.get('key')}}/>}
-                {node.get('ref') && <Props key="ref" props={{'ref': node.get('ref')}}/>}
-                {node.get('props') && <Props key="props" props={node.get('props')}/>}
-                {isCollapsed && <span style={tagStyle}> /</span>}
-                <span style={tagStyle}>&gt;</span>
+                <span style={topTagStyle}>&lt;{name}</span>
+                {node.get('key') &&
+                  <Props key="key" props={{'key': node.get('key')}} selected={selected}/>
+                }
+                {node.get('ref') &&
+                  <Props key="ref" props={{'ref': node.get('ref')}} selected={selected}/>
+                }
+                {node.get('props') &&
+                  <Props key="props" props={node.get('props')} selected={selected}/>
+                }
+                {isCollapsed && <span style={topTagStyle}> /</span>}
+                <span style={topTagStyle}>&gt;</span>
               </span>
               {!isCollapsed && [
-                <span key="content" style={styles.textContent}>{content}</span>,
+                <span key="content" style={styles.textContent}>
+                  {content}
+                </span>,
                 <span key="close" style={styles.closeTag}>
-                  <span style={tagStyle}>&lt;/{name}&gt;</span>
+                  <span style={topTagStyle}>&lt;/{name}&gt;</span>
                 </span>,
               ]}
             </span>
@@ -172,7 +188,7 @@ class Node extends React.Component {
 
     var closeTag = (
       <span style={styles.closeTag}>
-        <span style={tagStyle}>
+        <span style={collapsed ? topTagStyle : bottomTagStyle}>
           &lt;/{'' + node.get('name')}&gt;
         </span>
       </span>
@@ -189,12 +205,14 @@ class Node extends React.Component {
       assign(
         {},
         styles.collapsedArrow,
-        hasState && styles.collapsedArrowStateful
+        hasState && styles.collapsedArrowStateful,
+        selected && styles.collapsedArrowSelected
       ) :
       assign(
         {},
         styles.expandedArrow,
-        hasState && styles.expandedArrowStateful
+        hasState && styles.expandedArrowStateful,
+        selected && styles.expandedArrowSelected
       );
 
     var collapser =
@@ -202,21 +220,27 @@ class Node extends React.Component {
         title={hasState ? 'This component is stateful.' : null}
         onClick={this.props.onToggleCollapse} style={collapserStyle}
       >
-        <span style={arrowStyle} />
+        <span style={arrowStyle}/>
       </span>;
 
     var head = (
       <div ref={h => this._head = h} style={headStyles} {...tagEvents}>
         {collapser}
-        <span style={styles.tagText}>
+        <span style={tagTextStyle}>
           <span style={styles.openTag}>
-            <span style={tagStyle}>&lt;{'' + node.get('name')}</span>
-            {node.get('key') && <Props key="key" props={{'key': node.get('key')}}/>}
-            {node.get('ref') && <Props key="ref" props={{'ref': node.get('ref')}}/>}
-            {node.get('props') && <Props key="props" props={node.get('props')}/>}
-            <span style={tagStyle}>&gt;</span>
+            <span style={topTagStyle}>&lt;{'' + node.get('name')}</span>
+            {node.get('key') &&
+              <Props key="key" props={{'key': node.get('key')}} selected={selected}/>
+            }
+            {node.get('ref') &&
+              <Props key="ref" props={{'ref': node.get('ref')}} selected={selected}/>
+            }
+            {node.get('props') &&
+              <Props key="props" props={node.get('props')} selected={selected}/>
+            }
+            <span style={topTagStyle}>&gt;</span>
           </span>
-          {collapsed && '…'}
+          {collapsed && <span style={styles.textContent}>…</span>}
           {collapsed && closeTag}
         </span>
       </div>
@@ -234,7 +258,7 @@ class Node extends React.Component {
       {},
       styles.tail,
       this.props.hovered && styles.headHover,
-      this.props.selected && this.props.isBottomTagSelected && styles.headSelect,
+      selected && this.props.isBottomTagSelected && styles.headSelect,
       leftPad
     );
 
@@ -242,7 +266,7 @@ class Node extends React.Component {
       <div style={styles.container}>
         {head}
         <div style={styles.children}>
-          {children.map(id => <WrappedNode key={id} depth={this.props.depth + 1} id={id} />)}
+          {children.map(id => <WrappedNode key={id} depth={this.props.depth + 1} id={id}/>)}
         </div>
         <div ref={t => this._tail = t} style={tailStyles} {...tagEvents} onMouseDown={this.props.onSelectBottom}>
           {closeTag}
@@ -330,9 +354,11 @@ var styles = {
   tagName: {
     color: '#777',
   },
-
   customTagName: {
     color: 'rgb(136, 18, 128)',
+  },
+  selectedTagName: {
+    color: 'white'
   },
 
   openTag: {
@@ -342,9 +368,12 @@ var styles = {
     flex: 1,
     whiteSpace: 'nowrap',
   },
+  tagTextSelected: {
+    color: 'white'
+  },
 
   headSelect: {
-    backgroundColor: '#ccc',
+    backgroundColor: 'rgb(56, 121, 217)',
   },
 
   collapser: {
@@ -363,6 +392,9 @@ var styles = {
   collapsedArrowStateful: {
     borderColor: 'transparent transparent transparent #e55',
   },
+  collapsedArrowSelected: {
+    borderColor: 'transparent transparent transparent white',
+  },
 
   expandedArrow: {
     borderColor: '#555 transparent transparent transparent',
@@ -375,9 +407,12 @@ var styles = {
   expandedArrowStateful: {
     borderColor: '#e55 transparent transparent transparent',
   },
+  expandedArrowSelected: {
+    borderColor: 'white transparent transparent transparent',
+  },
 
   headHover: {
-    backgroundColor: '#eee',
+    backgroundColor: '#ebf2fb',
   },
 };
 

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -150,7 +150,7 @@ class Node extends React.Component {
     if (!node) {
       return;
     }
-    this.context.scrollTo(node.offsetTop, node.offsetHeight);
+    this.context.scrollTo(node);
   }
 
   render() {
@@ -180,13 +180,15 @@ class Node extends React.Component {
     var inverted = selected && isWindowFocused;
 
     var leftPad = {
-      paddingLeft: 3 + (this.props.depth + 1) * 10,
-      paddingRight: 3,
+      paddingLeft: 5 + (this.props.depth + 1) * 10,
+      paddingRight: 5,
     };
 
-    var headSelectStyle = isWindowFocused ?
-      styles.headSelectInverted :
-      styles.headSelectInactive;
+    var headSelectStyle = assign(
+      {},
+      styles.headSelect,
+      isWindowFocused ? styles.headSelectInverted : styles.headSelectInactive
+    );
 
     var headStyles = assign(
       {},
@@ -367,6 +369,15 @@ class Node extends React.Component {
       leftPad
     );
 
+    var guidelineStyle = assign(
+      {
+        left: leftPad.paddingLeft - 7,
+      },
+      styles.guideline,
+      this.props.hovered && styles.guidelineHover,
+      selected && styles.guidelineSelect,
+    );
+
     return (
       <div style={styles.container}>
         {head}
@@ -376,6 +387,7 @@ class Node extends React.Component {
         <div ref={t => this._tail = t} style={tailStyles} {...tagEvents} onMouseDown={this.props.onSelectBottom}>
           {closeTag}
         </div>
+        <div style={guidelineStyle} />
       </div>
     );
   }
@@ -424,11 +436,9 @@ var WrappedNode = decorate({
 }, Node);
 
 var styles = {
-  // TODO(jared): how do people feel about empty style rules? I put them here
-  // in case we need them later, and the corresponding divs refernce them. But
-  // I could remove them if desired.
   container: {
     flexShrink: 0,
+    position: 'relative',
   },
 
   children: {
@@ -449,6 +459,21 @@ var styles = {
     borderTop: '1px solid #fff',
     position: 'relative',
     display: 'flex',
+  },
+  headHover: {
+    backgroundColor: '#ebf2fb',
+    borderRadius: 20,
+  },
+  headSelect: {
+    // Bring it in front of the hover guideline on parents.
+    zIndex: 1,
+    borderRadius: 0,
+  },
+  headSelectInverted: {
+    backgroundColor: 'rgb(56, 121, 217)',
+  },
+  headSelectInactive: {
+    backgroundColor: 'rgb(218, 218, 218)',
   },
 
   tail: {
@@ -475,13 +500,6 @@ var styles = {
   },
   tagTextInverted: {
     color: 'white',
-  },
-
-  headSelectInverted: {
-    backgroundColor: 'rgb(56, 121, 217)',
-  },
-  headSelectInactive: {
-    backgroundColor: 'rgb(218, 218, 218)',
   },
 
   collapser: {
@@ -519,9 +537,23 @@ var styles = {
     borderColor: 'white transparent transparent transparent',
   },
 
-  headHover: {
-    backgroundColor: '#ebf2fb',
+  guideline: {
+    position: 'absolute',
+    width: '1px',
+    backgroundColor: 'rgb(230, 230, 230)',
+    top: 16,
+    bottom: 0,
+    opacity: 0,
+    willChange: 'opacity',
   },
+  guidelineHover: {
+    opacity: 1,
+  },
+  guidelineSelect: {
+    backgroundColor: '#a9c5ef',
+    opacity: 1,
+  }
+
 };
 
 module.exports = WrappedNode;

--- a/frontend/PropVal.js
+++ b/frontend/PropVal.js
@@ -22,7 +22,7 @@ class PropVal extends React.Component {
   props: {
     val: any,
     nested?: boolean,
-    selected?: boolean,
+    inverted?: boolean,
   };
   componentDidUpdate(prevProps: Object) {
     if (this.props.val === prevProps.val) {
@@ -36,17 +36,17 @@ class PropVal extends React.Component {
   }
 
   render() {
-    return previewProp(this.props.val, !!this.props.nested, !!this.props.selected);
+    return previewProp(this.props.val, !!this.props.nested, !!this.props.inverted);
   }
 }
 
-var selectedStyle = {
+var invertedStyle = {
   color: 'white',
 };
 
-function previewProp(val: any, nested: boolean, selected: boolean) {
+function previewProp(val: any, nested: boolean, inverted: boolean) {
   if (typeof val === 'number') {
-    const style = selected ? selectedStyle : valueStyles.number;
+    const style = inverted ? invertedStyle : valueStyles.number;
     return <span style={style}>{val}</span>;
   }
   if (typeof val === 'string') {
@@ -54,7 +54,7 @@ function previewProp(val: any, nested: boolean, selected: boolean) {
       val = val.slice(0, 50) + '…';
     }
 
-    const style = selected ? selectedStyle : valueStyles.string;
+    const style = inverted ? invertedStyle : valueStyles.string;
     return (
       <span style={style}>
         <span style={{ color: 'rgb(168, 148, 166)' }}>"</span>
@@ -64,71 +64,71 @@ function previewProp(val: any, nested: boolean, selected: boolean) {
     );
   }
   if (typeof val === 'boolean') {
-    const style = selected ? selectedStyle : valueStyles.bool;
+    const style = inverted ? invertedStyle : valueStyles.bool;
     return <span style={style}>{'' + val}</span>;
   }
   if (Array.isArray(val)) {
     if (nested) {
-      const style = selected ? selectedStyle : valueStyles.array;
+      const style = inverted ? invertedStyle : valueStyles.array;
       return <span style={style}>[({val.length})]</span>;
     }
-    return previewArray(val, selected);
+    return previewArray(val, inverted);
   }
   if (!val) {
-    const style = selected ? selectedStyle : valueStyles.empty;
+    const style = inverted ? invertedStyle : valueStyles.empty;
     return <span style={style}>{'' + val}</span>;
   }
   if (typeof val !== 'object') {
-    const style = selected ? selectedStyle : null;
+    const style = inverted ? invertedStyle : null;
     return <span style={style}>…</span>;
   }
 
   switch (val[consts.type]) {
     case 'date': {
-      const style = selected ? selectedStyle : valueStyles.date;
+      const style = inverted ? invertedStyle : valueStyles.date;
       return <span style={style}>{val[consts.name]}</span>;
     }
     case 'function': {
-      const style = selected ? selectedStyle : valueStyles.func;
+      const style = inverted ? invertedStyle : valueStyles.func;
       return <span style={style}>{val[consts.name] || 'fn'}()</span>;
     }
     case 'object': {
-      const style = selected ? selectedStyle : valueStyles.object;
+      const style = inverted ? invertedStyle : valueStyles.object;
       return <span style={style}>{val[consts.name] + '{…}'}</span>;
     }
     case 'array': {
-      const style = selected ? selectedStyle : null;
+      const style = inverted ? invertedStyle : null;
       return <span style={style}>Array[{val[consts.meta].length}]</span>;
     }
     case 'typed_array':
     case 'array_buffer':
     case 'data_view': {
-      const style = selected ? selectedStyle : valueStyles.object;
+      const style = inverted ? invertedStyle : valueStyles.object;
       return <span style={style}>{`${val[consts.name]}[${val[consts.meta].length}]`}</span>;
     }
     case 'iterator': {
-      const style = selected ? selectedStyle : valueStyles.object;
+      const style = inverted ? invertedStyle : valueStyles.object;
       return <span style={style}>{val[consts.name] + '(…)'}</span>;
     }
     case 'symbol': {
-      const style = selected ? selectedStyle : valueStyles.symbol;
+      const style = inverted ? invertedStyle : valueStyles.symbol;
       // the name is "Symbol(something)"
       return <span style={style}>{val[consts.name]}</span>;
     }
   }
 
   if (nested) {
-    const style = selected ? selectedStyle : null;
+    const style = inverted ? invertedStyle : null;
     return <span style={style}>{'{…}'}</span>;
   }
 
-  return previewObject(val, selected);
+  return previewObject(val, inverted);
 }
 
-function previewArray(val, selected) {
+function previewArray(val, inverted) {
   var items = {};
   val.slice(0, 3).forEach((item, i) => {
-    items['n' + i] = <PropVal val={item} nested={true} selected={selected} />;
+    items['n' + i] = <PropVal val={item} nested={true} inverted={inverted} />;
     items['c' + i] = ', ';
   });
   if (val.length > 3) {
@@ -136,7 +136,7 @@ function previewArray(val, selected) {
   } else {
     delete items['c' + (val.length - 1)];
   }
-  var style = selected ? selectedStyle : valueStyles.array;
+  var style = inverted ? invertedStyle : valueStyles.array;
   return (
     <span style={style}>
       [{createFragment(items)}]
@@ -144,14 +144,14 @@ function previewArray(val, selected) {
   );
 }
 
-function previewObject(val, selected) {
+function previewObject(val, inverted) {
   var names = Object.keys(val);
   var items = {};
-  var attrStyle = selected ? selectedStyle : valueStyles.attr;
+  var attrStyle = inverted ? invertedStyle : valueStyles.attr;
   names.slice(0, 3).forEach((name, i) => {
     items['k' + i] = <span style={attrStyle}>{name}</span>;
     items['c' + i] = ': ';
-    items['v' + i] = <PropVal val={val[name]} nested={true} selected={selected} />;
+    items['v' + i] = <PropVal val={val[name]} nested={true} inverted={inverted} />;
     items['m' + i] = ', ';
   });
   if (names.length > 3) {
@@ -159,7 +159,7 @@ function previewObject(val, selected) {
   } else {
     delete items['m' + (names.length - 1)];
   }
-  var style = selected ? selectedStyle : valueStyles.object;
+  var style = inverted ? invertedStyle : valueStyles.object;
   return (
     <span style={style}>
       {'{'}{createFragment(items)}{'}'}

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -39,7 +39,7 @@ class Props extends React.Component {
 
     names.slice(0, 3).forEach(name => {
       items.push(
-        <span key={name} style={styles.prop}>
+        <span key={'prop-' + name} style={styles.prop}>
           <span style={propNameStyle}>{name}</span>
           =
           <PropVal val={props[name]} selected={this.props.selected}/>
@@ -49,7 +49,7 @@ class Props extends React.Component {
 
     if (names.length > 3) {
       var ellipsisStyle = this.props.selected ? styles.ellipsisSelected : null;
-      items.push(<span style={ellipsisStyle}>…</span>);
+      items.push(<span key="ellipsis" style={ellipsisStyle}>…</span>);
     }
     return <span>{items}</span>;
   }

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -11,12 +11,13 @@
 'use strict';
 
 var React = require('react');
+var assign = require('object-assign');
 var PropVal = require('./PropVal');
 
 class Props extends React.Component {
   props: Object;
   shouldComponentUpdate(nextProps: Object): boolean {
-    return nextProps.props !== this.props.props;
+    return nextProps.props !== this.props.props || nextProps.selected !== this.props.selected;
   }
 
   render() {
@@ -30,30 +31,44 @@ class Props extends React.Component {
     });
 
     var items = [];
+    var propNameStyle = assign(
+      {},
+      styles.propName,
+      this.props.selected && styles.propNameSelected
+    );
+
     names.slice(0, 3).forEach(name => {
       items.push(
         <span key={name} style={styles.prop}>
-          <span style={styles.propName}>{name}</span>
+          <span style={propNameStyle}>{name}</span>
           =
-          <PropVal val={props[name]}/>
+          <PropVal val={props[name]} selected={this.props.selected}/>
         </span>
       );
     });
 
     if (names.length > 3) {
-      items.push('…');
+      var ellipsisStyle = this.props.selected ? styles.ellipsisSelected : null;
+      items.push(<span style={ellipsisStyle}>…</span>);
     }
     return <span>{items}</span>;
   }
 }
 
 var styles = {
+  ellipsisSelected: {
+    color: '#ccc',
+  },
+
   prop: {
     paddingLeft: 5,
   },
 
   propName: {
     color: '#994500',
+  },
+  propNameSelected: {
+    color: '#ccc',
   },
 };
 

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -17,7 +17,7 @@ var PropVal = require('./PropVal');
 class Props extends React.Component {
   props: Object;
   shouldComponentUpdate(nextProps: Object): boolean {
-    return nextProps.props !== this.props.props || nextProps.selected !== this.props.selected;
+    return nextProps.props !== this.props.props || nextProps.inverted !== this.props.inverted;
   }
 
   render() {
@@ -34,7 +34,7 @@ class Props extends React.Component {
     var propNameStyle = assign(
       {},
       styles.propName,
-      this.props.selected && styles.propNameSelected
+      this.props.inverted && styles.propNameInverted
     );
 
     names.slice(0, 3).forEach(name => {
@@ -42,13 +42,13 @@ class Props extends React.Component {
         <span key={'prop-' + name} style={styles.prop}>
           <span style={propNameStyle}>{name}</span>
           =
-          <PropVal val={props[name]} selected={this.props.selected}/>
+          <PropVal val={props[name]} inverted={this.props.inverted}/>
         </span>
       );
     });
 
     if (names.length > 3) {
-      var ellipsisStyle = this.props.selected ? styles.ellipsisSelected : null;
+      var ellipsisStyle = this.props.inverted ? styles.ellipsisInverted : null;
       items.push(<span key="ellipsis" style={ellipsisStyle}>…</span>);
     }
     return <span>{items}</span>;
@@ -56,7 +56,7 @@ class Props extends React.Component {
 }
 
 var styles = {
-  ellipsisSelected: {
+  ellipsisInverted: {
     color: '#ccc',
   },
 
@@ -67,7 +67,7 @@ var styles = {
   propName: {
     color: '#994500',
   },
-  propNameSelected: {
+  propNameInverted: {
     color: '#ccc',
   },
 };

--- a/frontend/SearchPane.js
+++ b/frontend/SearchPane.js
@@ -166,7 +166,7 @@ var styles = {
     right: '10px',
     top: '8px',
     color: 'white',
-    backgroundColor: 'rgb(255, 137, 137)',
+    backgroundColor: '#bbb',
     lineHeight: '0',
   },
 

--- a/frontend/SettingsCheckbox.js
+++ b/frontend/SettingsCheckbox.js
@@ -82,7 +82,7 @@ var styles = {
   },
   container: {
     WebkitUserSelect: 'none',
-    cursor: 'pointer',
+    cursor: 'default',
     display: 'inline-block',
     fontSize: '12px',
     outline: 'none',

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -65,7 +65,7 @@ const DEFAULT_PLACEHOLDER = 'Search by Component Name';
  * - toggleCollapse
  * - setProps/State/Context
  * - makeGlobal(id, path)
- * - setHover(id, isHovered)
+ * - setHover(id, isHovered, isBottomTag)
  * - selectTop(id)
  * - selectBottom(id)
  * - select(id)
@@ -92,6 +92,7 @@ class Store extends EventEmitter {
   regexState: ?ControlState;
   contextMenu: ?ContextMenu;
   hovered: ?ElementID;
+  isBottomTagHovered: boolean;
   isBottomTagSelected: boolean;
   placeholderText: string;
   refreshSearch: boolean;
@@ -121,6 +122,7 @@ class Store extends EventEmitter {
     this.selected = null;
     this.selectedTab = 'Elements';
     this.breadcrumbHead = null;
+    this.isBottomTagHovered = false;
     this.isBottomTagSelected = false;
     this.searchText = '';
     this.capabilities = {};
@@ -356,10 +358,11 @@ class Store extends EventEmitter {
     this._bridge.send('makeGlobal', {id, path});
   }
 
-  setHover(id: ElementID, isHovered: boolean) {
+  setHover(id: ElementID, isHovered: boolean, isBottomTag: boolean) {
     if (isHovered) {
       var old = this.hovered;
       this.hovered = id;
+      this.isBottomTagHovered = isBottomTag;
       if (old) {
         this.emit(old);
       }
@@ -368,6 +371,7 @@ class Store extends EventEmitter {
       this.highlight(id);
     } else if (this.hovered === id) {
       this.hideHighlight();
+      this.isBottomTagHovered = false;
     }
   }
 

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -14,14 +14,12 @@ var Breadcrumb = require('./Breadcrumb');
 var Node = require('./Node');
 var React = require('react');
 
-import type {DOMNode} from './types';
-
 var decorate = require('./decorate');
 
 var MAX_SEARCH_ROOTS = 200;
 
 class TreeView extends React.Component {
-  node: ?DOMNode;
+  node: ?HTMLElement;
 
   getChildContext() {
     return {
@@ -29,9 +27,15 @@ class TreeView extends React.Component {
     };
   }
 
-  scrollTo(val, height) {
+  scrollTo(toNode) {
     if (!this.node) {
       return;
+    }
+    var val = 0;
+    var height = toNode.offsetHeight;
+    while (toNode && this.node.contains(toNode)) {
+      val += toNode.offsetTop;
+      toNode = toNode.offsetParent;
     }
     var top = this.node.scrollTop;
     var rel = val - this.node.offsetTop;
@@ -118,7 +122,8 @@ var styles = {
   },
 
   scroll: {
-    padding: '5px',
+    paddingTop: 2,
+    paddingBottom: 2,
     overflow: 'auto',
     minHeight: 0,
     flex: 1,

--- a/frontend/detail_pane/DetailPane.js
+++ b/frontend/detail_pane/DetailPane.js
@@ -45,7 +45,6 @@ var styles = {
     userSelect: 'none',
   },
   header: {
-    backgroundColor: '#efefef',
     padding: 5,
     flexShrink: 0,
     display: 'flex',


### PR DESCRIPTION
Inspired by https://github.com/facebook/react-devtools/pull/553, I decided to revamp the colors to match what Chrome does. The main change is that the selected node is properly highlighted even on low contrast displays. Some work still pending.

Before:

![](https://d2ppvlu71ri8gs.cloudfront.net/items/1Y3e063R460o2C261Y0y/Screen%20Recording%202017-04-25%20at%2001.42%20PM.gif?v=766b79de)

After:

![](https://d2ppvlu71ri8gs.cloudfront.net/items/214218170n092k123K3J/Screen%20Recording%202017-04-25%20at%2001.41%20PM.gif?v=a6599cdc)


- [x] Change highlighting color when panel is inactive
- [x] Add vertical guide for currently selected tag pair
