### PR TITLE
Add 'Copy element name' to context menu

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -18,7 +18,7 @@ var performanceNow = require('fbjs/lib/performanceNow');
 
 // Use the polyfill if the function is not native implementation
 function getWindowFunction(name, polyfill): Function {
-  if (String(window[name]).indexOf(`[native code]`) === -1) {
+  if (String(window[name]).indexOf('[native code]') === -1) {
     return polyfill;
   }
   return window[name];

--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -133,17 +133,19 @@ var DEFAULT_MENU_ITEMS = {
         title: 'Show all ' + node.get('name'),
         action: () => store.changeSearch(node.get('name')),
       });
-      items.push({
-        key: 'copyNodeName',
-        title: 'Copy element name',
-        action: () => store.copyNodeName(node.get('name')),
-      });
     }
     if (store.capabilities.scroll) {
       items.push({
         key: 'scrollToNode',
         title: 'Scroll to node',
         action: () => store.scrollToNode(id),
+      });
+    }
+    if (node.get('nodeType') === 'Composite' && node.get('name')) {
+      items.push({
+        key: 'copyNodeName',
+        title: 'Copy element name',
+        action: () => store.copyNodeName(node.get('name')),
       });
     }
     return items;

--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -133,6 +133,11 @@ var DEFAULT_MENU_ITEMS = {
         title: 'Show all ' + node.get('name'),
         action: () => store.changeSearch(node.get('name')),
       });
+      items.push({
+        key: 'copyNodeName',
+        title: 'Copy element name',
+        action: () => store.copyNodeName(node.get('name')),
+      });
     }
     if (store.capabilities.scroll) {
       items.push({

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -11,12 +11,12 @@
 'use strict';
 
 var React = require('react');
-var { sansSerif } = require('./Themes/Fonts');
+var {sansSerif} = require('./Themes/Fonts');
 var HighlightHover = require('./HighlightHover');
 
 var decorate = require('./decorate');
 
-import type {Theme } from './types';
+import type {Theme} from './types';
 
 export type MenuItem = {
   key: string,

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -64,14 +64,16 @@ class ContextMenu extends React.Component {
   }
 
   getHeight = element => {
-    if (! element)
+    if (!element) {
       return;
+    }
 
     const elementHeight = element.querySelector('ul').clientHeight;
     const windowHeight = window.innerHeight;
 
-    if (this.state.elementHeight === elementHeight && this.state.windowHeight === windowHeight)
+    if (this.state.elementHeight === elementHeight && this.state.windowHeight === windowHeight) {
       return;
+    }
 
     this.setState({
       elementHeight: elementHeight,
@@ -84,8 +86,9 @@ class ContextMenu extends React.Component {
     const { items, open, pos } = this.props;
     const { elementHeight, windowHeight } = this.state;
 
-    if (pos && (pos.y + elementHeight) > windowHeight)
-       pos.y = pos.y - elementHeight;
+    if (pos && (pos.y + elementHeight) > windowHeight) {
+      pos.y -= elementHeight;
+    }
 
     if (!open) {
       return <div style={styles.hidden} />;

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -46,13 +46,13 @@ class ContextMenu extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      elementHeight: 0,
-      windowHeight: 0,
-    };
-
     this.handleBackdropClick = this.handleBackdropClick.bind(this);
   }
+
+  state = {
+    elementHeight: 0,
+    windowHeight: 0,
+  };
 
   onClick(i, evt) {
     this.props.items[i].action();
@@ -79,7 +79,7 @@ class ContextMenu extends React.Component {
       elementHeight: elementHeight,
       windowHeight: windowHeight,
     });
-  }
+  };
 
   render() {
     const { theme } = this.context;

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -63,7 +63,7 @@ class ContextMenu extends React.Component {
     this.props.hideContextMenu();
   }
 
-  getHeight = element => {
+  _setRef = element => {
     if (!element) {
       return;
     }
@@ -95,7 +95,7 @@ class ContextMenu extends React.Component {
     }
 
     return (
-      <div style={styles.backdrop} onClick={this.handleBackdropClick} ref={this.getHeight}>
+      <div style={styles.backdrop} onClick={this.handleBackdropClick} ref={this._setRef}>
         <ul style={containerStyle(pos.x, pos.y, theme)}>
           {!items.length && (
             <li style={emptyStyle(theme)}>No actions</li>

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -85,7 +85,7 @@ class ContextMenu extends React.Component {
     const { elementHeight, windowHeight } = this.state;
 
     if (pos && (pos.y + elementHeight) > windowHeight)
-       pos.y = pos.y - 50;
+       pos.y = pos.y - elementHeight;
 
     if (!open) {
       return <div style={styles.hidden} />;

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -11,12 +11,12 @@
 'use strict';
 
 var React = require('react');
-var {sansSerif} = require('./Themes/Fonts');
+var { sansSerif } = require('./Themes/Fonts');
 var HighlightHover = require('./HighlightHover');
 
 var decorate = require('./decorate');
 
-import type {Theme} from './types';
+import type {Theme } from './types';
 
 export type MenuItem = {
   key: string,
@@ -46,6 +46,11 @@ class ContextMenu extends React.Component {
   constructor(props) {
     super(props);
 
+    this.state = {
+      elementHeight: 0,
+      windowHeight: 0,
+    };
+
     this.handleBackdropClick = this.handleBackdropClick.bind(this);
   }
 
@@ -58,16 +63,36 @@ class ContextMenu extends React.Component {
     this.props.hideContextMenu();
   }
 
+  getHeight = element => {
+    if (! element)
+      return;
+
+    const elementHeight = element.querySelector('ul').clientHeight;
+    const windowHeight = window.innerHeight;
+
+    if (this.state.elementHeight === elementHeight && this.state.windowHeight === windowHeight)
+      return;
+
+    this.setState({
+      elementHeight: elementHeight,
+      windowHeight: windowHeight,
+    });
+  }
+
   render() {
-    const {theme} = this.context;
-    const {items, open, pos} = this.props;
+    const { theme } = this.context;
+    const { items, open, pos } = this.props;
+    const { elementHeight, windowHeight } = this.state;
+
+    if (pos && (pos.y + elementHeight) > windowHeight)
+       pos.y = pos.y - 50;
 
     if (!open) {
       return <div style={styles.hidden} />;
     }
 
     return (
-      <div style={styles.backdrop} onClick={this.handleBackdropClick}>
+      <div style={styles.backdrop} onClick={this.handleBackdropClick} ref={this.getHeight}>
         <ul style={containerStyle(pos.x, pos.y, theme)}>
           {!items.length && (
             <li style={emptyStyle(theme)}>No actions</li>
@@ -95,9 +120,9 @@ var Wrapped = decorate({
   },
   props(store, props) {
     if (!store.contextMenu) {
-      return {open: false};
+      return { open: false };
     }
-    var {x, y, type, args} = store.contextMenu;
+    var { x, y, type, args } = store.contextMenu;
 
     var items = [];
     args.push(store);
@@ -114,7 +139,7 @@ var Wrapped = decorate({
 
     return {
       open: true,
-      pos: {x, y},
+      pos: { x, y },
       hideContextMenu: () => store.hideContextMenu(),
       items,
     };

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -13,6 +13,7 @@
 var {EventEmitter} = require('events');
 var {Map, Set, List} = require('immutable');
 var assign = require('object-assign');
+var { copy } = require('clipboard-js');
 var nodeMatchesText = require('./nodeMatchesText');
 var consts = require('../agent/consts');
 var invariant = require('./invariant');
@@ -200,6 +201,10 @@ class Store extends EventEmitter {
   // Public actions
   scrollToNode(id: ElementID): void {
     this._bridge.send('scrollToNode', id);
+  }
+
+  copyNodeName(name: string): void {
+    copy(name);
   }
 
   setSelectedTab(name: string): void {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-preset-react": "6.3.13",
     "babel-preset-stage-0": "6.3.13",
     "classnames": "2.2.1",
+    "clipboard-js": "^0.3.3",
     "es6-symbol": "3.0.2",
     "eslint": "2.10.2",
     "eslint-plugin-react": "5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1155,6 +1155,10 @@ cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
+clipboard-js@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/clipboard-js/-/clipboard-js-0.3.3.tgz#62264c17c80ebf84f4022286f032501e890b8922"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"


### PR DESCRIPTION
This feature was mentioned in issue #754 and should add a 'Copy element name' to the context menu.