### PR TITLE
Minor UI tweaks

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -74,7 +74,7 @@ var styles = {
     padding: 0,
     margin: 0,
     maxHeight: '80px',
-    overflow: 'scroll',
+    overflow: 'auto',
   },
 
   selected: {

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -30,6 +30,7 @@ var styles = {
   container: {
     backgroundColor: '#efefef',
     padding: '5px 0 0 5px',
+    borderBottom: '1px solid rgb(204, 204, 204)',
     display: 'flex',
     flexWrap: 'wrap',
     flexShrink: 0,

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -122,8 +122,7 @@ var styles = {
   },
 
   scroll: {
-    paddingTop: 2,
-    paddingBottom: 2,
+    paddingTop: 3,
     overflow: 'auto',
     minHeight: 0,
     flex: 1,


### PR DESCRIPTION
Per @sebmarkbage feedback.

Removes the bleed of the settings panel and fixes the unnecessary always-on scroll in breadcrumbs.

Before:

<img width="1016" alt="screen shot 2017-04-27 at 6 01 58 pm" src="https://cloud.githubusercontent.com/assets/810438/25495026/a4f4e76a-2b73-11e7-939d-9246b130656e.png">


After:

<img width="1013" alt="screen shot 2017-04-27 at 6 00 07 pm" src="https://cloud.githubusercontent.com/assets/810438/25494989/7b43f366-2b73-11e7-826c-a7df3e0dd390.png">
