### PR TITLE
Dim React Native internal components RCT for better readability

### DIFF
--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -199,6 +199,7 @@ class Node extends React.Component {
     }
 
     const collapsed = node.get('collapsed');
+    const dimmed = node.get('dimmed');
     const inverted = selected && isWindowFocused;
 
     const sharedHeadBracketStyle = bracketStyle(inverted && !isBottomTagSelected, theme);
@@ -209,6 +210,7 @@ class Node extends React.Component {
       isBottomTagHovered,
       isBottomTagSelected,
       isCollapsed: collapsed,
+      isDimmed: dimmed,
       isHovered: hovered,
       isSelected: selected,
       isWindowFocused,
@@ -473,6 +475,7 @@ const headStyle = ({
   isBottomTagHovered,
   isBottomTagSelected,
   isCollapsed,
+  isDimmed,
   isHovered,
   isSelected,
   isWindowFocused,
@@ -489,6 +492,7 @@ const headStyle = ({
 
   const isInverted = isSelected && isWindowFocused && !isBottomTagSelected;
   const color = isInverted ? theme.state02 : undefined;
+  const opacity = isDimmed ? 0.25 : 1;
 
   return {
     cursor: 'default',
@@ -499,6 +503,7 @@ const headStyle = ({
     paddingRight,
     backgroundColor,
     color,
+    opacity,
   };
 };
 

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -627,6 +627,7 @@ class Store extends EventEmitter {
     var map = Map(data).set('renders', 1);
     if (data.nodeType === 'Composite') {
       map = map.set('collapsed', true);
+      map = map.set('dimmed', /^RCT/.test(data.name));
     }
     this._nodes = this._nodes.set(data.id, map);
     if (data.children && data.children.forEach) {


### PR DESCRIPTION
Hi,

After using the dev tools with React Native for a while, I wanted to get your thoughts on some ideas to improve the readability of the components' tree.

The first one is what's implemented on this PR, it dims `RCT` components as they tend to be almost the same as the one they're wrapping. I found that this alone helps tonnes with finding components when visually scanning the tree as those are pretty much all over the place. Here's a screenshot of it in action:

![screen shot 2017-09-11 at 21 57 09](https://user-images.githubusercontent.com/376268/30296616-b0740cda-973c-11e7-8980-18c072a7f1b1.png)

This could be optional through a checkbox. It could also allow a user to dim other nodes they're not interested in when looking at some specific part of an app, eg, wrapping data store connectors. I know that filtering allows for a subtree to be seen, but I found that the context switch the filter implies is sometimes too much. A mix mode in which the filter could be used to choose what not to dim could also be handy I guess.

Alternatively, could those `RCT` specific components be removed from the tree? I guess this is up whether for the sake of the component's tree there's a 1 to 1 mapping between say a `View` and its `RCTView` (point 3 of #668).

It's an area to explore I guess :).

The other one is around adjusting the top level node a user sees. A RN app already wraps your app in `AppContainer` and two views. Have you considered an option in which the top node is defined by the user or the RN-specific debugging components are filtered out by default?
Going even further, the example above, which is an CRNA/Expo app, wraps the app with even more components, which means that you have to drill down a good few levels before reaching the app itself. Since Expo is widely used, is this something that could perhaps be detected and implemented (even behind a flag to disable if needed)?

Would love your feedback on this!
Thanks,
Darío