### PR TITLE
Set electron version to upgrade to only patches

### DIFF
--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "cross-spawn": "^5.0.1",
-    "electron": "^1.4.15",
+    "electron": "~1.4.15",
     "ip": "^1.1.4",
     "minimist": "^1.2.0",
     "react-devtools-core": "^2.5.2",


### PR DESCRIPTION
Since electron doesn't follow semver, it's dangerous to assume that we can safely upgrade to minor versions. However, upgrading to patches is fine.
https://github.com/electron/electron/blob/master/docs/tutorial/electron-versioning.md#electron-versioning-1