### PR TITLE
[Electron] Add setBrowserName method

### DIFF
--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -92,7 +92,7 @@ class PreferencesPanel extends React.Component {
             >
               {browserName && (<option value="">{browserName}</option>)}
               {hasCustomTheme && (<option value={CUSTOM_THEME_NAME}>Custom</option>)}
-              {(!showHiddenThemes || hasCustomTheme) && <option disabled="disabled">---</option>}
+              {(browserName || hasCustomTheme) && <option disabled="disabled">---</option>}
               {themeNames.map(key => (
                 <option key={key} value={key}>{themes[key].displayName}</option>
               ))}

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -90,7 +90,7 @@ class PreferencesPanel extends React.Component {
               ref={this._setSelectRef}
               value={themeName}
             >
-              {!showHiddenThemes && (<option value="">{browserName}</option>)}
+              {browserName && (<option value="">{browserName}</option>)}
               {hasCustomTheme && (<option value={CUSTOM_THEME_NAME}>Custom</option>)}
               {(!showHiddenThemes || hasCustomTheme) && <option disabled="disabled">---</option>}
               {themeNames.map(key => (

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -200,6 +200,11 @@ var DevtoolsUI = {
     return DevtoolsUI;
   },
 
+  setBrowserName(name) {
+    config.browserName = name;
+    return DevtoolsUI;
+  },
+
   startServer,
 };
 


### PR DESCRIPTION
Related to https://github.com/facebook/react-devtools/pull/751#issuecomment-304695648, this make the Electron shell can custom the name for top option of theme dropdown, mirror the functionality for clear `localStorage.themeName`.