### PR TITLE
Upgrade electron dep to address vulnerability

### DIFF
--- a/packages/react-devtools/package.json
+++ b/packages/react-devtools/package.json
@@ -23,7 +23,7 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "cross-spawn": "^5.0.1",
-    "electron": "~1.4.15",
+    "electron": "^1.8.7",
     "ip": "^1.1.4",
     "minimist": "^1.2.0",
     "react-devtools-core": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@types/node@^8.0.24":
+  version "8.10.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.17.tgz#d48cf10f0dc6dcf59f827f5a3fc7a4a6004318d3"
+
 Base64@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.2.1.tgz#ba3a4230708e186705065e66babdd4c35cf60028"
@@ -2301,10 +2305,11 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron@~1.4.15:
-  version "1.4.16"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.4.16.tgz#435a7c037c6a858de37569bb4b012c3f286bf1f3"
+electron@^1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.7.tgz#373c1dc4589d7ab4acd49aff8db4a1c0a6c3bcc1"
   dependencies:
+    "@types/node" "^8.0.24"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
```
Package name: electron
Affected versions: < 1.8.2-beta5
Fixed in version: 1.8.2-beta5
```

This commit updates the dependency from ~1.4.15 to ^1.8.7 (the latest 1.x release)

I tested this change against a local React site via:
```sh
yarn build:standalone
yarn test:standalone
```