### PR TITLE
[WIP] Add dark mode

### DIFF
--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -9,6 +9,7 @@
  */
 'use strict';
 
+var DarkModeFrontendControl = require('../plugins/DarkMode/DarkModeFrontendControl');
 var TraceUpdatesFrontendControl = require('../plugins/TraceUpdates/TraceUpdatesFrontendControl');
 var ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
 var React = require('react');
@@ -97,6 +98,7 @@ class SettingsPane extends React.Component {
 
     return (
       <div style={styles.container}>
+        <DarkModeFrontendControl {...this.props} />
         <TraceUpdatesFrontendControl {...this.props} />
         
         <div style={styles.growToFill}>

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -89,6 +89,7 @@ class Store extends EventEmitter {
   _eventTimer: ?number;
 
   // Public state
+  darkModeState: ?ControlState;
   traceupdatesState: ?ControlState;
   colorizerState: ?ControlState;
   contextMenu: ?ContextMenu;
@@ -479,6 +480,13 @@ class Store extends EventEmitter {
       }
       cb();
     });
+  }
+
+  toggleDarkMode(state: ControlState) {
+    this.darkModeState = state;
+    this.emit('darkmodechange');
+    invariant(state.toJS);
+    this._bridge.send('darkmodechange', state.toJS());
   }
 
   changeTraceUpdates(state: ControlState) {

--- a/plugins/DarkMode/DarkModeFrontendControl.js
+++ b/plugins/DarkMode/DarkModeFrontendControl.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+var decorate = require('../../frontend/decorate');
+var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
+
+var Wrapped = decorate({
+  listeners() {
+    return ['darkmodechange'];
+  },
+  props(store) {
+    return {
+      state: store.darkModeState,
+      text: 'Dark Mode',
+      onChange: state => store.toggleDarkMode(state),
+    };
+  },
+}, SettingsCheckbox);
+
+module.exports = Wrapped;


### PR DESCRIPTION
This is a WIP PR to track the progress and discuss about the implementation as I'm not quite sure.

I've added the toggle and I have the color scheme in mind (I will borrow the Firefox dev edition as I find it less aggressive than the Chrome's dark one).

I have concerns on how to implement that however. I can listen to the toggle in each rendering component and a sort of `darkMode && styles.dark` in each `style` but it seems tedious and redundant.

I would like a more general way. Like a theme? https://github.com/markdalgleish/react-themeable?

In pure CSS I would add the `dark` class on the root element and style all the children with this. This is not possible with CSS in JS.

Any ideas?