### PR TITLE
Don't override default theme unless specified

### DIFF
--- a/packages/react-devtools/app.js
+++ b/packages/react-devtools/app.js
@@ -33,9 +33,12 @@ app.on('ready', function() {
     // as the argument to DevTools.
     'window.devtools.setProjectRoots(' + JSON.stringify(projectRoots) + ')'
   );
-  mainWindow.webContents.executeJavaScript(
-    'window.devtools.setDefaultThemeName(' + JSON.stringify(defaultThemeName) + ')'
-  );
+
+  if (defaultThemeName) {
+    mainWindow.webContents.executeJavaScript(
+      'window.devtools.setDefaultThemeName(' + JSON.stringify(defaultThemeName) + ')'
+    );
+  }
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function() {


### PR DESCRIPTION
Don't call `setDefaultThemeName` with an undefined value in case a value has already been set when devtools core was instantiated.

cc @jhen0409 