### PR TITLE
Add `innerRef` prop for Input & fix all ref issues

### DIFF
--- a/frontend/BlurInput.js
+++ b/frontend/BlurInput.js
@@ -59,7 +59,7 @@ class BlurInput extends React.Component {
     return (
       <Input
         value={this.state.text}
-        ref={i => this.node = i}
+        innerRef={i => this.node = i}
         onChange={e => this.setState({text: e.target.value})}
         onBlur={this.done.bind(this)}
         onKeyDown={e => this.onKeyDown(e)}

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -115,7 +115,7 @@ class Simple extends React.Component {
       return (
         <Input
           autoFocus={true}
-          ref={i => this.input = i}
+          innerRef={i => this.input = i}
           style={inputStyle(theme)}
           onChange={e => this.onChange(e)}
           onBlur={() => this.onSubmit(false)}

--- a/frontend/Input.js
+++ b/frontend/Input.js
@@ -21,6 +21,7 @@ type Context = {
 type Props = {
   theme?: Theme,
   style?: Object,
+  innerRef? : Function,
 };
 
 /**
@@ -31,6 +32,7 @@ const Input = (props: Props, context: Context) => {
   const {
     style = {},
     theme,
+    innerRef,
     ...rest,
   } = props;
 
@@ -42,6 +44,7 @@ const Input = (props: Props, context: Context) => {
         ...style,
         ...inputStyle(chosenTheme),
       }}
+      ref={innerRef}
       {...rest}
     />
   );

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -123,7 +123,7 @@ class SettingsPane extends React.Component {
         />
 
         <TraceUpdatesFrontendControl {...this.props} />
-        
+
         <div style={styles.growToFill}>
           <ColorizerFrontendControl {...this.props} />
         </div>
@@ -131,7 +131,7 @@ class SettingsPane extends React.Component {
         <div style={styles.searchInputWrapper}>
           <Input
             style={inputStyle}
-            ref={i => this.input = i}
+            innerRef={i => this.input = i}
             value={searchText}
             onFocus={() => this.setState({focused: true})}
             onBlur={() => this.setState({focused: false})}

--- a/plugins/ReactNativeStyle/AutoSizeInput.js
+++ b/plugins/ReactNativeStyle/AutoSizeInput.js
@@ -132,7 +132,7 @@ class AutoSizeInput extends React.Component {
     return (
       <div style={styles.wrapper}>
         <Input
-          ref={i => this.input = i}
+          innerRef={i => this.input = i}
           value={this.state.text}
           style={style}
           onChange={e => this.setState({text: e.target.value})}

--- a/plugins/ReactNativeStyle/BlurInput.js
+++ b/plugins/ReactNativeStyle/BlurInput.js
@@ -64,7 +64,7 @@ class BlurInput extends React.Component {
     return (
       <Input
         value={this.state.text}
-        ref={i => this.node = i}
+        innerRef={i => this.node = i}
         onChange={e => this.setState({text: e.target.value})}
         onBlur={this.done.bind(this)}
         onKeyDown={e => this.onKeyDown(e)}


### PR DESCRIPTION
It looks #761 breaks all input refs because it just get the wrapper. 

cc @bvaughn 