### PR TITLE
Clear stored themeName if select defaultThemeName

### DIFF
--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -127,13 +127,18 @@ class PreferencesPanel extends React.Component {
   }
 
   _changeTheme = (event) => {
-    const {showHiddenThemes, themes} = this.context;
+    const {defaultThemeName, showHiddenThemes, themes} = this.context;
     const {changeTheme} = this.props;
 
     const themeName = event.target.value;
     const theme = themes[themeName];
 
-    if (!themeName || !theme || (theme.hidden && !showHiddenThemes)) {
+    if (
+      !themeName ||
+      !theme ||
+      (theme.hidden && !showHiddenThemes) ||
+      themeName === defaultThemeName
+    ) {
       changeTheme('');
     } else {
       changeTheme(themeName);


### PR DESCRIPTION
Currently if we select the `defaultThemeName` on PreferencesPanel, the `Reset` button will be disabled but `localStorage.themeName` still not be `''`, so we should clear it if user select `defaultThemeName`.

cc @bvaughn 