### PR TITLE
Fix the DevTools warning URL

### DIFF
--- a/backend/installGlobalHook.js
+++ b/backend/installGlobalHook.js
@@ -155,7 +155,7 @@ function installGlobalHook(window: Object) {
               'React is running in production mode, but dead code ' +
                 'elimination has not been applied. Read how to correctly ' +
                 'configure React for production: ' +
-                'https://fburl.com/react-perf-use-the-production-build'
+                'https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build'
             );
           });
         }


### PR DESCRIPTION
fburl.com is FB-only.
We probably meant fb.me but I'm not at the office right now and can't create it.

Filing this so we don't forget to release an update to DevTools with this before 16.
Ideally should change it to fb.me alias.