### PR TITLE
Update react-devtools-core to ws@3.2.0

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -25,7 +25,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "shell-quote": "^1.6.1",
-    "ws": "^2.0.3"
+    "ws": "3.2.0"
   },
   "devDependencies": {
     "cross-env": "^3.1.4"

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -111,7 +111,10 @@ function initialize(socket) {
 var restartTimeout = null;
 function startServer(port = 8097) {
   var httpServer = require('http').createServer();
-  var server = new ws.Server({server: httpServer});
+  var server = new ws.Server({
+    server: httpServer,
+    perMessageDeflate: true,
+  });
   var connected = false;
   server.on('connection', (socket) => {
     if (connected) {


### PR DESCRIPTION
Address the breaking changes from https://github.com/websockets/ws/releases/tag/3.0.0
Keeping the old default `perMessageDeflate: true` -- not sure if you need it & willing to take its perf cost.