### PR TITLE
Allow modification to the global hook

### DIFF
--- a/backend/installGlobalHook.js
+++ b/backend/installGlobalHook.js
@@ -232,6 +232,8 @@ function installGlobalHook(window: Object) {
   });
   Object.defineProperty(window, '__REACT_DEVTOOLS_GLOBAL_HOOK__', {
     value: (hook : Hook),
+    configurable: true,
+    writable: true
   });
 }
 


### PR DESCRIPTION
We hijack the devtool hook to add a bunch of end-to-end testing utilities (like using enzyme to query the tree directly, and waiting for Relay requests to finish) to cut down on the `Wait()` calls in webdriver. Generally we run tests in a "clean" browser but sometimes it's helpful to debug with our dev envs, and it's a bit annoying to have to disable the extension to test the e2e stuff

cc @itajaja