### PR TITLE
Always use UTF-8 charset when injecting backend

### DIFF
--- a/shells/webextension/src/inject.js
+++ b/shells/webextension/src/inject.js
@@ -18,6 +18,7 @@ module.exports = function(scriptName: string, done: () => void) {
   (function () {
     var script = document.constructor.prototype.createElement.call(document, 'script');
     script.src = "${scriptName}";
+    script.charset = "utf-8";
     document.documentElement.appendChild(script);
     script.parentNode.removeChild(script);
   })()


### PR DESCRIPTION
Test example:
1. Go to https://untitled-52pbe26ac93b.runkit.sh/bad (source code: https://runkit.com/ngyikp/5a09b954735c280012e78536)
2. Inspect the React element

Expected result:
<img width="485" alt="screen shot 2017-11-14 at 12 00 11 am" src="https://user-images.githubusercontent.com/6135313/32735113-d76a3198-c8ce-11e7-9a8f-c9a1e1ebe59d.png">

Actual result:
<img width="480" alt="screen shot 2017-11-14 at 12 00 24 am" src="https://user-images.githubusercontent.com/6135313/32735115-d8bc9a54-c8ce-11e7-9dba-ff9a8ae0e816.png">

Why:
Webpages that use a different charset from UTF-8 may mangle the display of certain inspector elements on the page (e.g. the ‘×’ in ‘2px × 2px’)
Real life example would be https://www.deviantart.com

Solution is to force UTF-8 charset when injecting the script