### PR TITLE
Ignore 'null' internalInstance in React 15.*

### DIFF
--- a/backend/attachRenderer.js
+++ b/backend/attachRenderer.js
@@ -173,6 +173,14 @@ function walkRoots(roots, onMount, onRoot, isPre013) {
 }
 
 function walkNode(internalInstance, onMount, isPre013) {
+  if (internalInstance === null) {
+    // When a parent has children that include strings and a 'null' value
+    // the 'internalInstance' can be 'null' here, which leads to problems.
+    // So we ignore that node.
+    // Note that this is not an issue in React v16.0+; this path never gets hit
+    // in that case.
+    return;
+  }
   var data = isPre013 ? getData012(internalInstance) : getData(internalInstance);
   if (data.children && Array.isArray(data.children)) {
     data.children.forEach(child => walkNode(child, onMount, isPre013));

--- a/backend/attachRenderer.js
+++ b/backend/attachRenderer.js
@@ -173,14 +173,6 @@ function walkRoots(roots, onMount, onRoot, isPre013) {
 }
 
 function walkNode(internalInstance, onMount, isPre013) {
-  if (internalInstance === null) {
-    // When a parent has children that include strings and a 'null' value
-    // the 'internalInstance' can be 'null' here, which leads to problems.
-    // So we ignore that node.
-    // Note that this is not an issue in React v16.0+; this path never gets hit
-    // in that case.
-    return;
-  }
   var data = isPre013 ? getData012(internalInstance) : getData(internalInstance);
   if (data.children && Array.isArray(data.children)) {
     data.children.forEach(child => walkNode(child, onMount, isPre013));

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -59,7 +59,7 @@ function getData(internalInstance: Object): DataType {
     // Instead of pulling in the whole React library, we just copied over the
     // 'traverseAllChildrenImpl' method.
     // https://github.com/facebook/react/blob/240b84ed8e1db715d759afaae85033718a0b24e1/src/isomorphic/children/ReactChildren.js#L112-L158
-    let unfilteredChildren = internalInstance._currentElement.props.children;
+    const unfilteredChildren = internalInstance._currentElement.props.children;
     var filteredChildren = [];
     traverseAllChildrenImpl(
       unfilteredChildren,

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+var React = require('React');
 import type {DataType} from './types';
 var copyWithSet = require('./copyWithSet');
 var getDisplayName = require('./getDisplayName');
@@ -52,9 +53,17 @@ function getData(internalInstance: Object): DataType {
     children = childrenList(internalInstance._renderedChildren);
   } else if (internalInstance._currentElement && internalInstance._currentElement.props) {
     // This is a native node without rendered children -- meaning the children
-    // prop is just a string or (in the case of the <option>) a list of
-    // strings & numbers.
-    children = internalInstance._currentElement.props.children;
+    // prop is the unfiltered list of children.
+    // This may include 'null' or even other invalid values, so we need to
+    // filter it the same way that ReactDOM does.
+    const children = [];
+    React.Children.forEach(internalInstance._currentElement.props.children,
+      (child) => {
+        if (typeof child === 'string' || typeof child === 'number') {
+          children.push(child);
+        }
+      },
+    );
   }
 
   if (!props && internalInstance._currentElement && internalInstance._currentElement.props) {

--- a/backend/traverseAllChildrenImpl.js
+++ b/backend/traverseAllChildrenImpl.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var invariant = require('fbjs/lib/invariant');
+
+var SEPARATOR = '.';
+var SUBSEPARATOR = ':';
+
+var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+// The Symbol used to tag the ReactElement type. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+const REACT_ELEMENT_TYPE =
+  (
+    typeof Symbol === 'function'
+    && Symbol.for
+    && Symbol.for('react.element')
+  )
+  || 0xeac7;
+
+
+/**
+ * Escape and wrap key so it is safe to use as a reactid
+ *
+ * @param {string} key to be escaped.
+ * @return {string} the escaped key.
+ */
+function escape(key: string): string {
+  var escapeRegex = /[=:]/g;
+  var escaperLookup = {
+    '=': '=0',
+    ':': '=2',
+  };
+  var escapedString = ('' + key).replace(escapeRegex, function(match) {
+    return escaperLookup[match];
+  });
+
+  return '$' + escapedString;
+}
+
+/**
+ * Generate a key string that identifies a component within a set.
+ *
+ * @param {*} component A component that could contain a manual key.
+ * @param {number} index Index that is used if a manual key is not provided.
+ * @return {string}
+ */
+function getComponentKey(component, index) {
+  // Do some typechecking here since we call this blindly. We want to ensure
+  // that we don't block potential future ES APIs.
+  if (
+    typeof component === 'object' &&
+    component !== null &&
+    component.key != null
+  ) {
+    // Explicit key
+    return escape(component.key);
+  }
+  // Implicit key determined by the index in the set
+  return index.toString(36);
+}
+
+/**
+ * We do a copied the 'traverseAllChildrenImpl' method from
+ * `React.Children` so that we don't pull in the whole React library.
+ * @param {?*} children Children tree container.
+ * @param {!string} nameSoFar Name of the key path so far.
+ * @param {!function} callback Callback to invoke with each child found.
+ * @param {?*} traverseContext Used to pass information throughout the traversal
+ * process.
+ * @return {!number} The number of children in this subtree.
+ */
+function traverseAllChildrenImpl(
+  children,
+  nameSoFar,
+  callback,
+  traverseContext,
+) {
+  var type = typeof children;
+
+  if (type === 'undefined' || type === 'boolean') {
+    // All of the above are perceived as null.
+    children = null;
+  }
+
+  if (
+    children === null ||
+    type === 'string' ||
+    type === 'number' ||
+    // The following is inlined from ReactElement. This means we can optimize
+    // some checks. React Fiber also inlines this logic for similar purposes.
+    (type === 'object' && children.$$typeof === REACT_ELEMENT_TYPE)
+  ) {
+    callback(
+      traverseContext,
+      children,
+      // If it's the only child, treat the name as if it was wrapped in an array
+      // so that it's consistent if the number of children grows.
+      nameSoFar === '' ? SEPARATOR + getComponentKey(children, 0) : nameSoFar,
+    );
+    return 1;
+  }
+
+  var child;
+  var nextName;
+  var subtreeCount = 0; // Count of children found in the current subtree.
+  var nextNamePrefix = nameSoFar === '' ? SEPARATOR : nameSoFar + SUBSEPARATOR;
+
+  if (Array.isArray(children)) {
+    for (var i = 0; i < children.length; i++) {
+      child = children[i];
+      nextName = nextNamePrefix + getComponentKey(child, i);
+      subtreeCount += traverseAllChildrenImpl(
+        child,
+        nextName,
+        callback,
+        traverseContext,
+      );
+    }
+  } else {
+    var iteratorFn =
+      (ITERATOR_SYMBOL && children[ITERATOR_SYMBOL]) ||
+      children[FAUX_ITERATOR_SYMBOL];
+    if (typeof iteratorFn === 'function') {
+      var iterator = iteratorFn.call(children);
+      var step;
+      var ii = 0;
+      while (!(step = iterator.next()).done) {
+        child = step.value;
+        nextName = nextNamePrefix + getComponentKey(child, ii++);
+        subtreeCount += traverseAllChildrenImpl(
+          child,
+          nextName,
+          callback,
+          traverseContext,
+        );
+      }
+    } else if (type === 'object') {
+      var addendum =
+        ' If you meant to render a collection of children, use an array ' +
+          'instead.';
+      var childrenString = '' + children;
+      invariant(
+        false,
+        'The React Devtools cannot render an object as a child. (found: %s).%s',
+        childrenString === '[object Object]'
+          ? 'object with keys {' + Object.keys(children).join(', ') + '}'
+          : childrenString,
+        addendum,
+      );
+    }
+  }
+
+  return subtreeCount;
+}
+
+module.exports = traverseAllChildrenImpl;

--- a/backend/traverseAllChildrenImpl.js
+++ b/backend/traverseAllChildrenImpl.js
@@ -80,11 +80,11 @@ function getComponentKey(component, index) {
  * @return {!number} The number of children in this subtree.
  */
 function traverseAllChildrenImpl(
-  children,
-  nameSoFar,
-  callback,
-  traverseContext,
-) {
+  children: any,
+  nameSoFar: string,
+  callback: Function,
+  traverseContext: any
+): number {
   var type = typeof children;
 
   if (type === 'undefined' || type === 'boolean') {


### PR DESCRIPTION
**what is the change?:**
In the <s>'walkRoots'</s> `getData` method used with React pre v16.0 we get 'null' as the
internalInstance in the following situation;
when a parent has a string child followed by '{null}'.

**Edit:** Instead of importing the whole `React` library in order to use
`React.Children.forEach`, we just hand-process the children into an
array, filter it, and then unwrap any single children.

**why make this change?:**
This was causing React devtools to throw in the backend.

<s>An alternative would be to figure out what kind of element we could construct using the 'null' internalInstance, but it seems to me that the correct thing to do here is ignore it.</s>

**Edit:** We found the place where we were pulling in the 'null' child from React and filtered it there.

**test plan:**
**Edit:** I beefed up my manual testing, rendering the following in a CRA:
```
class App extends Component {
  componentWillMount() {
  }

  componentDidMount() {
  }
  render() {
    const optionList = [];
    // possible children types that we can render in various combinations:
    const childValues = [
      {type: 'validChild', value: 'string child'},
      {type: 'afunction', value: () => 'returned string from fn'},
      {type: 'invalidNullChild', value: null},
    ];
    childValues.forEach((firstChild) => {
      childValues.forEach((secondChild) => {
        const childKey = firstChild.type + '-' + secondChild.type;
        optionList.push(
          <option key={childKey} value={childKey}>
            {firstChild.value}-{secondChild.value}
          </option>
        );

      });
    });
    optionList.push(<option key='empty' value='empty'></option>);
    return (
      <div className="App">
        <div className="App-header">
          <img src={logo} className="App-logo" alt="logo" />
          <h2>Welcome to React</h2>
        </div>
        <p className="App-intro">
          To get started, edit <code>src/App.js</code> and save to reload.
        </p>
        <select>{optionList}</select>
      </div>
    );
  }
}
```
2. Run the CRA app and visit that url when testing the React devtools
   using `yarn test:chrome`
3. See that with this fix it actually renders the component tree, and
   without it the React devtools won't load.

**issue:**
fixes #845