### PR TITLE
Don't init modules until hook exists

### DIFF
--- a/flow/chrome.js
+++ b/flow/chrome.js
@@ -35,6 +35,7 @@ declare var chrome: {
     },
   },
   tabs: {
+    create: (options: Object) => void,
     executeScript: (tabId: number, options: Object, fn: () => void) => void,
     onUpdated: {
       addListener: (fn: (tabId: number, changeInfo: Object, tab: Object) => void) => void,

--- a/shells/webextension/src/backend.js
+++ b/shells/webextension/src/backend.js
@@ -10,13 +10,9 @@
  */
 'use strict';
 
-var Agent = require('../../../agent/Agent');
-var TraceUpdatesBackendManager = require('../../../plugins/TraceUpdates/TraceUpdatesBackendManager');
-var Bridge = require('../../../agent/Bridge');
-var inject = require('../../../agent/inject');
-var setupRNStyle = require('../../../plugins/ReactNativeStyle/setupBackend');
-var setupHighlighter = require('../../../frontend/Highlighter/setup');
-var setupRelay = require('../../../plugins/Relay/backend');
+// Do not add requires here!
+// Running module factories is intentionally delayed until we know the hook exists.
+// This is to avoid issues like: https://github.com/facebook/react-devtools/issues/1039
 
 window.addEventListener('message', welcome);
 function welcome(evt) {
@@ -29,6 +25,14 @@ function welcome(evt) {
 }
 
 function setup(hook) {
+  var Agent = require('../../../agent/Agent');
+  var TraceUpdatesBackendManager = require('../../../plugins/TraceUpdates/TraceUpdatesBackendManager');
+  var Bridge = require('../../../agent/Bridge');
+  var inject = require('../../../agent/inject');
+  var setupRNStyle = require('../../../plugins/ReactNativeStyle/setupBackend');
+  var setupHighlighter = require('../../../frontend/Highlighter/setup');
+  var setupRelay = require('../../../plugins/Relay/backend');
+
   var listeners = [];
 
   var wall = {


### PR DESCRIPTION
Fixes https://github.com/facebook/react-devtools/issues/1039.

The issue was that we read [stuff like this](https://github.com/facebook/react-devtools/blob/faa4b630a8c055d5ab4ff51536f1e92604d5c09c/shells/webextension/webpack.backend.js#L35-L38) from the hook but this assumes the hook exists. The hook won't exist if we didn't get a permission, such as if we're loading a `file://` URL and our extension doesn't have access to them.

https://github.com/facebook/react-devtools/issues/1039#issuecomment-399901658 has exact reproduction instructions, but note that you'll need to disable `file://` access to reproduce.

Even with the fix, we still have a React tab that can't ever connect. I'm not sure how to fix this, but for now I added a link to troubleshooting instructions once you wait over 3 seconds. I think there were some other cases where this could happen, and this links to a FAQ.