### PR TITLE
Fix typo in theme name

### DIFF
--- a/frontend/Themes/Themes.js
+++ b/frontend/Themes/Themes.js
@@ -411,8 +411,8 @@ const Halflife: Theme = {
   state06: '#222222',
 };
 
-const Materia: Theme = {
-  displayName: 'Materia',
+const Material: Theme = {
+  displayName: 'Material',
   base00: '#263238',
   base01: '#2C393F',
   base02: '#37474F',
@@ -627,7 +627,7 @@ module.exports = {
   GruvboxDark,
   GruvboxLight,
   Halflife,
-  Materia,
+  Material,
   MaterialDark,
   OceanDark,
   OneDark,


### PR DESCRIPTION
First PR, and super minor, and may have been typed this way for a reason, but it seems that "Materia" and "Material Dark" are related, but Materia is missing an `l`.

(CLA completed)