### PR TITLE
Add symbols for React.Timeout component to display the name properly

### DIFF
--- a/backend/ReactSymbols.js
+++ b/backend/ReactSymbols.js
@@ -23,4 +23,6 @@ module.exports = {
   FORWARD_REF_SYMBOL_STRING: 'Symbol(react.forward_ref)',
   STRICT_MODE_NUMBER: 0xeacc,
   STRICT_MODE_SYMBOL_STRING: 'Symbol(react.strict_mode)',
+  TIMEOUT_NUMBER: 0xead1,
+  TIMEOUT_SYMBOL_STRING: 'Symbol(react.timeout)',
 };

--- a/backend/getDataFiber.js
+++ b/backend/getDataFiber.js
@@ -33,6 +33,8 @@ var {
   FORWARD_REF_SYMBOL_STRING,
   STRICT_MODE_NUMBER,
   STRICT_MODE_SYMBOL_STRING,
+  TIMEOUT_NUMBER,
+  TIMEOUT_SYMBOL_STRING,
 } = require('./ReactSymbols');
 
 // TODO: we might want to change the data structure
@@ -168,6 +170,13 @@ function getDataFiber(fiber: Object, getOpaqueNode: (fiber: Object) => Object): 
           const functionName = getDisplayName(fiber.type.render, '');
           nodeType = 'Special';
           name = functionName !== '' ? `ForwardRef(${functionName})` : 'ForwardRef';
+          children = [];
+          break;
+        case TIMEOUT_NUMBER:
+        case TIMEOUT_SYMBOL_STRING:
+          nodeType = 'Special';
+          name = 'Timeout';
+          props = fiber.memoizedProps;
           children = [];
           break;
         default:


### PR DESCRIPTION
Hi, this PR is to update the React DevTools to display Timeout components properly, which previously fallbacks to `NOT_IMPLEMENTED_YET`.

My test code:

```js
<div className="App">
  <Timeout ms={1000}>
    {loading => 
      loading ? 
        <h1>Is loading</h1>
        :
        <h1>Loadings been finished</h1>
    }
  </Timeout>
</div>
```

Screenshot on chrome:
![image](https://user-images.githubusercontent.com/13282699/40147284-ea922d40-591d-11e8-9271-b5d1537e0b06.png)

Feel free to leave comments. 😄 


