### PR TITLE
Fix a crash with React 0.14 when DevTools are open

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -71,7 +71,10 @@ function getData(internalInstance: Object): DataType {
     ref = internalInstance._currentElement.ref;
     if (typeof type === 'string') {
       name = type;
-      if (typeof internalInstance.getPublicInstance === 'function') {
+      if (
+        typeof internalInstance._domID === 'number' &&
+        typeof internalInstance.getPublicInstance === 'function'
+      ) {
         publicInstance = internalInstance.getPublicInstance();
       }
     } else if (typeof type === 'function') {

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -86,7 +86,7 @@ class PropState extends React.Component {
     var state = this.props.node.get('state');
     var context = this.props.node.get('context');
     var propsReadOnly = !this.props.node.get('canUpdate');
-    var hasDollarR = nodeType === 'Composite' || nodeType === 'Native';
+    var hasDollarR = this.props.node.get('publicInstance') != null;
 
     return (
       <DetailPane


### PR DESCRIPTION
Fixes https://github.com/facebook/react-devtools/issues/661.
The root cause was DOM not existing during initial mount (because we used to render HTML).

I do a duck type check on a only existing in React 15.