### PR TITLE
Make the browser action popup look better by enabling `browser_style`

### DIFF
--- a/shells/firefox/manifest.json
+++ b/shells/firefox/manifest.json
@@ -26,7 +26,8 @@
       "128": "icons/128-disabled.png"
     },
 
-    "default_popup": "popups/disabled.html"
+    "default_popup": "popups/disabled.html",
+    "browser_style": true
   },
 
   "devtools_page": "main.html",

--- a/shells/webextension/popups/deadcode.html
+++ b/shells/webextension/popups/deadcode.html
@@ -1,9 +1,19 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  body {
     font-size: 14px;
+    line-height: 1.5;
+    margin: 8px;
     min-width: 460px;
     min-height: 133px;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  hr {
+    width: 100%;
   }
 </style>
 <p>
@@ -11,12 +21,12 @@
 </p>
 <p>
   The React build on this page includes both development and production versions because dead code elimination has not been applied correctly.
-  <br />
-  <br />
+</p>
+<p>
   This makes its size larger, and causes React to run slower.
-  <br />
-  <br />
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">set up dead code elimination</a> before deployment.
+</p>
+<p>
+  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build" target="_blank">set up dead code elimination</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/deadcode.html
+++ b/shells/webextension/popups/deadcode.html
@@ -1,15 +1,9 @@
 <script src="shared.js"></script>
 <style>
-  body {
+  html, body {
     font-size: 14px;
-    line-height: 1.5;
-    margin: 8px;
     min-width: 460px;
     min-height: 133px;
-  }
-
-  p {
-    margin: 0;
   }
 
   hr {
@@ -21,12 +15,12 @@
 </p>
 <p>
   The React build on this page includes both development and production versions because dead code elimination has not been applied correctly.
-</p>
-<p>
+  <br />
+  <br />
   This makes its size larger, and causes React to run slower.
-</p>
-<p>
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build" target="_blank">set up dead code elimination</a> before deployment.
+  <br />
+  <br />
+  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">set up dead code elimination</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/development.html
+++ b/shells/webextension/popups/development.html
@@ -1,15 +1,9 @@
 <script src="shared.js"></script>
 <style>
-  body {
+  html, body {
     font-size: 14px;
-    line-height: 1.5;
-    margin: 8px;
     min-width: 460px;
     min-height: 101px;
-  }
-
-  p {
-    margin: 0;
   }
 
   hr {
@@ -21,9 +15,8 @@
 </p>
 <p>
   Note that the development build is not suitable for production.
-</p>
-<p>
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build" target="_blank">use the production build</a> before deployment.
+  <br />
+  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">use the production build</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/development.html
+++ b/shells/webextension/popups/development.html
@@ -1,9 +1,19 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  body {
     font-size: 14px;
+    line-height: 1.5;
+    margin: 8px;
     min-width: 460px;
     min-height: 101px;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  hr {
+    width: 100%;
   }
 </style>
 <p>
@@ -11,8 +21,9 @@
 </p>
 <p>
   Note that the development build is not suitable for production.
-  <br />
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">use the production build</a> before deployment.
+</p>
+<p>
+  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build" target="_blank">use the production build</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/disabled.html
+++ b/shells/webextension/popups/disabled.html
@@ -1,13 +1,20 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  body {
     font-size: 14px;
+    line-height: 1.5;
+    margin: 8px;
     min-width: 410px;
     min-height: 33px;
+  }
+
+  p {
+    margin: 0;
   }
 </style>
 <p>
   <b>This page doesn&rsquo;t appear to be using React.</b>
-  <br />
-  If this seems wrong, follow the <a href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up">troubleshooting instructions</a>.
+ </p>
+ <p>
+  If this seems wrong, follow the <a href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up" target="_blank">troubleshooting instructions</a>.
 </p>

--- a/shells/webextension/popups/disabled.html
+++ b/shells/webextension/popups/disabled.html
@@ -1,20 +1,17 @@
 <script src="shared.js"></script>
 <style>
-  body {
+  html, body {
     font-size: 14px;
-    line-height: 1.5;
-    margin: 8px;
     min-width: 410px;
     min-height: 33px;
   }
 
-  p {
-    margin: 0;
+  hr {
+    width: 100%;
   }
 </style>
 <p>
   <b>This page doesn&rsquo;t appear to be using React.</b>
- </p>
- <p>
-  If this seems wrong, follow the <a href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up" target="_blank">troubleshooting instructions</a>.
+  <br />
+  If this seems wrong, follow the <a href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up">troubleshooting instructions</a>.
 </p>

--- a/shells/webextension/popups/outdated.html
+++ b/shells/webextension/popups/outdated.html
@@ -1,15 +1,9 @@
 <script src="shared.js"></script>
 <style>
-  body {
+  html, body {
     font-size: 14px;
-    line-height: 1.5;
-    margin: 8px;
     min-width: 460px;
     min-height: 117px;
-  }
-
-  p {
-    margin: 0;
   }
 
   hr {
@@ -21,9 +15,9 @@
 </p>
 <p>
   We recommend updating React to ensure that you receive important bugfixes and performance improvements.
-</p>
-<p>
-  You can find the upgrade instructions on the <a href="https://facebook.github.io/react/blog/" target="_blank">React blog</a>.
+  <br />
+  <br />
+  You can find the upgrade instructions on the <a href="https://facebook.github.io/react/blog/">React blog</a>.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/outdated.html
+++ b/shells/webextension/popups/outdated.html
@@ -1,9 +1,19 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  body {
     font-size: 14px;
+    line-height: 1.5;
+    margin: 8px;
     min-width: 460px;
     min-height: 117px;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  hr {
+    width: 100%;
   }
 </style>
 <p>
@@ -11,9 +21,9 @@
 </p>
 <p>
   We recommend updating React to ensure that you receive important bugfixes and performance improvements.
-  <br />
-  <br />
-  You can find the upgrade instructions on the <a href="https://facebook.github.io/react/blog/">React blog</a>.
+</p>
+<p>
+  You can find the upgrade instructions on the <a href="https://facebook.github.io/react/blog/" target="_blank">React blog</a>.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/production.html
+++ b/shells/webextension/popups/production.html
@@ -1,13 +1,20 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  body {
     font-size: 14px;
+    line-height: 1.5;
+    margin: 8px;
     min-width: 460px;
     min-height: 39px;
+  }
+
+  p {
+    margin: 0;
   }
 </style>
 <p>
   <b>This page is using the production build of React. &#x2705;</b>
-  <br />
+</p>
+<p>
   Open the developer tools, and the React tab will appear to the right.
 </p>

--- a/shells/webextension/popups/production.html
+++ b/shells/webextension/popups/production.html
@@ -1,20 +1,17 @@
 <script src="shared.js"></script>
 <style>
-  body {
+  html, body {
     font-size: 14px;
-    line-height: 1.5;
-    margin: 8px;
     min-width: 460px;
     min-height: 39px;
   }
 
-  p {
-    margin: 0;
+  hr {
+    width: 100%;
   }
 </style>
 <p>
   <b>This page is using the production build of React. &#x2705;</b>
-</p>
-<p>
+  <br />
   Open the developer tools, and the React tab will appear to the right.
 </p>

--- a/shells/webextension/popups/shared.js
+++ b/shells/webextension/popups/shared.js
@@ -1,4 +1,18 @@
+/* globals chrome */
+
 document.addEventListener('DOMContentLoaded', function() {
+  // Make links work
+  var links = document.getElementsByTagName('a');
+  for (var i = 0; i < links.length; i++) {
+    (function() {
+      var ln = links[i];
+      var location = ln.href;
+      ln.onclick = function() {
+        chrome.tabs.create({active: true, url: location});
+      };
+    })();
+  }
+
   // Work around https://bugs.chromium.org/p/chromium/issues/detail?id=428044
   document.body.style.opacity = 0;
   document.body.style.transition = 'opacity ease-out .4s';

--- a/shells/webextension/popups/shared.js
+++ b/shells/webextension/popups/shared.js
@@ -1,18 +1,4 @@
-/* globals chrome */
-
 document.addEventListener('DOMContentLoaded', function() {
-  // Make links work
-  var links = document.getElementsByTagName('a');
-  for (var i = 0; i < links.length; i++) {
-    (function() {
-      var ln = links[i];
-      var location = ln.href;
-      ln.onclick = function() {
-        chrome.tabs.create({active: true, url: location});
-      };
-    })();
-  }
-
   // Work around https://bugs.chromium.org/p/chromium/issues/detail?id=428044
   document.body.style.opacity = 0;
   document.body.style.transition = 'opacity ease-out .4s';

--- a/shells/webextension/popups/unminified.html
+++ b/shells/webextension/popups/unminified.html
@@ -1,9 +1,19 @@
 <script src="shared.js"></script>
 <style>
-  html, body {
+  body {
     font-size: 14px;
+    line-height: 1.5;
+    margin: 8px;
     min-width: 460px;
     min-height: 133px;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  hr {
+    width: 100%;
   }
 </style>
 <p>
@@ -11,11 +21,12 @@
 </p>
 <p>
   The React build on this page appears to be unminified.
-  <br />
+</p>
+<p>
   This makes its size larger, and causes React to run slower.
-  <br />
-  <br />
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">set up minification</a> before deployment.
+</p>
+<p>
+  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build" target="_blank">set up minification</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/unminified.html
+++ b/shells/webextension/popups/unminified.html
@@ -1,15 +1,9 @@
 <script src="shared.js"></script>
 <style>
-  body {
+  html, body {
     font-size: 14px;
-    line-height: 1.5;
-    margin: 8px;
     min-width: 460px;
     min-height: 133px;
-  }
-
-  p {
-    margin: 0;
   }
 
   hr {
@@ -21,12 +15,11 @@
 </p>
 <p>
   The React build on this page appears to be unminified.
-</p>
-<p>
+  <br />
   This makes its size larger, and causes React to run slower.
-</p>
-<p>
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build" target="_blank">set up minification</a> before deployment.
+  <br />
+  <br />
+  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">set up minification</a> before deployment.
 </p>
 <hr />
 <p>


### PR DESCRIPTION
Enable `browser_style` which is available on Firefox 48+ (https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/browser_action#Syntax)
Since the extension already requires Firefox 54, compatibility risk is not a big issue.

Other changes:
- Set consistent body and text spacing
- Set the width of `<hr>` to 100% for Firefox compatibility
- Replace unnecessary link opener JavaScript with `target=“_blank”`

Here are the screenshots of the new popup on Chrome/Firefox and Windows/Mac/Ubuntu:

![win7 chrome](https://user-images.githubusercontent.com/6135313/29860580-1b395596-8d99-11e7-83e7-6b499909d928.png)
![win7 firefox](https://user-images.githubusercontent.com/6135313/29860577-1b046f98-8d99-11e7-9b63-81d6f67ae60c.png)
---
![mac chrome](https://user-images.githubusercontent.com/6135313/29860579-1b391d1a-8d99-11e7-97b9-667202d7345d.png)
![mac firefox](https://user-images.githubusercontent.com/6135313/29860578-1b333bca-8d99-11e7-9b29-edc82c1b676c.png)
---
![ubuntu chrome](https://user-images.githubusercontent.com/6135313/29860581-1b4855dc-8d99-11e7-8298-7ffd3f2239c9.png)
![ubuntu firefox](https://user-images.githubusercontent.com/6135313/29860582-1b4dbd2e-8d99-11e7-9475-8515a3d85541.png)