### PR TITLE
Read precached host node directly

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -108,7 +108,9 @@ function getData(internalInstance: Object): DataType {
       setInState: inst.forceUpdate && setInState.bind(null, inst),
       setInContext: inst.forceUpdate && setInContext.bind(null, inst),
     };
-    publicInstance = inst;
+    if (typeof type === 'function') {
+      publicInstance = inst;
+    }
 
     // TODO: React ART currently falls in this bucket, but this doesn't
     // actually make sense and we should clean this up after stabilizing our

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -71,11 +71,11 @@ function getData(internalInstance: Object): DataType {
     ref = internalInstance._currentElement.ref;
     if (typeof type === 'string') {
       name = type;
-      if (
-        typeof internalInstance._domID === 'number' &&
-        typeof internalInstance.getPublicInstance === 'function'
-      ) {
-        publicInstance = internalInstance.getPublicInstance();
+      if (internalInstance._nativeNode != null) {
+        publicInstance = internalInstance._nativeNode;
+      }
+      if (internalInstance._hostNode != null) {
+        publicInstance = internalInstance._hostNode;
       }
     } else if (typeof type === 'function') {
       nodeType = 'Composite';


### PR DESCRIPTION
This should fix https://github.com/facebook/react-devtools/issues/682.
We could've read the transaction but the argument order is different in different version.