### PR TITLE
Persist the search term between refreshes

### DIFF
--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -18,7 +18,7 @@ const SvgIcon = require('./SvgIcon');
 const Icons = require('./Icons');
 const Input = require('./Input');
 const Hoverable = require('./Hoverable');
-
+const storage = require('../utils/storage');
 const decorate = require('./decorate');
 
 import type {Theme} from './types';
@@ -48,9 +48,9 @@ class SettingsPane extends React.Component {
     // capture=true is needed to prevent chrome devtools console popping up
     doc.addEventListener('keydown', this._key, true);
 
-    const lastSearch = localStorage.getItem('searchText') || '';
-    if (lastSearch !== '') {
-      this.props.onChangeSearch(lastSearch);
+    const lastSearchedTerm = storage.get('searchText', '');
+    if (lastSearchedTerm) {
+      this.props.onChangeSearch(lastSearchedTerm);
     }
   }
 

--- a/frontend/SettingsPane.js
+++ b/frontend/SettingsPane.js
@@ -47,6 +47,11 @@ class SettingsPane extends React.Component {
     const doc = ReactDOM.findDOMNode(this).ownerDocument;
     // capture=true is needed to prevent chrome devtools console popping up
     doc.addEventListener('keydown', this._key, true);
+
+    const lastSearch = localStorage.getItem('searchText') || '';
+    if (lastSearch !== '') {
+      this.props.onChangeSearch(lastSearch);
+    }
   }
 
   componentWillUnmount() {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -306,6 +306,9 @@ class Store extends EventEmitter {
     this.highlightSearch();
     this.refreshSearch = false;
 
+    // Save the search text in local storage so we can use it after a refresh
+    localStorage.setItem('searchText', text);
+
     // Search input depends on this change being flushed synchronously.
     this.flush();
   }

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -20,6 +20,7 @@ var serializePropsForCopy = require('../utils/serializePropsForCopy');
 var invariant = require('./invariant');
 var SearchUtils = require('./SearchUtils');
 var ThemeStore = require('./Themes/Store');
+var storage = require('../utils/storage');
 
 import type Bridge from '../agent/Bridge';
 import type {ControlState, DOMEvent, ElementID, Theme} from './types';
@@ -307,7 +308,7 @@ class Store extends EventEmitter {
     this.refreshSearch = false;
 
     // Save the search text in local storage so we can use it after a refresh
-    localStorage.setItem('searchText', text);
+    storage.set('searchText', text);
 
     // Search input depends on this change being flushed synchronously.
     this.flush();


### PR DESCRIPTION
Saves the last searched text in local storage so when the user refresh the page(auto reload or manually) - the search text appears and shows the results.

Fixes:
- [992](https://github.com/facebook/react-devtools/issues/992)
- [295](https://github.com/facebook/react-devtools/issues/295)

Would be great to get feedback about:
- Is using the local storage is a bad practice?
- When should the text be cleared from the local storage?(if ever)