### PR TITLE
Add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing to React Devtools
 
+## Code of Conduct
+Facebook has adopted a Code of Conduct that we expect project
+participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct)
+so that you can understand what actions will and will not be tolerated.
+
 ### Pull Requests
 
 The core team will be monitoring for pull requests.


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

Also linking to the COC in the 'CONTRIBUTING' guide, as we do in React
and other repos, for increased visibility.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will complete React Devtool's Community
Profile checklist and increase the visibility of our COC.
https://github.com/facebook/react-devtools/community

**test plan:**
Viewing it on my branch -
<img width="1341" alt="screen shot 2017-11-17 at 7 37 57 am" src="https://user-images.githubusercontent.com/1114467/32955247-5142be8e-cb6a-11e7-9dce-a70fa5feb5aa.png">
<img width="1325" alt="screen shot 2017-11-17 at 7 38 03 am" src="https://user-images.githubusercontent.com/1114467/32955248-516092b0-cb6a-11e7-90fb-d2daf5c866f7.png">


**issue:**
internal task t23481323