### PR TITLE
Fixed error when object without hasOwnProperty

### DIFF
--- a/agent/getIn.js
+++ b/agent/getIn.js
@@ -8,6 +8,8 @@
  *
  */
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
+
 /**
  * Retrieves the value from the path of nested objects
  * @param  {Object} base Base or root object for path
@@ -17,7 +19,7 @@
 function getIn(base, path) {
   return path.reduce((obj, attr) => {
     if (obj) {
-      if (obj.hasOwnProperty(attr)) {
+      if (hasOwnProperty.call(obj, attr)) {
         return obj[attr];
       }
       if (typeof obj[Symbol.iterator] === 'function') {


### PR DESCRIPTION
If object create by `Object.create(null)` , getIn will throw error!

![tim 20180616132950](https://user-images.githubusercontent.com/1730277/41496159-6c2dff7c-716b-11e8-8de6-ac9019ab1c37.png)
![tim 20180616132936](https://user-images.githubusercontent.com/1730277/41496160-6d999d30-716b-11e8-9213-6685d9764d68.png)

`counter` is create by:
```js
Object.create(null)
```