### PR TITLE
Theming-related UI fixes

### DIFF
--- a/frontend/BlurInput.js
+++ b/frontend/BlurInput.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var Input = require('./Input');
 
 import type {DOMEvent, DOMNode} from './types';
 
@@ -56,7 +57,7 @@ class BlurInput extends React.Component {
 
   render() {
     return (
-      <input
+      <Input
         value={this.state.text}
         ref={i => this.node = i}
         onChange={e => this.setState({text: e.target.value})}

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -13,6 +13,7 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
 
+var Input = require('../Input');
 var flash = require('../flash');
 var {monospace} = require('../Themes/Fonts');
 
@@ -112,7 +113,7 @@ class Simple extends React.Component {
 
     if (editing) {
       return (
-        <input
+        <Input
           autoFocus={true}
           ref={i => this.input = i}
           style={inputStyle(theme)}

--- a/frontend/Input.js
+++ b/frontend/Input.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const React = require('react');
+
+import type {Theme} from './types';
+
+type Context = {
+  theme: Theme,
+};
+
+type Props = {
+  theme?: Theme,
+  style?: Object,
+};
+
+/**
+ * Same as base <input> component but with pre-applied theme styles.
+ * Props theme overrides context theme if provided.
+ */
+const Input = (props: Props, context: Context) => {
+  const {
+    style = {},
+    theme,
+    ...rest,
+  } = props;
+
+  const chosenTheme = theme ? theme : context.theme;
+
+  return (
+    <input
+      style={{
+        ...style,
+        ...inputStyle(chosenTheme),
+      }}
+      {...rest}
+    />
+  );
+};
+
+Input.contextTypes = {
+  theme: React.PropTypes.object.isRequired,
+};
+
+const inputStyle = (theme: Theme) => ({
+  backgroundColor: theme.base00,
+  color: theme.base05,
+});
+
+module.exports = Input;

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -17,6 +17,7 @@ const {sansSerif} = require('./Themes/Fonts');
 const SearchUtils = require('./SearchUtils');
 const SvgIcon = require('./SvgIcon');
 const {PropTypes} = React;
+const Input = require('./Input');
 
 const decorate = require('./decorate');
 const {hexToRgba} = require('./Themes/utils');
@@ -128,7 +129,7 @@ class SettingsPane extends React.Component {
         </div>
 
         <div style={styles.searchInputWrapper}>
-          <input
+          <Input
             style={inputStyle}
             ref={i => this.input = i}
             value={searchText}

--- a/frontend/Themes/Editor/ColorInput.js
+++ b/frontend/Themes/Editor/ColorInput.js
@@ -14,7 +14,8 @@ const React = require('react');
 const {findDOMNode} = require('react-dom');
 const Portal = require('react-portal');
 const ColorPicker = require('./ColorPicker');
-const {monospace} = require('../../Themes/Fonts');
+const Input = require('../../Input');
+const {monospace} = require('../Fonts');
 const {isBright} = require('../utils');
 
 import type {Theme} from '../../types';
@@ -91,9 +92,10 @@ class ColorInput extends React.Component {
             ref={this._setColorChipRef}
             style={colorChipStyle(theme, color, backgroundIsBright === chipIsBright)}
           ></div>
-          <input
+          <Input
             onChange={this._onChange}
             style={styles.input}
+            theme={theme}
             type="text"
             value={color || ''}
           />

--- a/frontend/Themes/Editor/ColorPicker.js
+++ b/frontend/Themes/Editor/ColorPicker.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const React = require('react');
-const {findDOMNode} = require('react-dom');
 const {CustomPicker} = require('react-color');
 const {Hue, Saturation} = require('react-color/lib/components/common');
 
@@ -19,8 +18,6 @@ import type {Theme} from '../../types';
 
 type Props = {
   color: string,
-  hide: () => void,
-  isOpen: boolean,
   theme: Theme,
   updateColor: (color: string) => void,
 };
@@ -30,22 +27,8 @@ class ColorPicker extends React.Component {
 
   _ref: any;
 
-  componentDidMount() {
-    document.addEventListener('keydown', this._onDocumentKeyDown);
-    document.addEventListener('click', this._onDocumentClick);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this._onDocumentKeyDown);
-    document.removeEventListener('click', this._onDocumentClick);
-  }
-
   render() {
-    const {color, isOpen, theme} = this.props;
-
-    if (!isOpen) {
-      return null;
-    }
+    const {color, theme} = this.props;
 
     return (
       <DecoratedCustomColorPicker
@@ -60,32 +43,8 @@ class ColorPicker extends React.Component {
 
   // $FlowFixMe ^ class property `_onChangeComplete`. Missing annotation
   _onChangeComplete = (color) => {
+//    this.props.closePortal();
     this.props.updateColor(color.hex);
-  };
-
-  // $FlowFixMe ^ class property `_onClose`. Missing annotation
-  _onClose = () => {
-    this.props.hide();
-  };
-
-  // $FlowFixMe ^ class property `_onDocumentClick`. Missing annotation
-  _onDocumentClick = (event: Event) => {
-    if (this._ref) {
-      const node = findDOMNode(this._ref);
-      if (node.contains(event.target)) {
-        event.stopPropagation();
-        return;
-      }
-    }
-
-    this.props.hide();
-  };
-
-  // $FlowFixMe ^ class property `_onDocumentKeyDown`. Missing annotation
-  _onDocumentKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      this.props.hide();
-    }
   };
 
   // $FlowFixMe ^ class property `_setRef`. Missing annotation

--- a/frontend/Themes/Editor/ColorPicker.js
+++ b/frontend/Themes/Editor/ColorPicker.js
@@ -43,7 +43,6 @@ class ColorPicker extends React.Component {
 
   // $FlowFixMe ^ class property `_onChangeComplete`. Missing annotation
   _onChangeComplete = (color) => {
-//    this.props.closePortal();
     this.props.updateColor(color.hex);
   };
 

--- a/frontend/Themes/Editor/Editor.js
+++ b/frontend/Themes/Editor/Editor.js
@@ -14,6 +14,7 @@ const decorate = require('../../decorate');
 const React = require('react');
 const ColorInput = require('./ColorInput');
 const ColorGroups = require('./ColorGroups');
+const Input = require('../../Input');
 const {monospace, sansSerif} = require('../Fonts');
 const Preview = require('../Preview');
 const SvgIcon = require('../../SvgIcon');
@@ -72,7 +73,7 @@ class Editor extends React.Component {
   }
 
   render() {
-    const {hide, theme} = this.props;
+    const {hide} = this.props;
     const {isResetEnabled, updateCounter} = this.state;
 
     return (
@@ -126,9 +127,10 @@ class Editor extends React.Component {
             "/>
 
             <label style={styles.shareLabel}>Import/export:</label>
-            <input
+            <Input
               onChange={this._onShareChange}
-              style={shareInput(theme)}
+              style={shareInput(safeTheme)}
+              theme={safeTheme}
               type="text"
               value={serialize(this._customTheme)}
             />

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-addons-create-fragment": "15.4.2",
     "react-color": "^2.11.7",
     "react-dom": "15.4.2",
+    "react-portal": "^3.1.0",
     "webpack": "1.12.9"
   },
   "license": "BSD-3-Clause",

--- a/plugins/ReactNativeStyle/AutoSizeInput.js
+++ b/plugins/ReactNativeStyle/AutoSizeInput.js
@@ -12,6 +12,7 @@
 
 var React = require('react');
 var {monospace} = require('../../frontend/Themes/Fonts');
+var Input = require('../../frontend/Input');
 
 type Props = {
   onChange: (text: string|number) => any,
@@ -129,7 +130,7 @@ class AutoSizeInput extends React.Component {
     styles.input.width = this.state.inputWidth + 'px';
     return (
       <div style={styles.wrapper}>
-        <input
+        <Input
           ref={i => this.input = i}
           value={this.state.text}
           style={styles.input}

--- a/plugins/ReactNativeStyle/BlurInput.js
+++ b/plugins/ReactNativeStyle/BlurInput.js
@@ -11,6 +11,8 @@
 'use strict';
 
 var React = require('react');
+var Input = require('../../frontend/Input');
+
 import type {DOMEvent, DOMNode} from '../../frontend/types';
 
 type Props = {
@@ -60,7 +62,7 @@ class BlurInput extends React.Component {
 
   render() {
     return (
-      <input
+      <Input
         value={this.state.text}
         ref={i => this.node = i}
         onChange={e => this.setState({text: e.target.value})}

--- a/plugins/ReactNativeStyle/StyleEdit.js
+++ b/plugins/ReactNativeStyle/StyleEdit.js
@@ -118,7 +118,7 @@ StyleEdit.contextTypes = {
 };
 
 const tagStyle = (theme: Theme) => ({
-  color: theme.base03,
+  color: theme.base04,
 });
 
 const styles = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3417,7 +3417,7 @@ promise@^7.0.3, promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4:
+prop-types@^15.5.4, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -3505,6 +3505,12 @@ react-dom@15.4.2:
     fbjs "^0.8.1"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+react-portal@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-portal/-/react-portal-3.1.0.tgz#865c44fb72a1da106c649206936559ce891ee899"
+  dependencies:
+    prop-types "^15.5.8"
 
 react@15.4.2:
   version "15.4.2"


### PR DESCRIPTION
Relates to #759

- [x] Color picker now uses portal for better UX. Devtools isn't yet using React 16 so I'm using react-portal for the time being. We can replace this with createPortal once we upgrade though.
![screen shot 2017-05-31 at 3 22 11 pm](https://cloud.githubusercontent.com/assets/29597/26656702/049db53c-4615-11e7-8d14-af217f656402.png)

- [x] Text inputs use active theme for better UI (particularly for RN styles editor).
![screen shot 2017-05-31 at 3 22 22 pm](https://cloud.githubusercontent.com/assets/29597/26656718/13a863f6-4615-11e7-9317-c30a47f7fddf.png)
![screen shot 2017-05-31 at 3 22 26 pm](https://cloud.githubusercontent.com/assets/29597/26656719/13a858ac-4615-11e7-855e-a319ab165c46.png)
![screen shot 2017-05-31 at 3 22 30 pm](https://cloud.githubusercontent.com/assets/29597/26656717/13a4be04-4615-11e7-9a62-e449f7aab453.png)
![screen shot 2017-05-31 at 3 22 33 pm](https://cloud.githubusercontent.com/assets/29597/26656720/13acfb0a-4615-11e7-9e09-f4631481a49b.png)
![screen shot 2017-05-31 at 3 22 36 pm](https://cloud.githubusercontent.com/assets/29597/26656721/13b02d16-4615-11e7-8466-c90699a32099.png)
