### PR TITLE
Tweak split pane and borders

### DIFF
--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -27,6 +27,10 @@ type State = {
 
 var IS_VERTICAL_BREAKPOINT = 500;
 
+function shouldUseVerticalLayout(window) {
+  return window.innerWidth < IS_VERTICAL_BREAKPOINT;
+}
+
 class Container extends React.Component {
   props: {
     reload: () => void,
@@ -52,14 +56,14 @@ class Container extends React.Component {
     super(props);
 
     this.state = {
-      isVertical: (window.innerWidth > IS_VERTICAL_BREAKPOINT),
+      isVertical: shouldUseVerticalLayout(window),
     };
   }
 
   componentDidMount() {
     window.addEventListener('resize', this.handleResize, false);
     this.setState({
-      isVertical: (window.innerWidth > IS_VERTICAL_BREAKPOINT),
+      isVertical: shouldUseVerticalLayout(window),
     });
   }
 
@@ -80,7 +84,7 @@ class Container extends React.Component {
     this.resizeTimeout = null;
 
     this.setState({
-      isVertical: (window.innerWidth > IS_VERTICAL_BREAKPOINT),
+      isVertical: shouldUseVerticalLayout(window),
     });
   };
 

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -162,7 +162,7 @@ function SearchIcon() {
 
 var styles = {
   container: {
-    backgroundColor: '#efefef',
+    backgroundColor: 'rgb(243, 243, 243)',
     padding: '4px 4px',
     borderBottom: '1px solid rgb(204, 204, 204)',
     display: 'flex',

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -25,10 +25,6 @@ type Props = {
   isVertical: bool,
 };
 
-type DefaultProps = {
-  isVertical: true,
-};
-
 type State = {
   moving: boolean,
   width: number,
@@ -37,7 +33,6 @@ type State = {
 
 class SplitPane extends React.Component {
   props: Props;
-  defaultProps: DefaultProps;
   state: State;
 
   constructor(props: Props) {
@@ -53,8 +48,8 @@ class SplitPane extends React.Component {
     var node = ReactDOM.findDOMNode(this);
 
     this.setState({
-      width: this.props.isVertical ? node.offsetWidth * 0.3 : node.offsetWidth * 0.6,
-      height: node.offsetHeight * 0.3,
+      width: Math.floor(node.offsetWidth * (this.props.isVertical ? 0.6 : 0.3)),
+      height: Math.floor(node.offsetHeight * 0.3),
     });
   }
 
@@ -62,25 +57,34 @@ class SplitPane extends React.Component {
     var node = ReactDOM.findDOMNode(this);
 
     this.setState(prevState => ({
-      width: !this.props.isVertical ?
+      width: this.props.isVertical ?
         prevState.width :
-        (node.offsetLeft + node.offsetWidth - x),
-      height: this.props.isVertical ?
+        Math.floor(node.offsetLeft + node.offsetWidth - x),
+      height: !this.props.isVertical ?
         prevState.height :
-        (node.offsetTop + node.offsetHeight - y),
+        Math.floor(node.offsetTop + node.offsetHeight - y),
     }));
   }
 
   render() {
-    var containerStyles = this.props.isVertical ? styles.container : styles.containerVertical;
-    var draggerStyles = this.props.isVertical ? styles.dragger : styles.draggerVertical;
+    var containerStyles = this.props.isVertical ?
+      styles.containerVertical : styles.containerHorizontal;
+    var draggerStyles = assign({}, styles.dragger,
+      this.props.isVertical ?
+        styles.draggerVertical :
+        styles.draggerHorizontal
+    );
+    var draggerInnerStyles = assign({}, styles.draggerInner,
+      this.props.isVertical ?
+        styles.draggerInnerVertical :
+        styles.draggerInnerHorizontal
+    );
     var rightStyles = assign({}, containerStyles, {
-      width: this.props.isVertical ? this.state.width : '100%',
-      height: this.props.isVertical ? '100%' : this.state.height,
+      width: this.props.isVertical ? '100%' : this.state.width,
+      height: this.props.isVertical ? this.state.height : '100%',
       flex: 'initial',
-      minHeight: 100,
+      minHeight: 120,
       minWidth: 150,
-      marginLeft: (this.props.isVertical) ? 0 : -3,
     });
     return (
       <div style={containerStyles}>
@@ -93,7 +97,7 @@ class SplitPane extends React.Component {
             onStart={() => this.setState({moving: true})}
             onMove={(x, y) => this.onMove(x, y)}
             onStop={() => this.setState({moving: false})}>
-            <div style={styles.draggerInner} />
+            <div style={draggerInnerStyles} />
           </Draggable>
           <div style={styles.rightPane}>
             {this.props.right()}
@@ -105,7 +109,7 @@ class SplitPane extends React.Component {
 }
 
 var styles = {
-  container: {
+  containerHorizontal: {
     display: 'flex',
     minWidth: 0,
     flex: 1,
@@ -119,40 +123,47 @@ var styles = {
   },
 
   dragger: {
-    padding: '0 3px',
-    cursor: 'ew-resize',
     position: 'relative',
     zIndex: 1,
+  },
+
+  draggerHorizontal: {
+    padding: '0px 3px',
+    margin: '0px -3px',
+    cursor: 'ew-resize',
   },
 
   draggerVertical: {
-    backgroundColor: '#efefef',
-    padding: '3px 0',
+    padding: '3px 0px',
+    margin: '-3px 0px',
     cursor: 'ns-resize',
-    position: 'relative',
-    zIndex: 1,
   },
 
   draggerInner: {
-    backgroundColor: '#ccc',
+    backgroundColor: 'rgb(163, 163, 163)',
+  },
+
+  draggerInnerHorizontal: {
     height: '100%',
-    width: 1,
+    width: '1px',
+  },
+
+  draggerInnerVertical: {
+    height: '1px',
+    width: '100%',
   },
 
   rightPane: {
     display: 'flex',
-    marginLeft: -3,
     width: '100%',
-    padding: 5,
+    padding: 4,
   },
 
   leftPane: {
     display: 'flex',
-    marginRight: -3,
     minWidth: '50%',
     minHeight: '50%',
     flex: 1,
-    borderBottom: '1px solid #ccc',
   },
 };
 

--- a/frontend/detail_pane/DetailPane.js
+++ b/frontend/detail_pane/DetailPane.js
@@ -46,6 +46,7 @@ var styles = {
   },
   header: {
     padding: 5,
+    maxHeight: 38,
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
Minor tweaks.

* Changed `isVertical` prop to be `true` for vertical layout (it used to be the opposite for some reason).
* Removed the extra bottom border in horizontal layout.
* Made split pane border look consistently in horizontal and vertical modes, and made it darker to differentiate from non-resizable borders.
* Tweaked background and bottom colors to match those of Chrome inspector.
* Tweaked the right pane header border to align with the left pane border when there is enough space.

Before (horizontal):

<img width="869" alt="screen shot 2017-04-28 at 1 27 15 pm" src="https://cloud.githubusercontent.com/assets/810438/25528678/e8d46c64-2c16-11e7-846d-d729ac8c40d5.png">

After (horizontal):

<img width="891" alt="screen shot 2017-04-28 at 1 39 12 pm" src="https://cloud.githubusercontent.com/assets/810438/25528992/268281bc-2c18-11e7-83b8-031c0ca67f9f.png">

Before (vertical):

<img width="453" alt="screen shot 2017-04-28 at 1 26 41 pm" src="https://cloud.githubusercontent.com/assets/810438/25528696/f71dd18e-2c16-11e7-9bef-7d0103fb01e6.png">

After (vertical):

<img width="477" alt="screen shot 2017-04-28 at 1 40 27 pm" src="https://cloud.githubusercontent.com/assets/810438/25529018/45317e88-2c18-11e7-9992-64d80a2f40ba.png">
