### PR TITLE
Fix the issue with undefined node during selection

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -354,6 +354,16 @@ class Agent extends EventEmitter {
       return internalInstance;
     }
     if (!this.idsByInternalInstances.has(internalInstance)) {
+
+      // FIXME: this section is Fiber-specific but we shouldn't rely on its data structure.
+      // We need to rethink how ID <-> internal instance mapping works in the future.
+      const alternate = (internalInstance: any).alternate;
+      if (alternate) {
+        if (this.idsByInternalInstances.has(alternate)) {
+          return this.idsByInternalInstances.get(alternate);
+        }
+      }
+
       this.idsByInternalInstances.set(internalInstance, guid());
       this.internalInstancesById.set(
         this.idsByInternalInstances.get(internalInstance),

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -482,9 +482,6 @@ class Store extends EventEmitter {
       return undefined;
     }
     var node = this.get(id);
-    if (!node) {
-      return undefined;
-    }
     var nodeType = node.get('nodeType');
     if (nodeType !== 'Wrapper' && nodeType !== 'Native') {
       return id;


### PR DESCRIPTION
We are seeing an occasional issue when selecting something via RN Inspector causes an error in `Store.js`.

I'm reverting a previous temporary fix in the frontend code, and against adding a workaround for the root issue.

Specifically:

* The Agent assumes IDs map to internal instances 1:1.
* We [hack around it](https://github.com/facebook/react-devtools/blob/41b4f8b11de6b01dc25b8d9f5f56c087fbd9ef17/backend/attachRendererFiber.js#L21-L38) in the Fiber implementation to always give it the same Fiber
* However that code doesn't run for [this direct call](https://github.com/facebook/react-native/blob/a93b7a2da0849f15708afef1ff99022d8cc55b14/Libraries/Inspector/Inspector.js#L179) which may pass an unexpected alternate

To work around this, I'm "deduplicating" Fiber before assigning an ID to it in the Agent. But it's bad because now Agent depends on Fiber internal structure.

I'll raise an issue to investigate a proper fix. I think it would need rethinking how IDs are mapped to internal instances. Ideally we shouldn't need to expose the internal instances to Agent at all.

I tested the fix by putting an `alert` in the `if` block and verifying it does sometimes get called, but selection still works, and doesn’t throw.