### PR TITLE
Prefix cheap-module-eval-source-map with # to avoid warnings

### DIFF
--- a/shells/chrome/webpack.backend.js
+++ b/shells/chrome/webpack.backend.js
@@ -14,7 +14,7 @@ var webpack = require('webpack');
 var __DEV__ = process.env.NODE_ENV !== 'production';
 
 module.exports = {
-  devtool: __DEV__ ? 'cheap-module-eval-source-map' : false,
+  devtool: __DEV__ ? '#cheap-module-eval-source-map' : false,
   entry: {
     backend: './src/backend.js',
   },

--- a/shells/chrome/webpack.config.js
+++ b/shells/chrome/webpack.config.js
@@ -13,7 +13,7 @@ var webpack = require('webpack');
 var __DEV__ = process.env.NODE_ENV !== 'production';
 
 module.exports = {
-  devtool: __DEV__ ? 'cheap-module-eval-source-map' : false,
+  devtool: __DEV__ ? '#cheap-module-eval-source-map' : false,
   entry: {
     main: './src/main.js',
     background: './src/background.js',


### PR DESCRIPTION
Changes the source map plugin from the deprecated format `@` for declaring
the sourceMappingURL to the new format with the `#`

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_source_map_pragma

And: https://developers.google.com/web/updates/2013/06/sourceMappingURL-and-sourceURL-syntax-changed

Avoids these warnings in Firefox.  But I guess Chrome doesn't log these in the console anymore.

<img width="1012" alt="screen shot 2017-05-03 at 11 51 55 am" src="https://cloud.githubusercontent.com/assets/2134/25676492/043f0480-2ff7-11e7-8b0f-eec43cad2b5a.png">

Either way, it produces the same source map as before but with the syntax changed.