### PR TITLE
Incorporate react tags into UI

### DIFF
--- a/backend/getData.js
+++ b/backend/getData.js
@@ -31,6 +31,7 @@ function getData(internalInstance: Object): DataType {
   var text = null;
   var publicInstance = null;
   var nodeType = 'Native';
+  var reactTag = null;
   // If the parent is a native node without rendered children, but with
   // multiple string children, then the `element` that gets passed in here is
   // a plain value -- a string or number.
@@ -129,6 +130,10 @@ function getData(internalInstance: Object): DataType {
     };
   }
 
+  if (internalInstance._rootNodeID !== 0) {
+    reactTag = internalInstance._rootNodeID;
+  }
+
   return {
     nodeType,
     type,
@@ -143,6 +148,7 @@ function getData(internalInstance: Object): DataType {
     text,
     updater,
     publicInstance,
+    reactTag,
   };
 }
 

--- a/frontend/PropState.js
+++ b/frontend/PropState.js
@@ -102,6 +102,7 @@ class PropState extends React.Component {
 
     var key = this.props.node.get('key');
     var ref = this.props.node.get('ref');
+    var reactTag = this.props.node.get('reactTag');
     var state = this.props.node.get('state');
     var context = this.props.node.get('context');
     var propsReadOnly = !this.props.node.get('canUpdate');
@@ -115,6 +116,15 @@ class PropState extends React.Component {
             key={this.props.id + '-key'}>
             <PropVal
               val={key}
+            />
+          </DetailPaneSection>
+        }
+        {reactTag != null &&
+          <DetailPaneSection
+            title="React Tag"
+            key={this.props.id + '-react-tag'}>
+            <PropVal
+              val={reactTag}
             />
           </DetailPaneSection>
         }

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -258,7 +258,8 @@ class Store extends EventEmitter {
             var node = this.get(item);
             return (node.get('name') && node.get('name').toLowerCase().indexOf(needle) !== -1) ||
               (node.get('text') && node.get('text').toLowerCase().indexOf(needle) !== -1) ||
-              (typeof node.get('children') === 'string' && node.get('children').toLowerCase().indexOf(needle) !== -1);
+              (typeof node.get('children') === 'string' && node.get('children').toLowerCase().indexOf(needle) !== -1) ||
+              (node.get('reactTag') != null && node.get('reactTag').toString().indexOf(needle) === 0);
           });
       } else {
         this.searchRoots = this._nodes.entrySeq()

--- a/frontend/nodeMatchesText.js
+++ b/frontend/nodeMatchesText.js
@@ -21,6 +21,10 @@ function nodeMatchesText(node: Map, needle: string, key: string, store: Store): 
   if (node.get('nodeType') === 'Native' && wrapper && wrapper.get('nodeType') === 'NativeWrapper') {
     return false;
   }
+  var reactTag = node.get('reactTag');
+  if (reactTag != null && reactTag.toString().indexOf(needle) === 0) {
+    return true;
+  }
   var useRegex = SearchUtils.shouldSearchUseRegex(needle);
   if (name) {
     if (node.get('nodeType') !== 'Wrapper') {


### PR DESCRIPTION
@gaearon this PR is a reopening of #454 now that Fiber is done.

Fixes #439. When a node has a react tag and it is selected in the inspector, its react tag is shown in the right pane similar to how "key" and "ref" are shown when they're present.

Here's what it looks like:

**React web screenshot:**

![image](https://user-images.githubusercontent.com/199935/28555450-dc9ca53c-70b4-11e7-91d8-e862c6746707.png)

**React Native screenshot:**

![image](https://user-images.githubusercontent.com/199935/28555521-594b51e6-70b5-11e7-9a35-93aebb5cd8a4.png)

I only care about displaying react tags for use with React Native so I can disable it for React web if you'd like. If you'd like this, please recommend a conditional to distinguish between React Native and React web.

Summary of the changes:
  - React tag is rendered in the right pane when inspecting a node that has a react tag.
  - Search now supports searching by react tag.

Adam Comella
Microsoft Corp.