### PR TITLE
Skip nested empty array with keyboard

### DIFF
--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -511,11 +511,11 @@ class Store extends EventEmitter {
         id = parentId;
       } else {
         var children = node.get('children');
-        var index = end ? children.length - 1 : 0;
-        var childId = children[index > 0 ? index : 0];
-        if (!childId) {
-          return id;
+        if (children.length === 0) {
+          return undefined;
         }
+        var index = end ? children.length - 1 : 0;
+        var childId = children[index];
         id = childId;
       }
     }

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -178,12 +178,13 @@ function getNewSelection(dest: Dest, store: Store): ?ElementID {
   }
 
   // Children
+  var cid;
   if (dest === 'firstChild') {
     if (typeof children === 'string') {
       return getNewSelection('nextSibling', store);
     }
     for (var i = 0; i < children.length; i++) {
-      var cid = store.skipWrapper(children[i]);
+      cid = store.skipWrapper(children[i]);
       if (cid) {
         store.isBottomTagSelected = false;
         return cid;
@@ -194,7 +195,7 @@ function getNewSelection(dest: Dest, store: Store): ?ElementID {
     if (typeof children === 'string') {
       return getNewSelection('prevSibling', store);
     }
-    var cid = store.skipWrapper(children[children.length - 1], false, true);
+    cid = store.skipWrapper(children[children.length - 1], false, true);
     if (cid && !store.hasBottom(cid)) {
       store.isBottomTagSelected = false;
     }

--- a/frontend/keyboardNav.js
+++ b/frontend/keyboardNav.js
@@ -182,8 +182,13 @@ function getNewSelection(dest: Dest, store: Store): ?ElementID {
     if (typeof children === 'string') {
       return getNewSelection('nextSibling', store);
     }
-    store.isBottomTagSelected = false;
-    return store.skipWrapper(children[0]);
+    for (var i = 0; i < children.length; i++) {
+      var cid = store.skipWrapper(children[i]);
+      if (cid) {
+        store.isBottomTagSelected = false;
+        return cid;
+      }
+    }
   }
   if (dest === 'lastChild') {
     if (typeof children === 'string') {
@@ -209,29 +214,32 @@ function getNewSelection(dest: Dest, store: Store): ?ElementID {
     pix = pchildren.indexOf(store._parents.get(id));
   }
   if (dest === 'prevSibling') {
-    if (pix === 0) {
-      const roots = store.searchRoots || store.roots;
-      if (roots.indexOf(store.getParent(id)) > -1) {
-        return getRootSelection(dest, store, id);
-      }
-      const childId = pchildren[pix];
+    while (pix > 0) {
+      const childId = pchildren[pix - 1];
       const child = store.get(childId);
-      if (child.get('nodeType') === 'Wrapper') {
-        return store.getParent(id);
+      const prevCid = store.skipWrapper(
+        childId,
+        false,
+        child.get('nodeType') === 'Wrapper'
+      );
+      if (prevCid) {
+        if (store.hasBottom(prevCid)) {
+          store.isBottomTagSelected = true;
+        }
+        return prevCid;
       }
-      return getNewSelection('parent', store);
+      pix--;
     }
-    const childId = pchildren[pix - 1];
+    const roots = store.searchRoots || store.roots;
+    if (roots.indexOf(store.getParent(id)) > -1) {
+      return getRootSelection(dest, store, id);
+    }
+    const childId = pchildren[pix];
     const child = store.get(childId);
-    const prevCid = store.skipWrapper(
-      childId,
-      false,
-      child.get('nodeType') === 'Wrapper'
-    );
-    if (prevCid && store.hasBottom(prevCid)) {
-      store.isBottomTagSelected = true;
+    if (child.get('nodeType') === 'Wrapper') {
+      return store.getParent(id);
     }
-    return prevCid;
+    return getNewSelection('parent', store);
   }
   if (dest === 'nextSibling') {
     if (pix === pchildren.length - 1) {


### PR DESCRIPTION
I think this fixes remaining issue in https://github.com/facebook/react-devtools/issues/786.
It was occurring because we didn't "jump over" a nested array which can be empty.