### PR TITLE
Use fuzzy search in a search input field

### DIFF
--- a/frontend/SearchUtils.js
+++ b/frontend/SearchUtils.js
@@ -53,7 +53,68 @@ function trimSearchText(needle: string): string {
   return needle;
 }
 
+function fuzzySearch(needle: ?string, haystack: ?string): Object {
+  var output = {
+    result: false,
+    matches: [],
+  };
+
+  if (!needle || !haystack) {
+    return output;
+  }
+
+  if (needle.length > haystack.length) {
+    return output;
+  }
+
+  if (needle.length === haystack.length) {
+    output.result = needle.toLowerCase() === haystack.toLowerCase();
+
+    if (output.result) {
+      output.matches = needle.split('').map(function(item, itemIndex) {
+        return itemIndex;
+      });
+    }
+
+    return output;
+  }
+
+  var needleIdx = 0;
+  var haystackIdx = 0;
+
+  while ((needleIdx < needle.length) && (haystackIdx < haystack.length)) {
+    var needleChar = needle.charAt(needleIdx).toLowerCase();
+    var haystackChar = haystack.charAt(haystackIdx).toLowerCase();
+
+    if (needleChar === haystackChar) {
+      output.matches.push(haystackIdx);
+
+      needleIdx++;
+    }
+
+    haystackIdx++;
+  }
+
+  if (needleIdx === needle.length) {
+    output.result = true;
+  }
+
+  output.matches = output.result ? output.matches : [];
+
+  return output;
+}
+
+function isFuzzyMatch(needle: string, haystack: string): boolean {
+  return fuzzySearch(needle, haystack).result;
+}
+
+function getFuzzyMatches(needle: string, haystack: string): Array<number> {
+  return fuzzySearch(needle, haystack).matches;
+}
+
 module.exports = {
+  getFuzzyMatches,
+  isFuzzyMatch,
   isValidRegex,
   searchTextToRegExp,
   shouldSearchUseRegex,

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -231,9 +231,9 @@ class Store extends EventEmitter {
         this.searchRoots = this.searchRoots
           .filter(item => {
             var node = this.get(item);
-            return (node.get('name') && node.get('name').toLowerCase().indexOf(needle) !== -1) ||
-              (node.get('text') && node.get('text').toLowerCase().indexOf(needle) !== -1) ||
-              (typeof node.get('children') === 'string' && node.get('children').toLowerCase().indexOf(needle) !== -1);
+            return (node.get('name') && SearchUtils.isFuzzyMatch(needle, node.get('name'))) ||
+              (node.get('text') && SearchUtils.isFuzzyMatch(needle, node.get('text'))) ||
+              (typeof node.get('children') === 'string' && SearchUtils.isFuzzyMatch(needle, node.get('children')));
           });
       } else {
         this.searchRoots = this._nodes.entrySeq()

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -89,6 +89,7 @@ class TreeView extends React.Component {
                   depth={0}
                   id={id}
                   key={id}
+                  searchText={searchText}
                   searchRegExp={searchRegExp}
                 />
               )).toJS()}
@@ -108,6 +109,7 @@ class TreeView extends React.Component {
                 depth={0}
                 id={id}
                 key={id}
+                searchText={searchText}
                 searchRegExp={searchRegExp}
               />
             )).toJS()}

--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -47,7 +47,7 @@ function validString(str: string, needle: string, regex: boolean): boolean {
       return false;
     }
   }
-  return str.toLowerCase().indexOf(needle) !== -1;
+  return SearchUtils.isFuzzyMatch(needle, str);
 }
 
 module.exports = nodeMatchesText;


### PR DESCRIPTION
Component: Search input in `SettingsPane`.
Proposal: allow searching nodes by partial matches.

Current behaviour:
Input: `Higher`. Output: `<HigherOrderComponent> list`
Input: `hoc`. Output: `no results`
Input: `hdeon`. Output: `no results`

Proposed behaviour:
Input: `Higher`. Output: `<HigherOrderComponent> list`
Input: `hoc`. Output: `<HigherOrderComponent> list`
Input: `hdeon`. Output: `<HigherOrderComponent> list`

Changes results highlighting:
`hoc` => <**H**igher**O**rder**C**omponent>

This fuzzy search algo uses simple match approach (no weights for matches applied).

My questions:
1. Should I replace all `this.searchRoots` filtering with `nodeMatchesText`? See my comment in a code section.
2. Is it okay to output `<span>` for every char in a `Node.name`?
3. `flow check` outputs error about code I didn't touch. What should I do about it?