### PR TITLE
[Electron] Fix problem of setDefaultThemeName override user setting

### DIFF
--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -345,8 +345,9 @@ class Store extends EventEmitter {
     this.emit('theme');
   }
 
-  setDefaultThemeName(defaultThemeName: ?string) {
-    this.themeStore.setDefaultThemeName(defaultThemeName);
+  changeDefaultTheme(defaultThemeName: ?string) {
+    this.themeStore.setDefaultTheme(defaultThemeName);
+    this.emit('theme');
   }
 
   saveCustomTheme(theme: Theme) {
@@ -495,7 +496,7 @@ class Store extends EventEmitter {
     while (true) {
       var node = this.get(id);
       var nodeType = node.get('nodeType');
-      
+
       if (nodeType !== 'Wrapper' && nodeType !== 'Native') {
         return id;
       }

--- a/frontend/Themes/Store.js
+++ b/frontend/Themes/Store.js
@@ -31,7 +31,8 @@ class Store {
   }
 
   setDefaultTheme(defaultThemeName: ?string) {
-    this.setDefaultThemeName(defaultThemeName);
+    // Don't accept an invalid themeName as a default.
+    this.defaultThemeName = getSafeThemeName(defaultThemeName);
 
     // Don't restore an invalid themeName.
     // This guards against themes being removed or renamed.
@@ -75,11 +76,6 @@ class Store {
     this.theme = theme;
 
     setInLocalStorage(LOCAL_STORAGE_CUSTOM_THEME_KEY, serialize(theme));
-  }
-
-  setDefaultThemeName(defaultThemeName: ?string) {
-    // Don't accept an invalid themeName as a default.
-    this.defaultThemeName = getSafeThemeName(defaultThemeName);
   }
 }
 

--- a/frontend/Themes/Store.js
+++ b/frontend/Themes/Store.js
@@ -76,6 +76,12 @@ class Store {
   setDefaultThemeName(defaultThemeName: ?string) {
     // Don't accept an invalid themeName as a default.
     this.defaultThemeName = getSafeThemeName(defaultThemeName);
+    // Replace theme with new default if user hasn't select theme
+    const storedThemeKey = getFromLocalStorage(LOCAL_STORAGE_THEME_NAME_KEY);
+    if (storedThemeKey !== CUSTOM_THEME_NAME && !Themes.hasOwnProperty(storedThemeKey)) {
+      this.theme = Themes[this.defaultThemeName];
+      this.themeName = this.defaultThemeName;
+    }
   }
 }
 

--- a/frontend/Themes/Store.js
+++ b/frontend/Themes/Store.js
@@ -27,6 +27,10 @@ class Store {
   themes: { [key: string]: Theme };
 
   constructor(defaultThemeName: ?string) {
+    this.setDefaultTheme(defaultThemeName);
+  }
+
+  setDefaultTheme(defaultThemeName: ?string) {
     this.setDefaultThemeName(defaultThemeName);
 
     // Don't restore an invalid themeName.
@@ -76,12 +80,6 @@ class Store {
   setDefaultThemeName(defaultThemeName: ?string) {
     // Don't accept an invalid themeName as a default.
     this.defaultThemeName = getSafeThemeName(defaultThemeName);
-    // Replace theme with new default if user hasn't select theme
-    const storedThemeKey = getFromLocalStorage(LOCAL_STORAGE_THEME_NAME_KEY);
-    if (storedThemeKey !== CUSTOM_THEME_NAME && !Themes.hasOwnProperty(storedThemeKey)) {
-      this.theme = Themes[this.defaultThemeName];
-      this.themeName = this.defaultThemeName;
-    }
   }
 }
 

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -190,8 +190,7 @@ var DevtoolsUI = {
     if (panel) {
       var {store} = panel.getChildContext();
       // Change default themeName if panel mounted
-      store.setDefaultThemeName(themeName);
-      store.emit('theme');
+      store.changeDefaultTheme(themeName);
     }
     return DevtoolsUI;
   },

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -191,10 +191,7 @@ var DevtoolsUI = {
       var {store} = panel.getChildContext();
       // Change default themeName if panel mounted
       store.setDefaultThemeName(themeName);
-      // Render devtools with the current theme.
-      // If user has selected a theme then ThemeStore will return it.
-      // If not the new default we set above will be used.
-      store.changeTheme(store.themeStore.defaultThemeName);
+      store.emit('theme');
     }
     return DevtoolsUI;
   },


### PR DESCRIPTION
Currently call `setDefaultThemeName(themeName)` will override the current user selected theme with new default, this is not expected. It happened since #751 and #779.