### PR TITLE
Support relative paths for JSX source

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -24,6 +24,7 @@
   "author": "Jared Forsyth",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "absolute-path": "0.0.0",
     "shell-quote": "^1.6.1",
     "ws": "^2.0.3"
   },

--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -24,7 +24,6 @@
   "author": "Jared Forsyth",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "absolute-path": "0.0.0",
     "shell-quote": "^1.6.1",
     "ws": "^2.0.3"
   },

--- a/packages/react-devtools-core/src/launchEditor.js
+++ b/packages/react-devtools-core/src/launchEditor.js
@@ -11,6 +11,7 @@
 
 var fs = require('fs');
 var path = require('path');
+var isAbsolutePath = require('absolute-path');
 var child_process = require('child_process');
 var shellQuote = require('shell-quote');
 
@@ -105,8 +106,18 @@ function guessEditor() {
 }
 
 var _childProcess = null;
-function launchEditor(filePath, lineNumber) {
-  if (!fs.existsSync(filePath)) {
+function launchEditor(maybeRelativePath, lineNumber, absoluteProjectRoots) {
+  // We use relative paths at Facebook we deterministic builds.
+  // This is why our internal tooling calls React DevTools with absoluteProjectRoots.
+  // If the filename is absolute then we don't need to care about this.
+  var filePath = [maybeRelativePath]
+    .concat(
+      absoluteProjectRoots.map(root => path.join(root, maybeRelativePath))
+    ).find(combinedPath =>
+      fs.existsSync(combinedPath)
+    );
+
+  if (!filePath) {
     return;
   }
 

--- a/packages/react-devtools-core/src/launchEditor.js
+++ b/packages/react-devtools-core/src/launchEditor.js
@@ -11,7 +11,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var isAbsolutePath = require('absolute-path');
 var child_process = require('child_process');
 var shellQuote = require('shell-quote');
 

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -22,6 +22,7 @@ var ReactDOM = require('react-dom');
 
 var node = null;
 var onStatusChange = function noop() {};
+var projectRoots = [];
 var wall = null;
 
 var config = {
@@ -31,7 +32,7 @@ var config = {
     done(wall);
   },
   showElementSource(source) {
-    launchEditor(source.fileName, source.lineNumber);
+    launchEditor(source.fileName, source.lineNumber, projectRoots);
   },
 };
 
@@ -168,6 +169,10 @@ var DevtoolsUI = {
   setContentDOMNode(_node) {
     node = _node;
     return DevtoolsUI;
+  },
+
+  setProjectRoots(_projectRoots) {
+    projectRoots = _projectRoots;
   },
 
   setStatusListener(_listener) {

--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -101,6 +101,7 @@
                     '\n\nDid you run `npm run build` and `npm install` in packages/react-devtools-core?'
                 );
             }
+            window.devtools = devtools;
             window.server = devtools
                 .setContentDOMNode(document.getElementById('container'))
                 .setStatusListener(function(status) {

--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -15,6 +15,7 @@ var updateNotifier = require('update-notifier');
 var pkg = require('./package.json');
 
 var mainWindow = null;
+var argv = process.argv.slice(2);
 
 app.on('window-all-closed', function() {
   app.quit();
@@ -29,6 +30,12 @@ app.on('ready', function() {
 
   // and load the index.html of the app.
   mainWindow.loadURL('file://' + __dirname + '/app.html'); // eslint-disable-line no-path-concat
+  mainWindow.webContents.executeJavaScript(
+    // We use this so that RN can keep relative JSX __source filenames
+    // but "click to open in editor" still works. js1 passes project roots
+    // as the argument to DevTools.
+    'window.devtools.setProjectRoots(' + JSON.stringify(argv) + ')'
+  );
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {

--- a/packages/react-devtools/bin.js
+++ b/packages/react-devtools/bin.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 var electron = require('electron');
 var spawn = require('cross-spawn');
+var argv = process.argv.slice(2);
 
 var result = spawn.sync(
   electron,
-  [require.resolve('./app')],
+  [require.resolve('./app')].concat(argv),
   {stdio: 'inherit'}
 );
 process.exit(result.status);


### PR DESCRIPTION
This adds support for

```
react-devtools "/my/absolute/directory"
```

which will use it as a project root for "show in editor" (https://github.com/facebook/react-devtools/pull/588).

At Facebook we're going to give relative filenames to JSX `__source` transform for deterministic builds. So we need a way to pass the possible root directories.