### PR TITLE
Improve loading and error messages

### DIFF
--- a/frontend/Loading.js
+++ b/frontend/Loading.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var Message = require('./Message');
+
+function Loading() {
+  return (
+    <Message>
+      <h2>Looking for React...</h2>
+    </Message>
+  );
+}
+
+module.exports = Loading;

--- a/frontend/Message.js
+++ b/frontend/Message.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var { sansSerif } = require('./Themes/Fonts');
+
+import type { Theme } from './types';
+
+type Props = {
+  children?: any,
+};
+type Context = {
+  theme: Theme,
+};
+
+function Message(props: Props, context: Context) {
+  const { theme } = context;
+  return (
+    <div style={messageStyle(theme)}>
+      {props.children}
+    </div>
+  );
+}
+
+Message.contextTypes = {
+  theme: React.PropTypes.object.isRequired,
+};
+
+const messageStyle = (theme: Theme) => ({
+  fontFamily: sansSerif.family,
+  fontSize: sansSerif.sizes.large,
+  textAlign: 'center',
+  padding: 30,
+  flex: 1,
+
+  // This color is hard-coded to match app.html and standalone.js
+  // Without it, the loading headers change colors and look weird
+  color: '#aaa',
+});
+
+module.exports = Message;

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -268,7 +268,14 @@ class Panel extends React.Component {
   }
 
   render() {
+    if (this.state.loading) {
+      return <Loading />;
+    }
+    if (!this.state.isReact) {
+      return <ReactNotDetected />;
+    }
     var theme = this._store ? this._store.theme : Themes.ChromeDefault;
+    
     if (this.state.loading) {
       // TODO: This currently shows in the Firefox shell when navigating from a
       // React page to a non-React page. We should show a better message but
@@ -282,8 +289,19 @@ class Panel extends React.Component {
     }
     if (!this.state.isReact) {
       return (
-        <div style={loadingStyle(theme)}>
-          <h2>Looking for React…</h2>
+        <div style={styles.loading}>
+          <h2>React was not detected on this page.</h2>
+          <p>
+            If this seems wrong, follow the
+            {' '}
+            <a
+              href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up"
+              target="_blank"
+            >
+              troubleshooting instructions
+            </a>
+            .
+          </p>
         </div>
       );
     }

--- a/frontend/ReactNotDetected.js
+++ b/frontend/ReactNotDetected.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var Message = require('./Message');
+
+function ReactNotDetected() {
+  return (
+    <Message>
+      <h3>React was not detected on this page.</h3>
+      <p>
+        If this seems wrong, follow the
+        {' '}
+        <a
+          style={styles.link}
+          href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up"
+          target="_blank"
+        >
+          troubleshooting instructions
+        </a>
+        .
+      </p>
+    </Message>
+  );
+}
+
+var styles = {
+  link: {
+    textDecoration: 'underline',
+  },
+};
+
+module.exports = ReactNotDetected;

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -10,11 +10,12 @@
  */
 'use strict';
 
+var React = require('react');
+var { List } = require('immutable');
 var Breadcrumb = require('./Breadcrumb');
 var Node = require('./Node');
-var React = require('react');
 var SearchUtils = require('./SearchUtils');
-
+var Message = require('./Message');
 var decorate = require('./decorate');
 var {monospace, sansSerif} = require('./Themes/Fonts');
 
@@ -22,8 +23,16 @@ import type {Theme} from './types';
 
 var MAX_SEARCH_ROOTS = 200;
 
+type Props = {
+  reload?: () => void,
+  roots: List,
+  searching: boolean,
+  searchText: string,
+};
+
 class TreeView extends React.Component {
   node: ?HTMLElement;
+  props: Props;
 
   getChildContext() {
     return {
@@ -63,17 +72,13 @@ class TreeView extends React.Component {
         );
       } else {
         return (
-          <div style={styles.container}>
-            <div ref={n => this.node = n} style={styles.scroll}>
-              <div style={styles.scrollContents}>
-              Waiting for roots to load...
-              {this.props.reload &&
-                <span>
-                  to reload the inspector <button onClick={this.props.reload}> click here</button>
-                </span>}
-              </div>
-            </div>
-          </div>
+          <Message>
+            <h3>React was detected, but no components are mounted.</h3>
+            <p>If this seems wrong, try reloading the inspector.</p>
+            {this.props.reload &&
+              <button onClick={this.props.reload}>Reload inspector</button>
+            }
+          </Message>
         );
       }
     }

--- a/shells/chrome/panel.html
+++ b/shells/chrome/panel.html
@@ -26,7 +26,7 @@
     </head>
     <body>
         <!-- main react mount point -->
-        <div id="container">Unable to find React on the page.</div>
+        <div id="container"></div>
         <script src="./build/panel.js"></script>
     </body>
 </html>

--- a/shells/firefox/panel/run.js
+++ b/shells/firefox/panel/run.js
@@ -14,6 +14,8 @@ var installGlobalHook = require('../../../backend/installGlobalHook');
 installGlobalHook(window);
 
 var Panel = require('../../../frontend/Panel');
+var Loading = require('../../../frontend/Loading');
+var ReactNotDetected = require('../../../frontend/ReactNotDetected');
 var React = require('react');
 var ReactDOM = require('react-dom');
 
@@ -37,18 +39,13 @@ window.addEventListener('message', function(event) {
     if (evt.data === 'show') {
       reload();
     } else if (evt.data === 'unload') {
-      ReactDOM.render(<h1 id="message">Looking for React...</h1>, node);
+      ReactDOM.render(<Loading />, node);
     } else if (evt.data.type === 'hasReact') {
-      if (evt.data.val) {
-        ReactDOM.render(<Panel alreadyFoundReact={true} {...config} />, node);
+      var reactDetected = evt.data.val;
+      if (!reactDetected) {
+        ReactDOM.render(<ReactNotDetected />, node);
       } else {
-        // TODO: Does this actually show up? It seems like either the "Looking
-        // for React..." at the top of this file shows, or (when navigating
-        // from a React page to a non-React one) Panel renders the same text.
-        ReactDOM.render(
-          <h1 id="message">Unable to find React on the page.</h1>,
-          node
-        );
+        ReactDOM.render(<Panel {...config} alreadyFoundReact={true} />, node);
       }
     }
   };


### PR DESCRIPTION
fixes #650 

With [`chrome.devtools`](https://developer.chrome.com/extensions/devtools_panels) you can conditionally create a panel and this is exactly what `react-devtools` does, see [main.js](https://github.com/facebook/react-devtools/blob/8667d793916a0b40a84db0ae2f47000aabf9645d/shells/chrome/src/main.js#L30) . Unfortunately, there is no API to remove a panel, so once the **React tab** has been created there is no way to remove it.

In v2.1.3 and maybe earlier, if you visit a website not using React, no **React tab** will show up *(as expected)*. If you then switch to a website using React *(in the same Chrome tab)* the **React tab** will appear *(as expected)*. If you then go back to the site without React *(in the same Chrome tab)* the **React tab** will still be visible and it shows the message "Looking for React...".

This PR changes that message to more closely align with the message from the `react-devtools` icon, see [`not-detected.html`](https://github.com/facebook/react-devtools/blob/60c3e1bfa3ce60a22f1de1f3d8ea2beda3df2a2e/shells/chrome/popups/not-detected.html). This is also similar to what the [`ember-inspector`](https://github.com/emberjs/ember-inspector/blob/1c34df9e8e7f521b380d09d6f7d3af15c650cc78/app/templates/components/not-detected.hbs#L23-L24) does.

[Prettier](https://github.com/prettier/prettier) was used to style the modified JSX.