### PR TITLE
[Electron] Add setDefaultThemeName method

### DIFF
--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -224,7 +224,10 @@ class Panel extends React.Component {
       window.addEventListener('keydown', this._keyListener);
 
       this._store.on('connected', () => {
-        this.setState({loading: false});
+        this.setState({
+          loading: false,
+          themeName: this._store.themeName,
+        });
         this.getNewSelection();
       });
       this._store.on('preferencesPanelShown', () => {

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -86,8 +86,8 @@ class PreferencesPanel extends React.Component {
               ref={this._setSelectRef}
               value={themeName}
             >
-              {!showHiddenThemes && (<option value="">Match browser</option>)}
-              {!showHiddenThemes && (<option disabled="disabled">---</option>)}
+              <option value="">{showHiddenThemes ? 'Reset' : 'Match browser'}</option>
+              <option disabled="disabled">---</option>
               {themeNames.map(key => (
                 <option key={key} value={key}>{themes[key].displayName}</option>
               ))}

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -86,8 +86,8 @@ class PreferencesPanel extends React.Component {
               ref={this._setSelectRef}
               value={themeName}
             >
-              <option value="">{showHiddenThemes ? 'Reset' : 'Match browser'}</option>
-              <option disabled="disabled">---</option>
+              {!showHiddenThemes && (<option value="">Match browser</option>)}
+              {!showHiddenThemes && (<option disabled="disabled">---</option>)}
               {themeNames.map(key => (
                 <option key={key} value={key}>{themes[key].displayName}</option>
               ))}
@@ -99,12 +99,20 @@ class PreferencesPanel extends React.Component {
               <PreviewIcon />
             </button>
           </div>
-          <button
-            onClick={hide}
-            style={styles.closeButton}
-          >
-            Close
-          </button>
+          <div style={styles.buttonBar}>
+            <button
+              onClick={this._reset}
+              style={styles.button}
+            >
+              Reset
+            </button>
+            <button
+              onClick={hide}
+              style={styles.button}
+            >
+              Close
+            </button>
+          </div>
         </div>
       );
     }
@@ -141,6 +149,11 @@ class PreferencesPanel extends React.Component {
     } else {
       hide();
     }
+  };
+
+  _reset = () => {
+    const {changeTheme} = this.props;
+    changeTheme('');
   };
 
   _onKeyUp = ({ key }) => {
@@ -230,8 +243,12 @@ const styles = {
   header: {
     margin: '0 0 0.25rem',
   },
-  closeButton: {
+  buttonBar: {
+    flexDirection: 'row',
+  },
+  button: {
     marginTop: '0.5rem',
+    marginRight: '0.25rem',
     padding: '0.25rem',
   },
   selectAndPreviewRow: {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -121,10 +121,7 @@ class Store extends EventEmitter {
   constructor(bridge: Bridge, defaultThemeName: ?string) {
     super();
 
-    // Don't accept an invalid themeName as a default.
-    this._defaultThemeName = defaultThemeName && Themes.hasOwnProperty(defaultThemeName)
-      ? defaultThemeName
-      : 'ChromeDefault';
+    this.setDefaultThemeName(defaultThemeName);
 
     this._nodes = new Map();
     this._parents = new Map();
@@ -358,6 +355,13 @@ class Store extends EventEmitter {
 
     // But allow users to restore "default" mode by selecting an empty theme.
     ThemeStore.set(themeName || null);
+  }
+
+  setDefaultThemeName(defaultThemeName: ?string) {
+    // Don't accept an invalid themeName as a default.
+    this._defaultThemeName = defaultThemeName && Themes.hasOwnProperty(defaultThemeName)
+      ? defaultThemeName
+      : 'ChromeDefault';
   }
 
   showPreferencesPanel() {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -342,10 +342,10 @@ class Store extends EventEmitter {
     this.emit('contextMenu');
   }
 
-  _safeThemeName(maybeThemeName: string, safeThemeName: string): string {
+  _safeThemeName(maybeThemeName: ?string, safeThemeName: ?string): string {
     return maybeThemeName && Themes.hasOwnProperty(maybeThemeName)
       ? maybeThemeName
-      : safeThemeName;
+      : typeof safeThemeName === 'string' ? safeThemeName : 'ChromeDefault';
   }
 
   changeTheme(themeName: ?string) {
@@ -362,7 +362,7 @@ class Store extends EventEmitter {
 
   setDefaultThemeName(defaultThemeName: ?string) {
     // Don't accept an invalid themeName as a default.
-    this._defaultThemeName = this._safeThemeName(defaultThemeName, 'ChromeDefault');
+    this._defaultThemeName = this._safeThemeName(defaultThemeName);
   }
 
   showPreferencesPanel() {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -149,10 +149,7 @@ class Store extends EventEmitter {
 
     // Don't restore an invalid themeName.
     // This guards against themes being removed or renamed.
-    const restoredThemeKey = ThemeStore.get();
-    const themeName = restoredThemeKey && Themes.hasOwnProperty(restoredThemeKey)
-      ? restoredThemeKey
-      : this._defaultThemeName;
+    const themeName = this._safeThemeName(ThemeStore.get(), this._defaultThemeName);
 
     this.theme = Themes[themeName];
     this.themeName = themeName;
@@ -345,11 +342,15 @@ class Store extends EventEmitter {
     this.emit('contextMenu');
   }
 
+  _safeThemeName(maybeThemeName: string, safeThemeName: string): string {
+    return maybeThemeName && Themes.hasOwnProperty(maybeThemeName)
+      ? maybeThemeName
+      : safeThemeName;
+  }
+
   changeTheme(themeName: ?string) {
     // Only apply a valid theme.
-    const safeThemeKey = themeName && this.themes.hasOwnProperty(themeName)
-      ? themeName
-      : this._defaultThemeName;
+    const safeThemeKey = this._safeThemeName(themeName, this._defaultThemeName);
 
     this.theme = this.themes[safeThemeKey];
     this.themeName = safeThemeKey;
@@ -361,9 +362,7 @@ class Store extends EventEmitter {
 
   setDefaultThemeName(defaultThemeName: ?string) {
     // Don't accept an invalid themeName as a default.
-    this._defaultThemeName = defaultThemeName && Themes.hasOwnProperty(defaultThemeName)
-      ? defaultThemeName
-      : 'ChromeDefault';
+    this._defaultThemeName = this._safeThemeName(defaultThemeName, 'ChromeDefault');
   }
 
   showPreferencesPanel() {

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -192,8 +192,9 @@ var DevtoolsUI = {
       var {store} = panel.getChildContext();
       // Change default themeName if panel mounted
       store.setDefaultThemeName(themeName);
-      // Change theme with user selected theme,
-      // it always wins than default theme
+      // Render devtools with the current theme.
+      // If user has selected a theme then ThemeStore will return it.
+      // If not the new default we set above will be used.
       store.changeTheme(ThemeStore.get());
     }
     return DevtoolsUI;

--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -15,7 +15,9 @@ var updateNotifier = require('update-notifier');
 var pkg = require('./package.json');
 
 var mainWindow = null;
-var argv = process.argv.slice(2);
+var argv = require('minimist')(process.argv.slice(2));
+var projectRoots = argv._;
+var defaultThemeName = argv.theme;
 
 app.on('window-all-closed', function() {
   app.quit();
@@ -34,7 +36,10 @@ app.on('ready', function() {
     // We use this so that RN can keep relative JSX __source filenames
     // but "click to open in editor" still works. js1 passes project roots
     // as the argument to DevTools.
-    'window.devtools.setProjectRoots(' + JSON.stringify(argv) + ')'
+    'window.devtools.setProjectRoots(' + JSON.stringify(projectRoots) + ')'
+  );
+  mainWindow.webContents.executeJavaScript(
+    'window.devtools.setDefaultThemeName(' + JSON.stringify(defaultThemeName) + ')'
   );
 
   // Emitted when the window is closed.

--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -25,6 +25,7 @@
     "cross-spawn": "^5.0.1",
     "electron": "^1.4.15",
     "ip": "^1.1.4",
+    "minimist": "^1.2.0",
     "react-devtools-core": "^2.1.9",
     "update-notifier": "^2.1.0"
   }


### PR DESCRIPTION
This PR make `setDefaultThemeName` method in DevToolsUI for set `themeName` prop for `Panel`.

```js
require('react-devtools-core/standalone')
  .setContentDOMNode(document.getElementById('container'))
  .setDefaultThemeName('ChromeDark')
  .startServer(port);
```

I've a plan for detect Chrome DevTools theme on [`react-native-debugger`](https://github.com/jhen0409/react-native-debugger/commit/f5adc772c2a71a95795e8c56693d7e98cacf226e), I think it also useful for #684.

Also parse `--theme` for `react-devtools` bin, so we can use:

```bash
$ react-devtools --theme ChromeDark
```