### PR TITLE
fix: build failed in windows cmd

### DIFF
--- a/shells/webextension/build.js
+++ b/shells/webextension/build.js
@@ -54,8 +54,10 @@ const build = async(tempPath, manifestPath) => {
   const zipPath = join(tempPath, 'zip');
 
   const webpackPath = join(__dirname, '..', '..', 'node_modules', '.bin', 'webpack');
-  await exec(`NODE_ENV=production ${webpackPath} --config webpack.config.js --output-path ${binPath}`, {cwd: __dirname});
-  await exec(`NODE_ENV=production ${webpackPath} --config webpack.backend.js --output-path ${binPath}`, {cwd: __dirname});
+  await exec(`${webpackPath} --config webpack.config.js --output-path ${binPath}`, 
+             {cwd: __dirname, env:{NODE_ENV: 'production'}});
+  await exec(`${webpackPath} --config webpack.backend.js --output-path ${binPath}`, 
+             {cwd: __dirname, env:{NODE_ENV: 'production'}});
 
   // Make temp dir
   await ensureDir(zipPath);


### PR DESCRIPTION
Put `NODE_ENV` variable into `options.env` to resolve the issue #1013