### PR TITLE
Remove deprecated proptypes

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -16,6 +16,7 @@ import type {Theme} from './types';
 
 var {sansSerif} = require('./Themes/Fonts');
 var React = require('react');
+var PropTypes = require('prop-types');
 var decorate = require('./decorate');
 
 class Breadcrumb extends React.Component {
@@ -67,7 +68,7 @@ class Breadcrumb extends React.Component {
 }
 
 Breadcrumb.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const containerStyle = (theme: Theme) => ({

--- a/frontend/ContextMenu.js
+++ b/frontend/ContextMenu.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var {sansSerif} = require('./Themes/Fonts');
 var HighlightHover = require('./HighlightHover');
 
@@ -114,7 +115,7 @@ class ContextMenu extends React.Component {
 }
 
 ContextMenu.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 var Wrapped = decorate({

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -14,6 +14,7 @@ import type {Theme, DOMEvent} from '../types';
 
 var {sansSerif} = require('../Themes/Fonts');
 var React = require('react');
+var PropTypes = require('prop-types');
 var Simple = require('./Simple');
 
 var consts = require('../../agent/consts');
@@ -136,7 +137,7 @@ class DataView extends React.Component {
 }
 
 DataView.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 class DataItem extends React.Component {
@@ -293,8 +294,8 @@ class DataItem extends React.Component {
 }
 
 DataItem.contextTypes = {
-  onChange: React.PropTypes.func,
-  theme: React.PropTypes.object.isRequired,
+  onChange: PropTypes.func,
+  theme: PropTypes.object.isRequired,
 };
 
 function alphanumericSort(a: string, b: string): number {

--- a/frontend/DataView/Simple.js
+++ b/frontend/DataView/Simple.js
@@ -12,6 +12,7 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
+var PropTypes = require('prop-types');
 
 var Input = require('../Input');
 var flash = require('../flash');
@@ -142,14 +143,14 @@ class Simple extends React.Component {
 }
 
 Simple.propTypes = {
-  data: React.PropTypes.any,
-  path: React.PropTypes.array,
-  readOnly: React.PropTypes.bool,
+  data: PropTypes.any,
+  path: PropTypes.array,
+  readOnly: PropTypes.bool,
 };
 
 Simple.contextTypes = {
-  onChange: React.PropTypes.func,
-  theme: React.PropTypes.object.isRequired,
+  onChange: PropTypes.func,
+  theme: PropTypes.object.isRequired,
 };
 
 const inputStyle = (theme: Theme) => ({

--- a/frontend/HighlightHover.js
+++ b/frontend/HighlightHover.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var assign = require('object-assign');
 
 import type {Theme} from './types';
@@ -56,7 +57,7 @@ class HighlightHover extends React.Component {
 }
 
 HighlightHover.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 module.exports = HighlightHover;

--- a/frontend/Input.js
+++ b/frontend/Input.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const React = require('react');
+const PropTypes = require('prop-types');
 
 import type {Theme} from './types';
 
@@ -51,7 +52,7 @@ const Input = (props: Props, context: Context) => {
 };
 
 Input.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const inputStyle = (theme: Theme) => ({

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 
 var decorate = require('./decorate');
 var Props = require('./Props');
@@ -406,8 +407,8 @@ class Node extends React.Component {
 }
 
 Node.contextTypes = {
-  scrollTo: React.PropTypes.func,
-  theme: React.PropTypes.object.isRequired,
+  scrollTo: PropTypes.func,
+  theme: PropTypes.object.isRequired,
 };
 
 var WrappedNode = decorate({

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var Container = require('./Container');
 var Store = require('./Store');
 var keyboardNav = require('./keyboardNav');
@@ -222,7 +223,7 @@ class Panel extends React.Component {
 
       this._themeStore = new ThemeStore(this.state.themeName);
       this._store = new Store(this._bridge, this._themeStore);
-      
+
       var refresh = () => this.forceUpdate();
       this.plugins = [
         new RelayPlugin(this._store, this._bridge, refresh),
@@ -355,14 +356,14 @@ class Panel extends React.Component {
 }
 
 Panel.childContextTypes = {
-  browserName: React.PropTypes.string.isRequired,
-  defaultThemeName: React.PropTypes.string.isRequired,
-  showHiddenThemes: React.PropTypes.bool.isRequired,
-  showInspectButton: React.PropTypes.bool.isRequired,
-  store: React.PropTypes.object,
-  theme: React.PropTypes.object.isRequired,
-  themeName: React.PropTypes.string.isRequired,
-  themes: React.PropTypes.object.isRequired,
+  browserName: PropTypes.string.isRequired,
+  defaultThemeName: PropTypes.string.isRequired,
+  showHiddenThemes: PropTypes.bool.isRequired,
+  showInspectButton: PropTypes.bool.isRequired,
+  store: PropTypes.object,
+  theme: PropTypes.object.isRequired,
+  themeName: PropTypes.string.isRequired,
+  themes: PropTypes.object.isRequired,
 };
 
 var panelRNStyle = (bridge, supportsMeasure, theme) => (node, id) => {

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const React = require('react');
+const PropTypes = require('prop-types');
 
 const decorate = require('./decorate');
 const {sansSerif} = require('./Themes/Fonts');
@@ -162,16 +163,16 @@ class PreferencesPanel extends React.Component {
 }
 
 PreferencesPanel.contextTypes = {
-  browserName: React.PropTypes.string.isRequired,
-  showHiddenThemes: React.PropTypes.bool.isRequired,
-  theme: React.PropTypes.object.isRequired,
-  themeName: React.PropTypes.string.isRequired,
-  themes: React.PropTypes.object.isRequired,
+  browserName: PropTypes.string.isRequired,
+  showHiddenThemes: PropTypes.bool.isRequired,
+  theme: PropTypes.object.isRequired,
+  themeName: PropTypes.string.isRequired,
+  themes: PropTypes.object.isRequired,
 };
 PreferencesPanel.propTypes = {
-  changeTheme: React.PropTypes.func,
-  hide: React.PropTypes.func,
-  open: React.PropTypes.bool,
+  changeTheme: PropTypes.func,
+  hide: PropTypes.func,
+  open: PropTypes.bool,
 };
 
 

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -17,6 +17,7 @@ var DetailPaneSection = require('./detail_pane/DetailPaneSection');
 var {sansSerif} = require('./Themes/Fonts');
 var PropVal = require('./PropVal');
 var React = require('react');
+var PropTypes = require('prop-types');
 
 var decorate = require('./decorate');
 var invariant = require('./invariant');
@@ -171,11 +172,11 @@ class PropState extends React.Component {
 }
 
 PropState.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 PropState.childContextTypes = {
-  onChange: React.PropTypes.func,
+  onChange: PropTypes.func,
 };
 
 var WrappedPropState = decorate({

--- a/frontend/PropVal.js
+++ b/frontend/PropVal.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var ReactDOM = require('react-dom');
 
 var consts = require('../agent/consts');
@@ -46,7 +47,7 @@ class PropVal extends React.Component {
 }
 
 PropVal.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 function previewProp(val: any, nested: boolean, inverted: boolean, theme: Theme) {

--- a/frontend/Props.js
+++ b/frontend/Props.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var PropVal = require('./PropVal');
 var {getInvertedMid} = require('./Themes/utils');
 
@@ -55,7 +56,7 @@ class Props extends React.Component {
 }
 
 Props.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const attributeNameStyle = (isInverted: boolean, theme: Theme) => ({

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -13,6 +13,7 @@ const TraceUpdatesFrontendControl = require('../plugins/TraceUpdates/TraceUpdate
 const ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
 const React = require('react');
 const ReactDOM = require('react-dom');
+const PropTypes = require('prop-types');
 const {sansSerif} = require('./Themes/Fonts');
 const SearchUtils = require('./SearchUtils');
 const SvgIcon = require('./SvgIcon');
@@ -156,8 +157,8 @@ class SettingsPane extends React.Component {
 }
 
 SettingsPane.contextTypes = {
-  showInspectButton: React.PropTypes.bool.isRequired,
-  theme: React.PropTypes.object.isRequired,
+  showInspectButton: PropTypes.bool.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 SettingsPane.propTypes = {
   searchText: PropTypes.string,

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -12,6 +12,7 @@
 
 var React = require('react');
 var ReactDOM = require('react-dom');
+var PropTypes = require('prop-types');
 var Draggable = require('./Draggable');
 
 import type {Theme} from './types';
@@ -101,7 +102,7 @@ class SplitPane extends React.Component {
 }
 
 SplitPane.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const containerStyle = (isVertical: boolean) => ({

--- a/frontend/TabbedPane.js
+++ b/frontend/TabbedPane.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var decorate = require('./decorate');
 var {sansSerif} = require('./Themes/Fonts');
 
@@ -54,7 +55,7 @@ class TabbedPane extends React.Component {
 }
 
 TabbedPane.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const tabsStyle = (theme: Theme) => ({

--- a/frontend/Themes/Editor/Editor.js
+++ b/frontend/Themes/Editor/Editor.js
@@ -13,6 +13,7 @@
 const {copy} = require('clipboard-js');
 const decorate = require('../../decorate');
 const React = require('react');
+const PropTypes = require('prop-types');
 const ColorInput = require('./ColorInput');
 const ColorGroups = require('./ColorGroups');
 const Hoverable = require('../../Hoverable');
@@ -199,7 +200,7 @@ class Editor extends React.Component {
 }
 
 Editor.childContextTypes = {
-  theme: React.PropTypes.object,
+  theme: PropTypes.object,
 };
 
 const WrappedEditor = decorate({

--- a/frontend/Themes/Preview.js
+++ b/frontend/Themes/Preview.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const React = require('react');
+const PropTypes = require('prop-types');
 const {Map} = require('immutable');
 
 const consts = require('../../agent/consts');
@@ -54,8 +55,8 @@ class Preview extends React.Component {
 }
 
 Preview.childContextTypes = {
-  scrollTo: React.PropTypes.func,
-  store: React.PropTypes.object,
+  scrollTo: PropTypes.func,
+  store: PropTypes.object,
 };
 
 const fauxRef = {

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -13,6 +13,7 @@
 var Breadcrumb = require('./Breadcrumb');
 var Node = require('./Node');
 var React = require('react');
+var PropTypes = require('prop-types');
 var SearchUtils = require('./SearchUtils');
 
 var decorate = require('./decorate');
@@ -125,11 +126,11 @@ class TreeView extends React.Component {
 }
 
 TreeView.childContextTypes = {
-  scrollTo: React.PropTypes.func,
+  scrollTo: PropTypes.func,
 };
 
 TreeView.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const noSearchResultsStyle = (theme: Theme) => ({

--- a/frontend/decorate.js
+++ b/frontend/decorate.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 
 type Options = {
   /** A function determining whether the component should rerender when the
@@ -126,7 +127,7 @@ module.exports = function(options: Options, Component: any): any {
   }
 
   Wrapper.contextTypes = {
-    [storeKey]: React.PropTypes.object,
+    [storeKey]: PropTypes.object,
   };
 
   Wrapper.displayName = 'Wrapper(' + Component.name + ')';

--- a/frontend/detail_pane/DetailPaneSection.js
+++ b/frontend/detail_pane/DetailPaneSection.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 
 import type {Theme} from '../types';
 
@@ -33,7 +34,7 @@ class DetailPaneSection extends React.Component {
 }
 
 DetailPaneSection.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const sectionStyle = (theme: Theme) => ({

--- a/frontend/provideStore.js
+++ b/frontend/provideStore.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 
 module.exports = function(name: string): Object {
   class Wrapper extends React.Component {
@@ -26,7 +27,7 @@ module.exports = function(name: string): Object {
     }
   }
   Wrapper.childContextTypes = {
-    [name]: React.PropTypes.object,
+    [name]: PropTypes.object,
   };
   Wrapper.displayName = 'StoreProvider(' + name + ')';
   return Wrapper;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "log-update": "^2.0.0",
     "node-libs-browser": "0.5.3",
     "object-assign": "4.0.1",
+    "prop-types": "^15.5.7",
     "raw-loader": "^0.5.1",
     "react": "15.4.2",
     "react-addons-create-fragment": "15.4.2",

--- a/plugins/ReactNativeStyle/AutoSizeInput.js
+++ b/plugins/ReactNativeStyle/AutoSizeInput.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var {monospace} = require('../../frontend/Themes/Fonts');
 var Input = require('../../frontend/Input');
 
@@ -157,7 +158,7 @@ class AutoSizeInput extends React.Component {
 }
 
 AutoSizeInput.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const inputStyle = (text: ?string) => ({

--- a/plugins/ReactNativeStyle/BoxInspector.js
+++ b/plugins/ReactNativeStyle/BoxInspector.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var {sansSerif} = require('../../frontend/Themes/Fonts');
 
 import type {Theme} from '../../frontend/types';
@@ -78,7 +79,7 @@ class BoxInspector extends React.Component {
 }
 
 BoxInspector.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const labelStyle = (theme: Theme) => ({

--- a/plugins/ReactNativeStyle/StyleEdit.js
+++ b/plugins/ReactNativeStyle/StyleEdit.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var AutoSizeInput = require('./AutoSizeInput');
 
 import type {Theme} from '../../frontend/types';
@@ -114,7 +115,7 @@ class StyleEdit extends React.Component {
 }
 
 StyleEdit.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const blockClick = event => event.stopPropagation();

--- a/plugins/Relay/ElementPanel.js
+++ b/plugins/Relay/ElementPanel.js
@@ -11,6 +11,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var decorate = require('../../frontend/decorate');
 
 import type {Theme} from '../../frontend/types';
@@ -61,7 +62,7 @@ class ElementPanel extends React.Component {
 }
 
 ElementPanel.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const dataNodeStyle = (theme: Theme) => ({

--- a/plugins/Relay/Query.js
+++ b/plugins/Relay/Query.js
@@ -15,6 +15,7 @@ import type {Map} from 'immutable';
 
 var {sansSerif} = require('../../frontend/Themes/Fonts');
 var React = require('react');
+var PropTypes = require('prop-types');
 
 class Query extends React.Component {
   theme: {
@@ -60,7 +61,7 @@ class Query extends React.Component {
 }
 
 Query.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const baseContainer = {

--- a/plugins/Relay/StoreTab.js
+++ b/plugins/Relay/StoreTab.js
@@ -14,6 +14,7 @@ import type {Map} from 'immutable';
 import type {Theme} from '../../frontend/types';
 
 var React = require('react');
+var PropTypes = require('prop-types');
 var DataView = require('../../frontend/DataView/DataView');
 var decorate = require('../../frontend/decorate');
 var {sansSerif} = require('../../frontend/Themes/Fonts');
@@ -52,7 +53,7 @@ class StoreTab extends React.Component {
 }
 
 StoreTab.contextTypes = {
-  theme: React.PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const loadingStyle = (theme: Theme) => ({

--- a/shells/theme-preview/source/Application.js
+++ b/shells/theme-preview/source/Application.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const React = require('react');
+const PropTypes = require('prop-types');
 
 const LeftPane = require('./LeftPane');
 const {sansSerif} = require('../../../frontend/Themes/Fonts');
@@ -86,12 +87,12 @@ class Application extends React.Component {
 }
 
 Application.childContextTypes = {
-  store: React.PropTypes.object,
-  theme: React.PropTypes.object,
+  store: PropTypes.object,
+  theme: PropTypes.object,
 };
 Application.propTypes = {
-  theme: React.PropTypes.object,
-  updateTheme: React.PropTypes.func,
+  theme: PropTypes.object,
+  updateTheme: PropTypes.func,
 };
 
 const applicationStyle = (theme: Theme) => ({

--- a/shells/theme-preview/source/LeftPane.js
+++ b/shells/theme-preview/source/LeftPane.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const React = require('react');
+const PropTypes = require('prop-types');
 
 const ExampleIconButton = require('./ExampleIconButton');
 const Icons = require('../../../frontend/Icons');
@@ -58,7 +59,7 @@ const LeftPane = (_: any, {theme}: Context) => (
 );
 
 LeftPane.contextTypes = {
-  theme: React.PropTypes.object,
+  theme: PropTypes.object,
 };
 
 const noop = () => {};

--- a/shells/theme-preview/source/RightPane.js
+++ b/shells/theme-preview/source/RightPane.js
@@ -12,6 +12,7 @@
 
 const Immutable = require('immutable');
 const React = require('react');
+const PropTypes = require('prop-types');
 
 const PropState = require('../../../frontend/PropState');
 
@@ -34,7 +35,7 @@ class RightPane extends React.Component {
 }
 
 RightPane.childContextTypes = {
-  onChange: React.PropTypes.func,
+  onChange: PropTypes.func,
 };
 
 const fauxNode = Immutable.Map({


### PR DESCRIPTION
In react 15.5 React.Proptypes is deprecated and `prop-types` should be used instead