### PR TITLE
Fix source path not shown fully if content overflow

### DIFF
--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -220,7 +220,6 @@ const emptyStyle = (theme: Base16Theme) => ({
 const sourceStyle = (hasViewElementSource: boolean, theme: Base16Theme) => ({
   padding: '0.25rem 0.5rem',
   color: theme.base05,
-  overflow: 'auto',
   overflowWrap: 'break-word',
   cursor: hasViewElementSource ? 'pointer' : 'default',
 });


### PR DESCRIPTION
See the screenshot:

![](https://cloud.githubusercontent.com/assets/3001525/26005539/f5c26146-376b-11e7-940a-fc5f02c7e5d7.png)

It has been scrolled to end, remove `overflow: auto` will fix this.