### PR TITLE
Use higher contrast for selected node

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -86,7 +86,7 @@ const containerStyle = (theme: Base16Theme) => ({
 const itemStyle = (isSelected: boolean, isComposite: boolean, theme: Base16Theme) => {
   let color;
   if (isSelected) {
-    color = theme.base04;
+    color = theme.base01;
   } else if (isComposite) {
     color = theme.base0E;
   }

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -486,7 +486,7 @@ const headStyle = ({
 const jsxTagStyle = (inverted: boolean, isCustom: boolean, theme: Base16Theme) => {
   let color;
   if (inverted) {
-    color = 'inherit';
+    color = theme.base01;
   } else if (isCustom) {
     color = theme.base08;
   } else {


### PR DESCRIPTION
Currently on dark themes, the selection contrast is not very great:

<img width="302" alt="screen shot 2017-05-12 at 12 58 43 pm" src="https://cloud.githubusercontent.com/assets/810438/25997992/d981e9a2-3716-11e7-9cda-bea1fa3340f7.png">

I found that changing this improves it on most themes:

<img width="222" alt="screen shot 2017-05-12 at 12 59 09 pm" src="https://cloud.githubusercontent.com/assets/810438/25998000/e2c5d6ea-3716-11e7-8d5c-40ce1079c42f.png">

The only one suffering from this change is Materia:

<img width="589" alt="screen shot 2017-05-12 at 1 29 34 pm" src="https://cloud.githubusercontent.com/assets/810438/25998058/1a1a5f94-3717-11e7-8633-65a434173a70.png">

Can we just fix that specific case (e.g. by using a lighter selection instead of blue)?