### PR TITLE
Add ability to expand or collapse all the children of selected node

### DIFF
--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -63,6 +63,7 @@ const DEFAULT_PLACEHOLDER = 'Search by Component Name';
  * - hideContextMenu
  * - selectFirstSearchResult
  * - toggleCollapse
+ * - toggleAllChildrenNodes
  * - setProps/State/Context
  * - makeGlobal(id, path)
  * - setHover(id, isHovered)
@@ -340,7 +341,7 @@ class Store extends EventEmitter {
     this.emit(id);
   }
 
-  toggle(value: boolean) {
+  toggleAllChildrenNodes(value: boolean) {
     var id = this.selected;
     if (!id) {
       return;
@@ -556,7 +557,7 @@ class Store extends EventEmitter {
     if (children && children.forEach) {
       children.forEach(cid => this._toggleDeepChildren(cid, value));
     }
-    
+
   }
 
   _mountComponent(data: DataType) {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -557,7 +557,6 @@ class Store extends EventEmitter {
     if (children && children.forEach) {
       children.forEach(cid => this._toggleDeepChildren(cid, value));
     }
-
   }
 
   _mountComponent(data: DataType) {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -340,6 +340,14 @@ class Store extends EventEmitter {
     this.emit(id);
   }
 
+  toggle(value) {
+    var id = this.selected;
+    if (!id) {
+      return;
+    }
+    this._toggleDeepChildren(id, value);
+  }
+
   setProps(id: ElementID, path: Array<string>, value: any) {
     this._bridge.send('setProps', {id, path, value});
   }
@@ -533,6 +541,22 @@ class Store extends EventEmitter {
       }
       pid = this._parents.get(pid);
     }
+  }
+
+  _toggleDeepChildren(id: ElementID, value: boolean) {
+    var node = this._nodes.get(id);
+    if (!node) {
+      return;
+    }
+    if (!(node.get('collapsed') === value)) {
+      this._nodes = this._nodes.setIn([id, 'collapsed'], value);
+      this.emit(id);
+    }
+    var children = node.get('children');
+    if (children && children.forEach) {
+      children.forEach(cid => this._toggleDeepChildren(cid, value));
+    }
+    
   }
 
   _mountComponent(data: DataType) {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -340,7 +340,7 @@ class Store extends EventEmitter {
     this.emit(id);
   }
 
-  toggle(value) {
+  toggle(value: boolean) {
     var id = this.selected;
     if (!id) {
       return;

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -549,7 +549,7 @@ class Store extends EventEmitter {
     if (!node) {
       return;
     }
-    if (!(node.get('collapsed') === value)) {
+    if (node.get('collapsed') !== value) {
       this._nodes = this._nodes.setIn([id, 'collapsed'], value);
       this.emit(id);
     }

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -26,9 +26,6 @@ var keyCodes = {
   '38': 'up',
   '39': 'right',
   '40': 'down',
-
-  '69': 'expand',
-  '67': 'collapse',
 };
 
 module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) => void {
@@ -37,7 +34,7 @@ module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) 
     if (win.document.activeElement !== win.document.body) {
       return;
     }
-    if (e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) {
+    if (e.shiftKey || e.metaKey) {
       return;
     }
 
@@ -46,12 +43,15 @@ module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) 
       return;
     }
     e.preventDefault();
-    if (direction === 'expand') {
-      store.toggle(false);
+    if ((e.altKey && direction == 'right') || (e.ctrlKey && e.altKey && direction == 'right')) {
+      store.toggleAllChildrenNodes(false);
       return;
     }
-    if (direction === 'collapse') {
-      store.toggle(true);
+    if ((e.altKey && direction == 'left') || (e.ctrlKey && e.altKey && direction == 'left')) {
+      store.toggleAllChildrenNodes(true);
+      return;
+    }
+    if (e.ctrlKey || e.altKey) {
       return;
     }
     var dest = getDest(direction, store);

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -26,6 +26,9 @@ var keyCodes = {
   '38': 'up',
   '39': 'right',
   '40': 'down',
+
+  '69': 'expand',
+  '67': 'collapse',
 };
 
 module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) => void {
@@ -43,6 +46,14 @@ module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) 
       return;
     }
     e.preventDefault();
+    if (direction === 'expand') {
+      store.toggle(false);
+      return;
+    }
+    if (direction === 'collapse') {
+      store.toggle(true);
+      return;
+    }
     var dest = getDest(direction, store);
     if (!dest) {
       return;

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -43,11 +43,11 @@ module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) 
       return;
     }
     e.preventDefault();
-    if ((e.altKey && direction == 'right') || (e.ctrlKey && e.altKey && direction == 'right')) {
+    if ((e.altKey && direction === 'right') || (e.ctrlKey && e.altKey && direction === 'right')) {
       store.toggleAllChildrenNodes(false);
       return;
     }
-    if ((e.altKey && direction == 'left') || (e.ctrlKey && e.altKey && direction == 'left')) {
+    if ((e.altKey && direction === 'left') || (e.ctrlKey && e.altKey && direction === 'left')) {
       store.toggleAllChildrenNodes(true);
       return;
     }

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -43,11 +43,11 @@ module.exports = function keyboardNav(store: Store, win: Object): (e: DOMEvent) 
       return;
     }
     e.preventDefault();
-    if ((e.altKey && direction === 'right') || (e.ctrlKey && e.altKey && direction === 'right')) {
+    if (e.altKey && direction === 'right') {
       store.toggleAllChildrenNodes(false);
       return;
     }
-    if ((e.altKey && direction === 'left') || (e.ctrlKey && e.altKey && direction === 'left')) {
+    if (e.altKey && direction === 'left') {
       store.toggleAllChildrenNodes(true);
       return;
     }


### PR DESCRIPTION
Adds #591 

Took inspiration from `_revealDeep`. Not sure how efficient it is when the total nodes are large. Added shortcuts in `keyboardNav` but not sure if it is the right way to do it. This should work in all the shells.