### PR TITLE
Remove unnecessary icon font reference

### DIFF
--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -51,7 +51,6 @@
                 margin-top: 10px;
             }
         </style>
-        <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     </head>
     <body>
         <div id="container">


### PR DESCRIPTION
It was added on commit 9283c40789bee888f6c341a9cdf5205528ef9f00 but I don't see any material icons reference on that commit and the current codebase