### PR TITLE
update notifications for electron app

### DIFF
--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -11,6 +11,8 @@
 var app = require('electron').app;  // Module to control application life.
 var BrowserWindow = require('electron').BrowserWindow;  // Module to create native browser window.
 var path = require('path');
+var updateNotifier = require('update-notifier');
+var pkg = require('./package.json');
 
 var mainWindow = null;
 
@@ -19,6 +21,9 @@ app.on('window-all-closed', function() {
 });
 
 app.on('ready', function() {
+  // notify if there's an update
+  updateNotifier({pkg}).notify({defer: false});
+
   // Create the browser window.
   mainWindow = new BrowserWindow({width: 800, height: 600, icon: path.join(__dirname, 'icons/icon128.png')});
 

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -25,6 +25,7 @@
     "cross-spawn": "^5.0.1",
     "electron": "^1.4.15",
     "ip": "^1.1.4",
-    "react-devtools-core": "^2.1.7"
+    "react-devtools-core": "^2.1.7",
+    "update-notifier": "^2.1.0"
   }
 }


### PR DESCRIPTION
For #662. Simple integration of `update-notifier` without much customization. This is how the notification looks now (locally changed the package version to previous one):

![react-devtools-updatae-notifier](https://cloud.githubusercontent.com/assets/450559/25778376/c8bd59ae-3319-11e7-9d0a-e2bc891c3032.png)

Would you want to customize the message? Also, I was wondering if integrating something like `node-notifier` for native OS notification would be any better?

