### PR TITLE
Preferences panel position is fixed now instead of absolute

### DIFF
--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -236,7 +236,8 @@ const buttonStyle = (isHovered: boolean, theme: Theme) => ({
 
 const styles = {
   backdrop: {
-    position: 'absolute',
+    position: 'fixed',
+    zIndex: 1,
     width: '100%',
     height: '100%',
     top: 0,


### PR DESCRIPTION
This is to help applications that include devtools core inside of a larger UI.

cc @jhen0409

This improvement can also be seen in the plain shell.

#### Before
![screen shot 2017-06-06 at 9 35 05 am](https://user-images.githubusercontent.com/29597/26840611-85d208ee-4a9b-11e7-96e8-4668ffce336b.png)

#### After
![screen shot 2017-06-06 at 9 34 52 am](https://user-images.githubusercontent.com/29597/26840610-85ce9cb8-4a9b-11e7-9ded-e81934f04ff1.png)
