### PR TITLE
Button cursors and hover-styles

### DIFF
--- a/frontend/Hoverable.js
+++ b/frontend/Hoverable.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const React = require('react');
+
+type Props = {
+};
+
+type State = {
+  isHovered: boolean,
+};
+
+const Hoverable = (Component: any) => {
+  class HoverableImplementation extends React.Component<void, Props, State> {
+    props: Props;
+    state: State = {
+      isHovered: false,
+    };
+
+    render() {
+      const {isHovered} = this.state;
+
+      return (
+        <Component
+          {...this.props}
+          isHovered={isHovered}
+          onMouseEnter={this._onMouseEnter}
+          onMouseLeave={this._onMouseLeave}
+        />
+      );
+    }
+
+    _onMouseEnter: Function = (event: SyntheticEvent): void => {
+      this.setState({ isHovered: true });
+    };
+
+    _onMouseLeave: Function = (event: SyntheticEvent): void => {
+      this.setState({ isHovered: false });
+    };
+  }
+
+  return HoverableImplementation;
+};
+
+module.exports = Hoverable;

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -245,7 +245,6 @@ const styles = {
     background: 'none',
     border: 'none',
     color: 'inherit',
-    cursor: 'pointer',
   },
 };
 

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -17,6 +17,7 @@ const {sansSerif} = require('./Themes/Fonts');
 const {CUSTOM_THEME_NAME} = require('./Themes/constants');
 const SvgIcon = require('./SvgIcon');
 const ThemeEditor = require('./Themes/Editor/Editor');
+const Hoverable = require('./Hoverable');
 
 import type {Theme} from './types';
 
@@ -97,12 +98,12 @@ class PreferencesPanel extends React.Component {
                 <option key={key} value={key}>{themes[key].displayName}</option>
               ))}
             </select>
-            <button
+            <EditButton
               onClick={this._onEditCustomThemeClick}
-              style={styles.iconButton}
+              theme={theme}
             >
               <EditIcon />
-            </button>
+            </EditButton>
           </div>
           <div style={styles.buttonBar}>
             <button
@@ -172,6 +173,20 @@ PreferencesPanel.propTypes = {
   open: React.PropTypes.bool,
 };
 
+
+const EditButton = Hoverable(
+  ({ isHovered, onClick, onMouseEnter, onMouseLeave, theme }) => (
+    <button
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={buttonStyle(isHovered, theme)}
+    >
+      <EditIcon/>
+    </button>
+  )
+);
+
 const EditIcon = () => (
   <SvgIcon path="
     M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,
@@ -210,6 +225,15 @@ const panelStyle = (theme: Theme) => ({
   color: theme.base05,
 });
 
+const buttonStyle = (isHovered: boolean, theme: Theme) => ({
+  padding: '0.25rem',
+  marginLeft: '0.25rem',
+  height: '1.5rem',
+  background: 'none',
+  border: 'none',
+  color: isHovered ? theme.state06 : 'inherit',
+});
+
 const styles = {
   backdrop: {
     position: 'absolute',
@@ -237,14 +261,6 @@ const styles = {
     display: 'flex',
     direction: 'row',
     alignItems: 'center',
-  },
-  iconButton: {
-    padding: '0.25rem',
-    marginLeft: '0.25rem',
-    height: '1.5rem',
-    background: 'none',
-    border: 'none',
-    color: 'inherit',
   },
 };
 

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -249,7 +249,6 @@ const cancelButtonStyle = (theme: Theme) => ({
 
 const inspectMenuButtonStyle = (isInspectEnabled: boolean, theme: Theme) => ({
   display: 'flex',
-  cursor: 'pointer',
   background: 'none',
   border: 'none',
   outline: 'none', // Use custom active highlight instead
@@ -299,7 +298,6 @@ var styles = {
 
   settingsMenuButton: {
     display: 'flex',
-    cursor: 'pointer',
     background: 'none',
     border: 'none',
     color: 'inherit',

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -18,6 +18,7 @@ const SearchUtils = require('./SearchUtils');
 const SvgIcon = require('./SvgIcon');
 const {PropTypes} = React;
 const Input = require('./Input');
+const Hoverable = require('./Hoverable');
 
 const decorate = require('./decorate');
 const {hexToRgba} = require('./Themes/utils');
@@ -142,9 +143,10 @@ class SettingsPane extends React.Component {
           />
           <SearchIcon theme={theme} />
           {!!searchText && (
-            <div onClick={this.cancel.bind(this)} style={cancelButtonStyle(theme)}>
-              &times;
-            </div>
+            <ClearSearchButton
+              onClick={this.cancel.bind(this)}
+              theme={theme}
+            />
           )}
         </div>
       </div>
@@ -180,41 +182,62 @@ var Wrapped = decorate({
   },
 }, SettingsPane);
 
-const InspectMenuButton = ({ isInspectEnabled, onClick, theme }) => (
-  <button
-    onClick={onClick}
-    style={inspectMenuButtonStyle(isInspectEnabled, theme)}
-    title="Select a React element in the page to inspect it"
-  >
-    <SvgIcon path="
-      M12,8A4,4 0 0,1 16,12A4,4 0 0,1 12,16A4,4 0 0,1 8,12A4,4 0 0,1 12,8M3.05,
-      13H1V11H3.05C3.5,6.83 6.83,3.5 11,3.05V1H13V3.05C17.17,3.5 20.5,6.83 20.95,
-      11H23V13H20.95C20.5,17.17 17.17,20.5 13,20.95V23H11V20.95C6.83,20.5 3.5,17.17 3.05,
-      13M12,5A7,7 0 0,0 5,12A7,7 0 0,0 12,19A7,7 0 0,0 19,12A7,7 0 0,0 12,5Z
-    "/>
-  </button>
+const ClearSearchButton = Hoverable(
+  ({ isHovered, onClick, onMouseEnter, onMouseLeave, theme }) => (
+    <div
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={clearSearchButtonStyle(isHovered, theme)}
+    >
+      &times;
+    </div>
+  )
 );
 
-const SettingsMenuButton = ({ onClick, theme }) => (
-  <button
-    onClick={onClick}
-    style={styles.settingsMenuButton}
-    title="Customize React DevTools"
-  >
-    <SvgIcon path="
-      M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,
-      1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,
-      11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,
-      5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,
-      2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,
-      4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,
-      11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,
-      15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,
-      18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,
-      18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,
-      18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z
-    "/>
-  </button>
+const InspectMenuButton = Hoverable(
+  ({ isHovered, isInspectEnabled, onClick, onMouseEnter, onMouseLeave, theme }) => (
+    <button
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={inspectMenuButtonStyle(isInspectEnabled, isHovered, theme)}
+      title="Select a React element in the page to inspect it"
+    >
+      <SvgIcon path="
+        M12,8A4,4 0 0,1 16,12A4,4 0 0,1 12,16A4,4 0 0,1 8,12A4,4 0 0,1 12,8M3.05,
+        13H1V11H3.05C3.5,6.83 6.83,3.5 11,3.05V1H13V3.05C17.17,3.5 20.5,6.83 20.95,
+        11H23V13H20.95C20.5,17.17 17.17,20.5 13,20.95V23H11V20.95C6.83,20.5 3.5,17.17 3.05,
+        13M12,5A7,7 0 0,0 5,12A7,7 0 0,0 12,19A7,7 0 0,0 19,12A7,7 0 0,0 12,5Z
+      "/>
+    </button>
+  )
+);
+
+const SettingsMenuButton = Hoverable(
+  ({ isHovered, onClick, onMouseEnter, onMouseLeave, theme }) => (
+    <button
+      onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      style={settingsMenuButtonStyle(isHovered, theme)}
+      title="Customize React DevTools"
+    >
+      <SvgIcon path="
+        M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,
+        1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,
+        11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,
+        5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,
+        2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,
+        4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.21,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,
+        11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.21,15.05 2.34,
+        15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,
+        18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,
+        18.93C15.5,18.67 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,
+        18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z
+      "/>
+    </button>
+  )
 );
 
 function SearchIcon({ theme }) {
@@ -237,23 +260,34 @@ const settingsPaneStyle = (theme: Theme) => ({
   borderBottom: `1px solid ${theme.base03}`,
 });
 
-const cancelButtonStyle = (theme: Theme) => ({
+const clearSearchButtonStyle = (isHovered: boolean, theme: Theme) => ({
   fontSize: sansSerif.sizes.large,
   padding: '0 0.5rem',
   position: 'absolute',
-  cursor: 'pointer',
+  cursor: 'default',
   right: 0,
   lineHeight: '28px',
-  color: theme.base02,
+  color: isHovered ? theme.base04 : theme.base02,
 });
 
-const inspectMenuButtonStyle = (isInspectEnabled: boolean, theme: Theme) => ({
-  display: 'flex',
-  background: 'none',
-  border: 'none',
-  outline: 'none', // Use custom active highlight instead
-  color: isInspectEnabled ? theme.state00 : 'inherit',
-});
+const inspectMenuButtonStyle = (isInspectEnabled: boolean, isHovered: boolean, theme: Theme) => {
+  let color;
+  if (isInspectEnabled) {
+    color = theme.state00;
+  } else if (isHovered) {
+    color = theme.state06;
+  } else {
+    color = 'inherit';
+  }
+
+  return {
+    display: 'flex',
+    background: 'none',
+    border: 'none',
+    outline: 'none', // Use custom active highlight instead
+    color,
+  };
+};
 
 const searchIconStyle = (theme: Theme) => ({
   position: 'absolute',
@@ -268,6 +302,14 @@ const searchIconStyle = (theme: Theme) => ({
   fill: theme.base02,
   lineHeight: '28px',
   fontSize: sansSerif.sizes.normal,
+});
+
+const settingsMenuButtonStyle = (isHovered: boolean, theme: Theme) => ({
+  display: 'flex',
+  background: 'none',
+  border: 'none',
+  marginRight: '0.5rem',
+  color: isHovered ? theme.state06 : 'inherit',
 });
 
 const baseInputStyle = (theme: Theme) => ({
@@ -295,15 +337,6 @@ var styles = {
   growToFill: {
     flexGrow: 1,
   },
-
-  settingsMenuButton: {
-    display: 'flex',
-    background: 'none',
-    border: 'none',
-    color: 'inherit',
-    marginRight: '0.5rem',
-  },
-
   searchInputWrapper: {
     display: 'flex',
     alignItems: 'center',

--- a/frontend/Themes/Editor/ColorGroups.js
+++ b/frontend/Themes/Editor/ColorGroups.js
@@ -37,6 +37,7 @@ const Selection = {
   state02: 'Focused Foreground',
   state04: 'Search Background',
   state05: 'Search Foreground',
+  state06: 'Interactive Hover',
 };
 
 module.exports = {

--- a/frontend/Themes/Editor/ColorInput.js
+++ b/frontend/Themes/Editor/ColorInput.js
@@ -180,7 +180,6 @@ const colorChipStyle = (theme: Theme, color: string = '', showBorder: boolean = 
   borderRadius: '2px',
   backgroundColor: color,
   boxSizing: 'border-box',
-  cursor: 'pointer',
   border: showBorder ? `1px solid ${theme.base03}` : 'none',
 });
 

--- a/frontend/Themes/Serializer.js
+++ b/frontend/Themes/Serializer.js
@@ -25,7 +25,7 @@ function deserialize(string: string, fallbackTheme: Theme = ChromeDefault): Them
     // Make sure serialized theme has no extra keys.
     themeKeys.forEach(key => {
       const maybeColor = maybeTheme[key];
-      if (typeof maybeColor === 'string' && maybeColor !== '') {
+      if (isColorSet(maybeColor)) {
         theme[key] = maybeColor;
       }
     });
@@ -34,15 +34,24 @@ function deserialize(string: string, fallbackTheme: Theme = ChromeDefault): Them
     console.error('Could not deserialize theme', error);
   }
 
+  // Update outdated custom theme formats and set reasonable defaults.
+  if (!isColorSet(theme.state06)) { // Added in version > 2.3.0
+    theme.state06 = theme.base05;
+  }
+
   // Make sure serialized theme has all of the required color values.
   themeKeys.forEach(key => {
     const maybeColor = theme[key];
-    if (typeof maybeColor !== 'string' || maybeColor === '') {
+    if (!isColorSet(maybeColor)) {
       theme[key] = fallbackTheme[key];
     }
   });
 
   return ((theme: any): Theme);
+}
+
+function isColorSet(maybeColor: any): boolean {
+  return typeof maybeColor === 'string' && maybeColor !== '';
 }
 
 function serialize(theme: Theme): string {

--- a/frontend/Themes/Themes.js
+++ b/frontend/Themes/Themes.js
@@ -51,6 +51,7 @@ const ApathyDark: Theme = {
   state03: '#28423d',
   state04: '#3E4C96',
   state05: '#f5fcfb',
+  state06: '#ffffff',
 };
 
 const ApathyLight: Theme = {
@@ -75,6 +76,7 @@ const ApathyLight: Theme = {
   state03: '#f5fcfb',
   state04: '#3E4C96',
   state05: '#f5fcfb',
+  state06: '#000000',
 };
 
 const ChromeDark: Theme = {
@@ -100,6 +102,7 @@ const ChromeDark: Theme = {
   state03: '#342e24',
   state04: '#66ff88',
   state05: '#242424',
+  state06: '#cccccc',
 };
 
 const ChromeDefault: Theme = {
@@ -125,6 +128,7 @@ const ChromeDefault: Theme = {
   state03: '#ebf1fb',
   state04: '#FFFF00',
   state05: '#222222',
+  state06: '#222222',
 };
 
 const Dracula: Theme = {
@@ -149,6 +153,7 @@ const Dracula: Theme = {
   state03: '#323547',
   state04: '#fafa8c',
   state05: '#000000',
+  state06: '#ffffff',
 };
 
 const Eighties: Theme = {
@@ -173,6 +178,7 @@ const Eighties: Theme = {
   state03: '#3f3e3e',
   state04: '#4afa7b',
   state05: '#121212',
+  state06: '#e3e0d8',
 };
 
 const FirefoxDark: Theme = {
@@ -198,6 +204,7 @@ const FirefoxDark: Theme = {
   state03: '#475983',
   state04: '#00ff7f',
   state05: '#181d20',
+  state06: '#b9cadb',
 };
 
 const FirefoxFirebug: Theme = {
@@ -223,6 +230,7 @@ const FirefoxFirebug: Theme = {
   state03: '#e6e6e6',
   state04: '#ffee99',
   state05: '#000000',
+  state06: '#000000',
 };
 
 const FirefoxLight: Theme = {
@@ -248,6 +256,7 @@ const FirefoxLight: Theme = {
   state03: '#e4f1fa',
   state04: '#FFFF00',
   state05: '#585959',
+  state06: '#444444',
 };
 
 const Flat: Theme = {
@@ -272,6 +281,7 @@ const Flat: Theme = {
   state03: '#364c62',
   state04: '#64fa82',
   state05: '#2C3E50',
+  state06: '#ffffff',
 };
 
 const GruvboxDark: Theme = {
@@ -296,6 +306,7 @@ const GruvboxDark: Theme = {
   state03: '#3c3836',
   state04: '#7c6f64',
   state05: '#fbf1c7',
+  state06: '#fbebc2',
 };
 
 const GruvboxLight: Theme = {
@@ -320,6 +331,7 @@ const GruvboxLight: Theme = {
   state03: '#d5c4a1',
   state04: '#d5c4a1',
   state05: '#282828',
+  state06: '#000000',
 };
 
 const Materia: Theme = {
@@ -344,6 +356,7 @@ const Materia: Theme = {
   state03: '#314048',
   state04: '#00ff84',
   state05: '#263238',
+  state06: '#DDE3EE',
 };
 
 const MaterialDark: Theme = {
@@ -368,6 +381,7 @@ const MaterialDark: Theme = {
   state03: '#212b30',
   state04: '#4a55b9',
   state05: '#ffffff',
+  state06: '#D2ECF6',
 };
 
 const OceanDark: Theme = {
@@ -392,6 +406,7 @@ const OceanDark: Theme = {
   state03: '#314048',
   state04: '#d06a77',
   state05: '#1c1f27',
+  state06: '#A5A9B4',
 };
 
 const Phd: Theme = {
@@ -416,6 +431,7 @@ const Phd: Theme = {
   state03: '#112243',
   state04: '#00c8fa',
   state05: '#061229',
+  state06: '#d8dbe2',
 };
 
 const Tomorrow: Theme = {
@@ -440,6 +456,7 @@ const Tomorrow: Theme = {
   state03: '#e0e0e0',
   state04: '#eab700',
   state05: '#1d1f21',
+  state06: '#222222',
 };
 
 const TomorrowNight: Theme = {
@@ -464,6 +481,7 @@ const TomorrowNight: Theme = {
   state03: '#373b41',
   state04: '#f0c674',
   state05: '#1d1f21',
+  state06: '#e5e8e6',
 };
 
 module.exports = {

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -119,4 +119,5 @@ export type Theme = {
   state02: string; // Focused Foreground
   state04: string; // Search Background
   state05: string; // Search Foreground
+  state06: string; // Interactive Hover
 };


### PR DESCRIPTION
@gaearon pointed out that several of the devtools buttons used the `pointer` cursor style when they should probably be using the `default` style instead. My original reasons for this were that they don't look like normal buttons or otherwise provide visual cues that they are clickable (eg Chrome and Firefox icons change color on hover).

This PR removes the `pointer` cursor in favor of adding hover colors via a new `Hoverable` HOC. To make this work I also had to add a new theme color, `state06`. I backfilled this color in all existing themes so they would work automatically.

### Settings and Inspect icons
![hover-color](https://cloud.githubusercontent.com/assets/29597/26763583/f9babae6-4909-11e7-9770-25143414a5c1.gif)

### Clear search icon
![clear-search-hover](https://cloud.githubusercontent.com/assets/29597/26763596/2b21541e-490a-11e7-8d09-209d141c569b.gif)

### Edit theme icon
![pencil-hover](https://cloud.githubusercontent.com/assets/29597/26763617/7e9f72c4-490a-11e7-87e5-e2d24256322a.gif)
