### PR TITLE
[React Native] Fix instance measure of rnstyle for Android

### DIFF
--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -65,7 +65,8 @@ function measureStyle(agent, bridge, resolveRNStyle, id) {
   }
 
   instance.measure((x, y, width, height, left, top) => {
-    // It may got undefined for measure some instance in Android
+    // RN Android sometimes returns undefined here. Don't send measurements in this case.
+    // https://github.com/jhen0409/react-native-debugger/issues/84#issuecomment-304611817
     if (typeof x !== 'number') {
       bridge.send('rn-style:measure', {style});
       return;

--- a/plugins/ReactNativeStyle/setupBackend.js
+++ b/plugins/ReactNativeStyle/setupBackend.js
@@ -65,6 +65,11 @@ function measureStyle(agent, bridge, resolveRNStyle, id) {
   }
 
   instance.measure((x, y, width, height, left, top) => {
+    // It may got undefined for measure some instance in Android
+    if (typeof x !== 'number') {
+      bridge.send('rn-style:measure', {style});
+      return;
+    }
     var margin = (style && resolveBoxStyle('margin', style)) || blank;
     var padding = (style && resolveBoxStyle('padding', style)) || blank;
     bridge.send('rn-style:measure', {


### PR DESCRIPTION
It looks like measure some instance will got `undefined` in Android (See [this comment](https://github.com/jhen0409/react-native-debugger/issues/84#issuecomment-304611817)), we can avoid it use `undefined` values as `measuredLayout` send to react-devtools.

The original errors will causing react-devtools not to work properly on Android.