### PR TITLE
Theme Editor: Use percent instead of viewport for max size

### DIFF
--- a/frontend/Themes/Editor/Editor.js
+++ b/frontend/Themes/Editor/Editor.js
@@ -193,8 +193,8 @@ const WrappedEditor = decorate({
 const editorStyle = (theme: Theme) => ({
   display: 'flex',
   flexDirection: 'column',
-  maxWidth: 'calc(100vw - 2rem)',
-  maxHeight: 'calc(100vh - 2rem)',
+  maxWidth: 'calc(100% - 2rem)',
+  maxHeight: 'calc(100% - 2rem)',
   boxSizing: 'border-box',
   zIndex: 1,
   padding: '0.5rem',


### PR DESCRIPTION
Currently the theme editor size is not depends on Panel when use `react-devtools-core` and put it to the different position, see the following screenshot:

<img width="750" alt="2017-06-05 10 57 27" src="https://cloud.githubusercontent.com/assets/3001525/26789406/c94b7370-4a42-11e7-9e55-fba2af9ce181.png">

Use percent for max size will fix this.