### PR TITLE
[React Native] Keep only 3 decimals for box measurements

### DIFF
--- a/plugins/ReactNativeStyle/BoxInspector.js
+++ b/plugins/ReactNativeStyle/BoxInspector.js
@@ -30,14 +30,14 @@ var Box = (props: BoxProps) => {
     <div style={styles.box}>
       <div style={styles.row}>
         <span style={styles.label}>{title}</span>
-        <span style={styles.boxText}>{top}</span>
+        <span style={styles.boxText}>{+top.toFixed(3)}</span>
       </div>
       <div style={styles.row}>
-        <span style={styles.boxText}>{left}</span>
+        <span style={styles.boxText}>{+left.toFixed(3)}</span>
         {children}
-        <span style={styles.boxText}>{right}</span>
+        <span style={styles.boxText}>{+right.toFixed(3)}</span>
       </div>
-      <div style={styles.boxText}>{bottom}</div>
+      <div style={styles.boxText}>{+bottom.toFixed(3)}</div>
     </div>
   );
 };
@@ -59,10 +59,10 @@ class BoxInspector extends React.Component {
         <Box title="padding" {...padding}>
           <div style={styles.measureLayout}>
             <span style={styles.innerText}>
-              ({left}, {top})
+              ({+left.toFixed(3)}, {+top.toFixed(3)})
             </span>
             <span style={styles.innerText}>
-              {width} &times; {height}
+              {+width.toFixed(3)} &times; {+height.toFixed(3)}
             </span>
           </div>
         </Box>
@@ -93,7 +93,7 @@ var styles = {
   box: {
     padding: 8,
     margin: 8,
-    width: 200,
+    width: 208,
     border: '1px solid grey',
     alignItems: 'center',
   },


### PR DESCRIPTION
This PR fixed the problem of long layout measurements:

## Before

<img width="235" alt="1" src="https://cloud.githubusercontent.com/assets/3001525/25579197/2b4d7a2a-2ea8-11e7-8334-c3303ae177f2.png">

## After

<img width="229" alt="2" src="https://cloud.githubusercontent.com/assets/3001525/25579198/2c9c8a42-2ea8-11e7-93ac-a00974d35507.png">

Chrome DevTools also keep 3 decimals for box measurements.

Also increased box width (200 -> 208) because It can keep `left` and `top` on the same line.