### PR TITLE
Initial set of changes required to get Firefox WebExtension working

### DIFF
--- a/shells/chrome/main.html
+++ b/shells/chrome/main.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
     <head>
+        <meta charset="utf-8">
         <script src="./build/main.js"></script>
     </head>
     <body>

--- a/shells/chrome/panel.html
+++ b/shells/chrome/panel.html
@@ -10,6 +10,7 @@
                 left: 0;
                 right: 0;
                 bottom: 0;
+                height: 100%;
             }
             body {
                 margin: 0;

--- a/shells/chrome/panel.html
+++ b/shells/chrome/panel.html
@@ -5,24 +5,22 @@
         <style>
             html {
                 display: flex;
-                position: fixed;
-                top: 0;
-                left: 0;
-                right: 0;
-                bottom: 0;
-                height: 100%;
             }
             body {
                 margin: 0;
                 padding: 0;
                 flex: 1;
                 display: flex;
-                width: 100%;
             }
             #container {
                 display: flex;
                 flex: 1;
                 width: 100%;
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
             }
         </style>
     </head>


### PR DESCRIPTION
This is the first PR required to merge Firefox and Chrome shells as described in #524 by merging the CSS properties used in both browsers.  The next PR will need to look into the `manifest.json` changes required to maintain the minimum Firefox version required to run this WebExtension.

Without this change Firefox allows the content to expand horizontally beyond the panel to accommodate content.  Chrome appears to continue to behave in the same way as it currently does with this change.