### PR TITLE
Changed preview panel in themes editor to stretch

### DIFF
--- a/frontend/Themes/Editor/Editor.js
+++ b/frontend/Themes/Editor/Editor.js
@@ -255,7 +255,7 @@ const styles = {
     display: 'flex',
     flex: '1 0 auto',
     marginLeft: '0.5rem',
-    alignItems: 'flex-start',
+    alignItems: 'stretch',
   },
   importExportRow: {
     display: 'flex',


### PR DESCRIPTION
I think this is a slightly improved UI.

![stretch](https://cloud.githubusercontent.com/assets/29597/26732309/08afbc76-476c-11e7-87d0-0a4c54e5204d.gif)
