### PR TITLE
Avoid global variable `script`

### DIFF
--- a/shells/webextension/src/inject.js
+++ b/shells/webextension/src/inject.js
@@ -15,10 +15,12 @@
 module.exports = function(scriptName: string, done: () => void) {
   var src = `
   // the prototype stuff is in case document.createElement has been modified
-  var script = document.constructor.prototype.createElement.call(document, 'script');
-  script.src = "${scriptName}";
-  document.documentElement.appendChild(script);
-  script.parentNode.removeChild(script);
+  (function () {
+    var script = document.constructor.prototype.createElement.call(document, 'script');
+    script.src = "${scriptName}";
+    document.documentElement.appendChild(script);
+    script.parentNode.removeChild(script);
+  })()
   `;
 
   chrome.devtools.inspectedWindow.eval(src, function(res, err) {


### PR DESCRIPTION
Wrap `var script = ...` with a self executing function to avoid global variable `script`.