### PR TITLE
Set the minimum Chrome version to 49

### DIFF
--- a/shells/chrome/manifest.json
+++ b/shells/chrome/manifest.json
@@ -4,7 +4,7 @@
   "description": "Adds React debugging tools to the Chrome Developer Tools.",
   "version": "2.5.0",
 
-  "minimum_chrome_version": "43",
+  "minimum_chrome_version": "49",
 
   "icons": {
     "16": "icons/16-production.png",


### PR DESCRIPTION
On older versions of Chrome, the browser action icon doesn’t change properly and gives incorrect results. Even the React inspector itself might not work properly.

<img width="1027" alt="chrome minimum version" src="https://user-images.githubusercontent.com/6135313/29857735-cbcf5ca0-8d8c-11e7-91f8-7945594a54a5.png">

I tested multiple old Chrome versions and found that 49 is the minimum.