### PR TITLE
Fix left right arrow behavior

### DIFF
--- a/frontend/dirToDest.js
+++ b/frontend/dirToDest.js
@@ -42,7 +42,7 @@ module.exports = function(dir: Dir, bottom: boolean, collapsed: boolean, hasChil
     }
     if (hasChildren) {
       if (bottom) {
-        return 'lastChild';
+        return null;
       } else {
         return 'firstChild';
       }

--- a/frontend/dirToDest.js
+++ b/frontend/dirToDest.js
@@ -31,7 +31,7 @@ module.exports = function(dir: Dir, bottom: boolean, collapsed: boolean, hasChil
 
   if (dir === 'left') {
     if (!collapsed && hasChildren) {
-      return 'selectTop';
+      return bottom ? 'selectTop' : 'collapse';
     }
     return 'parent';
   }

--- a/frontend/dirToDest.js
+++ b/frontend/dirToDest.js
@@ -31,7 +31,7 @@ module.exports = function(dir: Dir, bottom: boolean, collapsed: boolean, hasChil
 
   if (dir === 'left') {
     if (!collapsed && hasChildren) {
-      return 'collapse';
+      return 'selectTop';
     }
     return 'parent';
   }

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -159,13 +159,17 @@ function getNewSelection(dest: Dest, store: Store): ?ElementID {
 
   if (store.searchRoots && store.searchRoots.contains(pid)) {
     pid = null;
-  }  
+  }
   if (dest === 'collapse' || dest === 'uncollapse') {
     if (dest === 'collapse') {
       store.isBottomTagSelected = false;
     }
     store.toggleCollapse(id);
     return undefined;
+  }
+
+  if (dest === 'selectTop') {
+    store.selectTop(id);
   }
 
   var children = node.get('children');
@@ -214,7 +218,7 @@ function getNewSelection(dest: Dest, store: Store): ?ElementID {
       const child = store.get(childId);
       if (child.get('nodeType') === 'Wrapper') {
         return store.getParent(id);
-      }				
+      }
       return getNewSelection('parent', store);
     }
     const childId = pchildren[pix - 1];

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -13,7 +13,7 @@
 var {Record} = require('immutable');
 
 export type Dir = 'up' | 'down' | 'left' | 'right';
-export type Dest = 'firstChild' | 'lastChild' | 'prevSibling' | 'nextSibling' | 'collapse' | 'uncollapse' | 'parent' | 'parentBottom';
+export type Dest = 'firstChild' | 'lastChild' | 'prevSibling' | 'nextSibling' | 'collapse' | 'uncollapse' | 'parent' | 'parentBottom' | 'selectTop';
 
 export type ElementID = string;
 


### PR DESCRIPTION
#### What does this PR do
* When the left arrow is clicked on the closing tag, the cursor jumps to the head tag.
* When the right arrow is clicked on the closing tag, it does nothing instead of the cursor
focusing on the last child.

Fixes [783](https://github.com/facebook/react-devtools/issues/783)