### PR TITLE
Use PerformedWork effect to tell if a context consumer re-rendered

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -17,7 +17,6 @@ var {
   FunctionalComponent,
   ContextConsumer,
   HostRoot,
-  ForwardRef,
 } = require('./ReactTypeOfWork');
 
 // Inlined from ReactTypeOfSideEffect
@@ -48,7 +47,6 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       case ClassComponent:
       case FunctionalComponent:
       case ContextConsumer:
-      case ForwardRef:
         // For types that execute user code, we check PerformedWork effect.
         // We don't reflect bailouts (either referential or sCU) in DevTools.
         // eslint-disable-next-line no-bitwise

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -51,6 +51,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       case ForwardRef:
         // For types that execute user code, we check PerformedWork effect.
         // We don't reflect bailouts (either referential or sCU) in DevTools.
+        // eslint-disable-next-line no-bitwise
         return (nextFiber.effectTag & PerformedWork) === PerformedWork;
         // Note: ContextConsumer only gets PerformedWork effect in 16.3.3+
         // so it won't get highlighted with React 16.3.0 to 16.3.2.


### PR DESCRIPTION
This depends on https://github.com/facebook/react/pull/12729. It should avoid false positives in Highlight Updates handling of context consumers in an edge case when there's a referential bailout.

The idea is that we should just tag whatever re-rendered (and not just classes) with `PerformedWork`. I forgot about this flag when I added context consumer highlights in https://github.com/facebook/react-devtools/pull/1005.

The downside of this is that people who get this version of DevTools won't see highlights for context consumers for versions of React between 16.3.0 to 16.3.3. I think it's okay and it's better if the feature works consistently for future users.

I like that this lets us simplify the logic and remove the dependency on `updateQueue.hasForceUpdate`. If there was a forced update, *the work was performed* so we don't need to check for that specifically.