### PR TITLE
RN: Show computed properties for debugging flexbox layout

### DIFF
--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -222,7 +222,7 @@ class Panel extends React.Component {
 
       this._themeStore = new ThemeStore(this.state.themeName);
       this._store = new Store(this._bridge, this._themeStore);
-      
+
       var refresh = () => this.forceUpdate();
       this.plugins = [
         new RelayPlugin(this._store, this._bridge, refresh),
@@ -303,7 +303,7 @@ class Panel extends React.Component {
     var extraTabs = assign.apply(null, [{}].concat(this.plugins.map(p => p.tabs())));
     var extraPanes = [].concat(...this.plugins.map(p => p.panes()));
     if (this._store.capabilities.rnStyle) {
-      extraPanes.push(panelRNStyle(this._bridge, this._store.capabilities.rnStyleMeasure, theme));
+      extraPanes.push(panelRNStyle(this._store, this._bridge, this._store.capabilities.rnStyleMeasure, theme));
     }
     return (
       <Container
@@ -365,20 +365,15 @@ Panel.childContextTypes = {
   themes: React.PropTypes.object.isRequired,
 };
 
-var panelRNStyle = (bridge, supportsMeasure, theme) => (node, id) => {
-  var props = node.get('props');
-  if (!props || !props.style) {
-    return (
-      <div key="rnstyle" style={containerStyle(theme)}>
-        <strong>No style</strong>
-      </div>
-    );
-  }
+var panelRNStyle = (store, bridge, supportsMeasure, theme) => (node, id) => {
   return (
-    <div key="rnstyle" style={containerStyle(theme)}>
-      <strong>React Native Style Editor</strong>
-      <NativeStyler id={id} bridge={bridge} supportsMeasure={supportsMeasure} />
-    </div>
+    <NativeStyler
+      key="rnstyle"
+      id={id}
+      parentId={store.getParent(id)}
+      bridge={bridge}
+      supportsMeasure={supportsMeasure}
+    />
   );
 };
 

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -377,12 +377,6 @@ var panelRNStyle = (store, bridge, supportsMeasure, theme) => (node, id) => {
   );
 };
 
-const containerStyle = (theme: Theme) => ({
-  borderTop: `1px solid ${theme.base01}`,
-  padding: '0.25rem',
-  marginBottom: '0.25rem',
-  flexShrink: 0,
-});
 const loadingStyle = (theme: Theme) => ({
   fontFamily: sansSerif.family,
   fontSize: sansSerif.sizes.large,

--- a/plugins/ReactNativeStyle/ComputedProperties.js
+++ b/plugins/ReactNativeStyle/ComputedProperties.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+var React = require('react');
+var {monospace} = require('../../frontend/Themes/Fonts');
+import type {Theme} from '../../frontend/types';
+
+type CssValue = {
+  value: string | number,
+  source: string
+};
+
+function resolveAlignSelf(parentStyle: Object, style: Object): CssValue {
+  if (style.alignSelf != null) {
+    return { value: style.alignSelf, source: 'explicit' };
+  } else if (parentStyle.alignItems != null) {
+    return { value: parentStyle.alignItems, source: 'alignItems' };
+  } else {
+    return { value: 'stretch', source: 'default' };
+  }
+}
+
+function resolveFlexBasis(style: Object): CssValue {
+  if (style.flexBasis != null) {
+    return { value: style.flexBasis, source: 'explicit' };
+  } else if (style.flex != null) {
+    return {
+      value: style.flex > 0 ? 0 : 'auto',
+      source: 'flex'
+    };
+  } else {
+    return { value: 'auto', source: 'default' };
+  }
+}
+
+function resolveFlexGrow(style: Object): CssValue {
+  if (style.flexGrow != null) {
+    return { value: style.flexGrow, source: 'explicit' };
+  } else if (style.flex != null) {
+    return {
+      value: style.flex > 0 ? style.flex : 0,
+      source: 'flex'
+    };
+  } else {
+    return { value: 0, source: 'default' };
+  }
+}
+
+function resolveFlexShrink(style: Object): CssValue {
+  if (style.flexShrink != null) {
+    return { value: style.flexShrink, source: 'explicit' };
+  } else if (style.flex != null) {
+    return {
+      value: style.flex < 0 ? -style.flex : 0,
+      source: 'flex'
+    };
+  } else {
+    return { value: 0, source: 'default' };
+  }
+}
+
+function resolveWidth(style: Object): CssValue {
+  if (style.width != null) {
+    return { value: style.width, source: 'explicit' };
+  } else {
+    return { value: 'undefined', source: 'default' };
+  }
+}
+
+function resolveHeight(style: Object): CssValue {
+  if (style.height != null) {
+    return { value: style.height, source: 'explicit' };
+  } else {
+    return { value: 'undefined', source: 'default' };
+  }
+}
+
+type Props = {
+  style: Object,
+  parentStyle: Object,
+  width: number,
+  height: number,
+};
+
+type DefaultProps = {};
+
+type State = {};
+
+class ComputedProperties extends React.Component {
+  props: Props;
+  defaultProps: DefaultProps;
+  state: State;
+
+  constructor(props: Object) {
+    super(props);
+  }
+
+  _renderField(label: string, value: CssValue): React$Element {
+    var sourceDescription = (
+      value.source === 'explicit' ? 'Property set explicity' :
+      value.source === 'default' ? 'Default value' :
+      `Value inherited from '${value.source}' property`
+    );
+    return (
+      <li style={listItemStyle(value.source === 'default')}>
+        <div style={textStyle(this.context.theme, true)}>
+          {label}
+        </div>
+        <span style={styles.colon}>:</span>
+        <div style={textStyle(this.context.theme, false)} title={sourceDescription}>
+          {value.value}
+        </div>
+      </li>
+    );
+  }
+
+  _renderFlexAxisProperties(): React$Element[] {
+    var style = this.props.style;
+    return [
+      this._renderField('flexBasis', resolveFlexBasis(style)),
+      this._renderField('flexGrow', resolveFlexGrow(style)),
+      this._renderField('flexShrink', resolveFlexShrink(style)),
+    ];
+  }
+
+  _renderCrossAxisProperties() {
+    var style = this.props.style;
+    var parentStyle = this.props.parentStyle;
+    return (
+      this._renderField('alignSelf', resolveAlignSelf(parentStyle, style))
+    );
+  }
+
+  render() {
+    var theme = this.context.theme;
+    var parentFlexDirection = this.props.parentStyle.flexDirection || 'column';
+    var isFlexAxisColumn = parentFlexDirection === 'column' || parentFlexDirection === 'column-reverse';
+    return (
+      <div style={styles.container}>
+        <div style={styles.dimensionGroup}>
+          <span style={headerStyle(theme)}>Width</span>
+          <span style={dimenTextStyle(theme)}>{this.props.width}</span>
+          <ul style={styles.list}>
+            {isFlexAxisColumn ? this._renderCrossAxisProperties() : this._renderFlexAxisProperties()}
+            {this._renderField('width', resolveWidth(this.props.style))}
+          </ul>
+        </div>
+
+        <div style={styles.dimensionGroup}>
+          <span style={headerStyle(theme)}>Height</span>
+          <span style={dimenTextStyle(theme)}>{this.props.height}</span>
+          <ul style={styles.list}>
+            {isFlexAxisColumn ? this._renderFlexAxisProperties() : this._renderCrossAxisProperties()}
+            {this._renderField('height', resolveHeight(this.props.style))}
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
+
+ComputedProperties.contextTypes = {
+  theme: React.PropTypes.object.isRequired,
+};
+
+const headerStyle = (theme: Theme) => ({
+  color: theme.base04,
+});
+
+const dimenTextStyle = (theme: Theme) => ({
+  color: theme.special02,
+  marginLeft: 6,
+});
+
+const listItemStyle = (isDisabled: boolean) => ({
+  opacity: isDisabled ? 0.5 : 1.0,
+  margin: 0,
+  display: 'flex',
+  alignItems: 'center',
+  cursor: 'default',
+});
+
+const textStyle = (theme: Theme, isLabel: boolean) => ({
+  color: isLabel ? theme.special03 : theme.base05,
+  marginLeft: isLabel ? 12 : 6,
+  border: 'none',
+  padding: '1px 2px',
+  boxSizing: 'content-box',
+  display: 'inline-block',
+  fontFamily: monospace.family,
+  fontSize: monospace.sizes.normal,
+});
+
+const styles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  dimensionGroup: {
+    margin: '5px 0px',
+  },
+  list: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    cursor: 'text',
+  },
+  colon: {
+    margin: '-3px',
+  },
+};
+
+module.exports = ComputedProperties;

--- a/plugins/ReactNativeStyle/ComputedProperties.js
+++ b/plugins/ReactNativeStyle/ComputedProperties.js
@@ -35,7 +35,7 @@ function resolveFlexBasis(style: Object): CssValue {
   } else if (style.flex != null) {
     return {
       value: style.flex > 0 ? 0 : 'auto',
-      source: 'flex'
+      source: 'flex',
     };
   } else {
     return { value: 'auto', source: 'default' };
@@ -48,7 +48,7 @@ function resolveFlexGrow(style: Object): CssValue {
   } else if (style.flex != null) {
     return {
       value: style.flex > 0 ? style.flex : 0,
-      source: 'flex'
+      source: 'flex',
     };
   } else {
     return { value: 0, source: 'default' };
@@ -61,7 +61,7 @@ function resolveFlexShrink(style: Object): CssValue {
   } else if (style.flex != null) {
     return {
       value: style.flex < 0 ? -style.flex : 0,
-      source: 'flex'
+      source: 'flex',
     };
   } else {
     return { value: 0, source: 'default' };

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -67,7 +67,7 @@ class NativeStyler extends React.Component {
     this.state = {
       style: null,
       measuredLayout: null,
-      parentStyle: getDefaultParentStyle(props)
+      parentStyle: getDefaultParentStyle(props),
     };
   }
 
@@ -100,7 +100,7 @@ class NativeStyler extends React.Component {
     }
     this.setState({
       style: null,
-      parentStyle: getDefaultParentStyle(nextProps)
+      parentStyle: getDefaultParentStyle(nextProps),
     });
     this.props.bridge.send('rn-style:get', nextProps.id);
 
@@ -122,7 +122,7 @@ class NativeStyler extends React.Component {
     var {style, measuredLayout} = result;
     this.setState({
       style: style || {},
-      measuredLayout
+      measuredLayout,
     });
   }
 
@@ -163,7 +163,7 @@ class NativeStyler extends React.Component {
           parentStyle={parentStyle}
           width={this.state.measuredLayout.width}
           height={this.state.measuredLayout.height}
-        />
+        />,
       ];
     } else {
       body = (

--- a/plugins/ReactNativeStyle/ReactNativeStyle.js
+++ b/plugins/ReactNativeStyle/ReactNativeStyle.js
@@ -13,6 +13,10 @@
 var React = require('react');
 var StyleEdit = require('./StyleEdit');
 var BoxInspector = require('./BoxInspector');
+var ComputedProperties = require('./ComputedProperties');
+var DetailPaneSection = require('../../frontend/detail_pane/DetailPaneSection');
+var {sansSerif} = require('../../frontend/Themes/Fonts');
+import type {Theme} from '../../frontend/types';
 
 function shallowClone(obj) {
   var nobj = {};
@@ -22,10 +26,20 @@ function shallowClone(obj) {
   return nobj;
 }
 
+function getDefaultParentStyle(props) {
+  var willFetchParentStyle = props.parentId && props.supportsMeasure;
+  return (
+    willFetchParentStyle
+    ? null // We don't know the parent's style yet. It is or will be loading.
+    : {} // We already know we should treat the parent's style as empty.
+  );
+}
+
 type Props = {
   // TODO: typecheck bridge interface
   bridge: any;
   id: any;
+  parentId: any;
   supportsMeasure: boolean;
 };
 
@@ -33,6 +47,7 @@ type DefaultProps = {};
 
 type State = {
   style: ?Object;
+  parentStyle: ?Object;
   measuredLayout: ?Object;
 };
 
@@ -49,7 +64,11 @@ class NativeStyler extends React.Component {
 
   constructor(props: Object) {
     super(props);
-    this.state = {style: null, measuredLayout: null};
+    this.state = {
+      style: null,
+      measuredLayout: null,
+      parentStyle: getDefaultParentStyle(props)
+    };
   }
 
   componentWillMount() {
@@ -57,6 +76,11 @@ class NativeStyler extends React.Component {
     if (this.props.supportsMeasure) {
       this.props.bridge.on('rn-style:measure', this._styleGet);
       this.props.bridge.send('rn-style:measure', this.props.id);
+      if (this.props.parentId) {
+        this.props.bridge.call('rn-style:get', this.props.parentId, parentStyle => {
+          this.setState({parentStyle: parentStyle || {}});
+        });
+      }
     } else {
       this.props.bridge.call('rn-style:get', this.props.id, style => {
         this.setState({style});
@@ -74,11 +98,19 @@ class NativeStyler extends React.Component {
     if (nextProps.id === this.props.id) {
       return;
     }
-    this.setState({style: null});
+    this.setState({
+      style: null,
+      parentStyle: getDefaultParentStyle(nextProps)
+    });
     this.props.bridge.send('rn-style:get', nextProps.id);
 
     if (this.props.supportsMeasure) {
       this.props.bridge.send('rn-style:measure', nextProps.id);
+      if (nextProps.parentId) {
+        this.props.bridge.call('rn-style:get', nextProps.parentId, parentStyle => {
+          this.setState({parentStyle: parentStyle || {}});
+        });
+      }
     } else {
       this.props.bridge.call('rn-style:get', nextProps.id, style => {
         this.setState({style});
@@ -88,7 +120,10 @@ class NativeStyler extends React.Component {
 
   _styleGet(result: StyleResult) {
     var {style, measuredLayout} = result;
-    this.setState({style, measuredLayout});
+    this.setState({
+      style: style || {},
+      measuredLayout
+    });
   }
 
   _handleStyleChange(attr: string, val: string | number) {
@@ -107,22 +142,100 @@ class NativeStyler extends React.Component {
     this.setState({style});
   }
 
-  render() {
-    if (!this.state.style) {
-      return <em>loading</em>;
+  _renderLayoutSection(loading: boolean) {
+    if (!this.props.supportsMeasure) {
+      return null;
     }
+
+    var body;
+    if (loading) {
+      body = <em>loading</em>;
+    } else if (this.state.measuredLayout) {
+      // These shouldn't be null in this branch but we
+      // need to ensure they aren't null so the program type checks.
+      var style = this.state.style || {};
+      var parentStyle = this.state.parentStyle || {};
+
+      body = [
+        <BoxInspector {...this.state.measuredLayout} />,
+        <ComputedProperties
+          style={style}
+          parentStyle={parentStyle}
+          width={this.state.measuredLayout.width}
+          height={this.state.measuredLayout.height}
+        />
+      ];
+    } else {
+      body = (
+        <div style={emptyStyle(this.context.theme)}>
+          Layout unavailable
+        </div>
+      );
+    }
+
     return (
-      <div style={styles.container}>
-        {this.state.measuredLayout && <BoxInspector {...this.state.measuredLayout} />}
+      <DetailPaneSection
+        title="Layout"
+        key={this.props.id + '-layout'}
+      >
+        {body}
+      </DetailPaneSection>
+    );
+  }
+
+  _renderStyleEditSection(loading: boolean) {
+    var body;
+    if (loading) {
+      body = <em>loading</em>;
+    } else if (!this.state.style || Object.keys(this.state.style).length === 0) {
+      body = (
+        <div style={emptyStyle(this.context.theme)}>
+          No style
+        </div>
+      );
+    } else {
+      body = (
         <StyleEdit
           style={this.state.style}
           onRename={this._handleStyleRename.bind(this)}
           onChange={this._handleStyleChange.bind(this)}
         />
+      );
+    }
+
+    return (
+      <DetailPaneSection
+        title="React Native Style Editor"
+        key={this.props.id + '-style-editor'}
+      >
+        {body}
+      </DetailPaneSection>
+    );
+  }
+
+  render() {
+    var loading = !this.state.style || !this.state.parentStyle;
+    return (
+      <div style={styles.container}>
+        {this._renderLayoutSection(loading)}
+        {this._renderStyleEditSection(loading)}
       </div>
     );
   }
 }
+
+NativeStyler.contextTypes = {
+  theme: React.PropTypes.object.isRequired,
+};
+
+const emptyStyle = (theme: Theme) => ({
+  marginLeft: '0.75rem',
+  padding: '0 5px',
+  color: theme.base04,
+  fontFamily: sansSerif.family,
+  fontSize: sansSerif.sizes.normal,
+  fontStyle: 'italic',
+});
 
 var styles = {
   container: {


### PR DESCRIPTION
Fixes #515.

The primary purpose of this change is to render a new section in the right pane useful for debugging flexbox layouts in React Native. It helps answer questions such as what values does the layout engine see for properties like `flexGrow`, `flexShrink`, and `alignSelf`? Which dimension are these properties influencing (e.g. width or height)? How did each property get its value? Was `flexGrow` set explicitly, is it getting its value from `flex`, or is it just using its default value?

As part of this change, I decided to create a new section in the right pane called "Layout". This section shows the new information I added for debugging flexbox. Additionally, I moved the box which shows the element's width, height, margin, and padding out of the "React Native Style Editor" section and into the "Layout" section. Initially, I tried putting the new flexbox debug UI into the "React Native Style Editor" section but it looked out of place. This is why I created the new "Layout" section.

Here's what it looks like when the inspected element doesn't have a style and it doesn't have a measure method:

![image](https://user-images.githubusercontent.com/199935/28605330-eaafa698-7185-11e7-9913-7859adb0ffc7.png)

Here's what the new flexbox debug information looks like:

![image](https://user-images.githubusercontent.com/199935/28605465-cbe4cf9e-7186-11e7-9c25-7c0aa11a12cd.png)

Some things to note about the sceenshot:
  - `alignSelf` is under the width because it influences the width. Similarly, `flexBasis`, `flexGrow`, and `flexShrink` are under the height because they influence the height.
  - `alignSelf` is slightly faded out because its value is the default. Its value is neither explicitly set nor is it being set indirectly via another property (i.e. the parent's `alignItems` property).
  - `flexBasis`, `flexGrow` and `flexShrink` are fully opaque because their values are either explicitly set or being set indirectly via another property.
  - If you hover over a value, a tooltip appears indicating how the property got its value. The screenshot tells us that `flexGrow` inherited its value from the `flex` property.
  - The blue numbers next to the "Width" and "Height" headers indicate the measured value of that dimension.
  - The slightly faded out "width" and "height" properties represent the value the developer explicitly set for that dimension. In this case, they are slightly faded out and their values are both `undefined` indicating that the developer didn't explicitly set either dimension.

Adam Comella
Microsoft Corp.