### PR TITLE
Add an argument to selectFromDOMNode() to skip leafs

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -272,14 +272,18 @@ class Agent extends EventEmitter {
     return null;
   }
 
-  selectFromDOMNode(node: Object, quiet?: boolean) {
+  selectFromDOMNode(node: Object, quiet?: boolean, offsetFromLeaf: ?number = 0) {
     var id = this.getIDForNode(node);
     if (!id) {
       return;
     }
-    this.emit('setSelection', {id, quiet});
+    this.emit('setSelection', {id, quiet, offsetFromLeaf});
   }
 
+  // TODO: remove this method because it's breaking encapsulation.
+  // It was used by RN inspector but this required leaking Fibers to it.
+  // RN inspector will use selectFromDOMNode() instead now.
+  // Remove this method in a few months after this comment was added.
   selectFromReactInstance(instance: OpaqueNodeHandle, quiet?: boolean) {
     var id = this.getId(instance);
     if (!id) {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -163,7 +163,17 @@ class Store extends EventEmitter {
     this._bridge.on('update', (data) => this._updateComponent(data));
     this._bridge.on('unmount', id => this._unmountComponent(id));
     this._bridge.on('setInspectEnabled', (data) => this.setInspectEnabled(data));
-    this._bridge.on('select', ({id, quiet}) => {
+    this._bridge.on('select', ({id, quiet, offsetFromLeaf = 0}) => {
+      // Backtrack if we want to skip leaf nodes
+      while (offsetFromLeaf > 0) {
+        offsetFromLeaf--;
+        var pid = this._parents.get(id);
+        if (pid) {
+          id = pid;
+        } else {
+          break;
+        }
+      }
       this._revealDeep(id);
       this.selectTop(this.skipWrapper(id), quiet);
       this.setSelectedTab('Elements');

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -482,9 +482,6 @@ class Store extends EventEmitter {
       return undefined;
     }
     var node = this.get(id);
-    if (!node) {
-      return undefined;
-    }
     var nodeType = node.get('nodeType');
     if (nodeType !== 'Wrapper' && nodeType !== 'Native') {
       return id;


### PR DESCRIPTION
This reverts a bandaid fix that attempted to work around a crash, and instead fixes the root issue (with another PR to RN).

The issue is that passing Fiber from outside to `selectFromReactInstance()` didn't work because it could potentially be an alternate, and our [deduplication logic](https://github.com/facebook/react-devtools/blob/575e416f45aa9d2898f7493b0266e306f9d0646e/backend/attachRendererFiber.js#L27-L38) wouldn't work for a [direct call like this](https://github.com/facebook/react-native/blob/a93b7a2da0849f15708afef1ff99022d8cc55b14/Libraries/Inspector/Inspector.js#L179).

Instead I'm adding support to `selectFromDOMNode()` to skip a few leafs (which was original motivation of [exposing](https://github.com/facebook/react/blob/9dcc60af3394f5e5f92a7cc9d54a68ce48795681/src/renderers/native/ReactNativeFiberInspector.js#L107) the `instance`). This lets us change RN code to just call:

```js
    if (this.state.devtoolsAgent) {
      // Skip host leafs
      const offsetFromLeaf = hierarchy.length - 1 - selection;
      this.state.devtoolsAgent.selectFromDOMNode(touchedViewTag, true, offsetFromLeaf);
    }
```

This doesn't pass a fiber, so we don't get the "wrong fiber" issue.