### PR TITLE
Fix drag position in SplitPane

### DIFF
--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -59,15 +59,15 @@ class SplitPane extends React.Component {
   }
 
   onMove(x: number, y: number) {
-    var node = ReactDOM.findDOMNode(this);
+    var rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
 
     this.setState(prevState => ({
       width: this.props.isVertical ?
         prevState.width :
-        Math.floor(node.offsetLeft + node.offsetWidth - x),
+        Math.floor(rect.left + rect.width - x),
       height: !this.props.isVertical ?
         prevState.height :
-        Math.floor(node.offsetTop + node.offsetHeight - y),
+        Math.floor(rect.top + rect.height - y),
     }));
   }
 


### PR DESCRIPTION
I'm experiencing the drag problem for use [`react-devtools-core`](https://github.com/facebook/react-devtools/tree/master/packages/react-devtools-core) and render it on different position:

![2017-05-23 12_55_42](https://cloud.githubusercontent.com/assets/3001525/26339065/b6e4ef4e-3fb7-11e7-933d-f1895a005730.gif)

Use `node.getBoundingClientRect` fixed this.