### PR TITLE
Prevent error if global hook couldn't run

### DIFF
--- a/shells/webextension/src/checkForReact.js
+++ b/shells/webextension/src/checkForReact.js
@@ -14,7 +14,7 @@
 
 module.exports = function(done: (pageHasReact: boolean) => void) {
   chrome.devtools.inspectedWindow.eval(`!!(
-    Object.keys(window.__REACT_DEVTOOLS_GLOBAL_HOOK__._renderers).length || window.React || (window.require && (require('react') || require('React')))
+    (window.__REACT_DEVTOOLS_GLOBAL_HOOK__ && Object.keys(window.__REACT_DEVTOOLS_GLOBAL_HOOK__._renderers).length) || window.React || (window.require && (require('react') || require('React')))
   )`, function(pageHasReact, err) {
     done(pageHasReact);
   });

--- a/shells/webextension/src/main.js
+++ b/shells/webextension/src/main.js
@@ -19,7 +19,7 @@ function createPanelIfReactLoaded() {
     return;
   }
   chrome.devtools.inspectedWindow.eval(`!!(
-    Object.keys(window.__REACT_DEVTOOLS_GLOBAL_HOOK__._renderers).length || window.React
+    (window.__REACT_DEVTOOLS_GLOBAL_HOOK__ && Object.keys(window.__REACT_DEVTOOLS_GLOBAL_HOOK__._renderers).length) || window.React
   )`, function(pageHasReact, err) {
     if (!pageHasReact || panelCreated) {
       return;


### PR DESCRIPTION
On pages with a CSP that prevents loading of scripts at self (e.g. github), the global
hook will fail. This is because we create a script tag and then inject
it into the page itself.

When this happens window.__REACT_DEVTOOLS_GLOBAL_HOOK__ will be
undefined, and our checks for react will throw an exception.