### PR TITLE
Use sender.url instead of sender.tab.url

### DIFF
--- a/flow/chrome.js
+++ b/flow/chrome.js
@@ -73,9 +73,9 @@ declare var chrome: {
     },
     onMessage: {
       addListener: (fn: (req: Object, sender: {
+        url: string,
         tab: {
           id: number,
-          url: string,
         },
       }) => void) => void,
     },

--- a/shells/chrome/src/background.js
+++ b/shells/chrome/src/background.js
@@ -76,7 +76,7 @@ chrome.runtime.onMessage.addListener((req, sender) => {
     // display a custom default popup when React is *not* detected.
     // It is specified in the manifest.
     var reactBuildType = req.reactBuildType;
-    if (sender.tab.url.indexOf('facebook.github.io/react') !== -1) {
+    if (sender.url.indexOf('facebook.github.io/react') !== -1) {
       // Cheat: We use the development version on the website because
       // it is better for interactive examples. However we're going
       // to get misguided bug reports if the extension highlights it


### PR DESCRIPTION
According to the docs the URL shouldn’t be included in the tab object
unless the react-devtools has the ‘tabs’ permission.  I’m not sure why
this is working as is right now.

Fixes #679