### PR TITLE
[React Native] Fix issue with style editor empty key (#627)

### DIFF
--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -102,6 +102,10 @@ class NativeStyler extends React.Component {
   _handleStyleRename(oldName: string, newName: string, val: string | number) {
     var style = shallowClone(this.state.style);
     delete style[oldName];
+    if (newName === '') {
+      this.setState({style});
+      return;
+    }
     style[newName] = val;
     this.props.bridge.send('rn-style:rename', {id: this.props.id, oldName, newName, val});
     this.setState({style});

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -102,10 +102,6 @@ class NativeStyler extends React.Component {
   _handleStyleRename(oldName: string, newName: string, val: string | number) {
     var style = shallowClone(this.state.style);
     delete style[oldName];
-    if (newName === '') {
-      this.setState({style});
-      return;
-    }
     style[newName] = val;
     this.props.bridge.send('rn-style:rename', {id: this.props.id, oldName, newName, val});
     this.setState({style});

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -93,7 +93,10 @@ function shallowClone(obj) {
 
 function renameStyle(agent, id, oldName, newName, val) {
   var data = agent.elementData.get(id);
-  var newStyle = {[newName]: val};
+  var newStyle = {};
+  if (newName !== '') {
+    newStyle = {[newName]: val};
+  }
   if (!data || !data.updater || !data.updater.setInProps) {
     var el = agent.internalInstancesById.get(id);
     if (el && el.setNativeProps) {
@@ -109,7 +112,9 @@ function renameStyle(agent, id, oldName, newName, val) {
     if (typeof style[style.length - 1] === 'object' && !Array.isArray(style[style.length - 1])) {
       customStyle = shallowClone(style[style.length - 1]);
       delete customStyle[oldName];
-      customStyle[newName] = val;
+      if (newName !== '') {
+        customStyle[newName] = val;
+      }
       // $FlowFixMe we know that updater is not null here
       data.updater.setInProps(['style', style.length - 1], customStyle);
     } else {
@@ -121,7 +126,9 @@ function renameStyle(agent, id, oldName, newName, val) {
     if (typeof style === 'object') {
       customStyle = shallowClone(style);
       delete customStyle[oldName];
-      customStyle[newName] = val;
+      if (newName !== '') {
+        customStyle[newName] = val;
+      }
       // $FlowFixMe we know that updater is not null here
       data.updater.setInProps(['style'], customStyle);
     } else {


### PR DESCRIPTION
Added additional check for empty key (inside `_handleStyleRename` function). Now, there is no warning message about empty key in `style` object. Please, let me know if I've missed something. 