### PR TITLE
[Electron] Fix return value of guessEditor() in launchEditor

### DIFF
--- a/packages/react-devtools-core/src/launchEditor.js
+++ b/packages/react-devtools-core/src/launchEditor.js
@@ -101,7 +101,7 @@ function guessEditor() {
     return [process.env.EDITOR];
   }
 
-  return null;
+  return [];
 }
 
 var _childProcess = null;


### PR DESCRIPTION
The [`launchEditor`](https://github.com/facebook/react-devtools/blob/master/packages/react-devtools-core/src/launchEditor.js#L129) function will throw `Cannot convert undefined or null to object` error if `guessEditor()` returns `null` (No opened editors).

Related to https://github.com/jhen0409/react-native-debugger/issues/69.