### PR TITLE
Add "Copy element props" option to context menu

### DIFF
--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -148,6 +148,20 @@ var DEFAULT_MENU_ITEMS = {
         action: () => store.copyNodeName(node.get('name')),
       });
     }
+    const props = node.get('props');
+    if (props) {
+      const numKeys = Object.keys(props)
+        .filter(key => key !== 'children')
+        .length;
+
+      if (numKeys > 0) {
+        items.push({
+          key: 'copyNodeProps',
+          title: 'Copy element props',
+          action: () => store.copyNodeProps(props),
+        });
+      }
+    }
     return items;
   },
   attr: (id, node, val, path, name, store) => {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -16,7 +16,7 @@ var assign = require('object-assign');
 var { copy } = require('clipboard-js');
 var nodeMatchesText = require('./nodeMatchesText');
 var consts = require('../agent/consts');
-var serializeProps = require('../utils/serializeProps');
+var serializePropsForCopy = require('../utils/serializePropsForCopy');
 var invariant = require('./invariant');
 var SearchUtils = require('./SearchUtils');
 var ThemeStore = require('./Themes/Store');
@@ -215,7 +215,7 @@ class Store extends EventEmitter {
   }
 
   copyNodeProps(props: Object): void {
-    copy(serializeProps(props));
+    copy(serializePropsForCopy(props));
   }
 
   setSelectedTab(name: string): void {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -16,6 +16,7 @@ var assign = require('object-assign');
 var { copy } = require('clipboard-js');
 var nodeMatchesText = require('./nodeMatchesText');
 var consts = require('../agent/consts');
+var serializeProps = require('../utils/serializeProps');
 var invariant = require('./invariant');
 var SearchUtils = require('./SearchUtils');
 var ThemeStore = require('./Themes/Store');
@@ -214,9 +215,7 @@ class Store extends EventEmitter {
   }
 
   copyNodeProps(props: Object): void {
-    const cloned = Object.assign({}, props);
-    delete cloned.children;
-    copy(JSON.stringify(cloned, null, 2));
+    copy(serializeProps(props));
   }
 
   setSelectedTab(name: string): void {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -213,6 +213,12 @@ class Store extends EventEmitter {
     copy(name);
   }
 
+  copyNodeProps(props: Object): void {
+    const cloned = Object.assign({}, props);
+    delete cloned.children;
+    copy(JSON.stringify(cloned, null, 2));
+  }
+
   setSelectedTab(name: string): void {
     if (this.selectedTab === name) {
       return;

--- a/utils/serializeProps.js
+++ b/utils/serializeProps.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const consts = require('../agent/consts');
+
+function stripFunctions(props: Object) {
+  for (const key in props) {
+    const value = props[key];
+    const type = (value && value[consts.type]) || typeof value;
+
+    if (type === 'function') {
+      const name = value[consts.name];
+
+      props[key] = `[function ${name}]`;
+    }
+  }
+}
+
+function serializeProps(props: Object): string {
+  const cloned = Object.assign({}, props);
+
+  // Don't try to copy 'children'; the data is probably not meaningful.
+  delete cloned.children;
+
+  // Convert functions to '[function]'
+  stripFunctions(cloned);
+
+  return JSON.stringify(cloned, null, 2);
+}
+
+module.exports = serializeProps;

--- a/utils/serializePropsForCopy.js
+++ b/utils/serializePropsForCopy.js
@@ -25,7 +25,7 @@ function stripFunctions(props: Object) {
   }
 }
 
-function serializeProps(props: Object): string {
+function serializePropsForCopy(props: Object): string {
   const cloned = Object.assign({}, props);
 
   // Don't try to copy 'children'; the data is probably not meaningful.
@@ -37,4 +37,4 @@ function serializeProps(props: Object): string {
   return JSON.stringify(cloned, null, 2);
 }
 
-module.exports = serializeProps;
+module.exports = serializePropsForCopy;

--- a/utils/serializePropsForCopy.js
+++ b/utils/serializePropsForCopy.js
@@ -34,7 +34,11 @@ function serializePropsForCopy(props: Object): string {
   // Convert functions to '[function]'
   stripFunctions(cloned);
 
-  return JSON.stringify(cloned, null, 2);
+  try {
+    return JSON.stringify(cloned, null, 2);
+  } catch (error) {
+    return '';
+  }
 }
 
 module.exports = serializePropsForCopy;


### PR DESCRIPTION
As the gif below shows, elements with props (other than `children`) have a right-click option to copy props to clipboard. All props (excluding `children`) are copied as JSON. This may be helpful to people wanting to quickly copy "production" values out for testing/stubbing purposes.

Is this useful?

![copy-element-props-](https://user-images.githubusercontent.com/29597/28080703-b06763f0-6621-11e7-93aa-e00c6f1018dd.gif)

Resolves #833