### PR TITLE
Show highlighter when inspect is enabled

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -126,6 +126,8 @@ class Agent extends EventEmitter {
       this._updateScroll = this._updateScroll.bind(this);
       window.addEventListener('scroll', this._onScroll.bind(this), true);
       window.addEventListener('click', this._onClick.bind(this), true);
+      window.addEventListener('mouseover', this._onMouseOver.bind(this), true);
+      window.addEventListener('resize', this._onResize.bind(this), true);
     }
   }
 
@@ -213,6 +215,7 @@ class Agent extends EventEmitter {
       bridge.forget(id);
     });
     this.on('setSelection', data => bridge.send('select', data));
+    this.on('setInspectEnabled', data => bridge.send('setInspectEnabled', data));
   }
 
   scrollToNode(id: ElementID): void {
@@ -431,6 +434,22 @@ class Agent extends EventEmitter {
     event.preventDefault();
 
     this.emit('setSelection', {id});
+    this.emit('setInspectEnabled', false);
+  }
+
+  _onMouseOver(event: Event) {
+    if (this._inspectEnabled) {
+      const id = this.getIDForNode(event.target);
+      if (!id) {
+        return;
+      }
+      
+      this.highlight(id);
+    }
+  }
+
+  _onResize(event: Event) {
+    this.emit('stopInspecting');
   }
 }
 

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -176,6 +176,7 @@ class Store extends EventEmitter {
     this._bridge.on('mount', (data) => this._mountComponent(data));
     this._bridge.on('update', (data) => this._updateComponent(data));
     this._bridge.on('unmount', id => this._unmountComponent(id));
+    this._bridge.on('setInspectEnabled', (data) => this.setInspectEnabled(data));
     this._bridge.on('select', ({id, quiet}) => {
       this._revealDeep(id);
       this.selectTop(this.skipWrapper(id), quiet);


### PR DESCRIPTION
(Kind of a follow-up to #729)

- Added highlighting for the Inspect button when hovering
- Disables the Inspect button once an element has been clicked
- Hide the highlight when the window is resized (otherwise it is incorrectly positioned)

![inspect-button-hover](https://cloud.githubusercontent.com/assets/24449/26419272/07ebc55c-40b7-11e7-8b94-8bc08cf7d277.png)

cc @bvaughn 
