### PR TITLE
improve scrolling to element

### DIFF
--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -18,6 +18,7 @@ var SearchUtils = require('./SearchUtils');
 
 var decorate = require('./decorate');
 var {monospace, sansSerif} = require('./Themes/Fonts');
+const scrollIntoView = require('scroll-into-view-if-needed');
 
 import type {List} from 'immutable';
 import type {Theme} from './types';
@@ -44,20 +45,18 @@ class TreeView extends React.Component<Props> {
     if (!this.node) {
       return;
     }
-    var val = 0;
-    var height = toNode.offsetHeight;
-    while (toNode && this.node.contains(toNode)) {
-      val += toNode.offsetTop;
-      toNode = toNode.offsetParent;
-    }
-    var top = this.node.scrollTop;
-    var rel = val - this.node.offsetTop;
-    var margin = 40;
-    if (top > rel - margin) {
-      this.node.scrollTop = rel - margin;
-    } else if (top + this.node.offsetHeight < rel + height + margin) {
-      this.node.scrollTop = rel - this.node.offsetHeight + height + margin;
-    }
+    // @TODO timeout used to workaround for breadcrumbs affecting scrollview height
+    clearTimeout(this.pendingScroll);
+
+    const target = toNode.children[0] || toNode;
+    this.pendingScroll = setTimeout(() => {
+      scrollIntoView(target, {
+        scrollMode: 'if-needed',
+        block: 'nearest',
+        inline: 'nearest',
+        boundary: parent => this.node.contains(parent),
+      });
+    }, 1);
   }
 
   render() {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-color": "^2.11.7",
     "react-dom": "^16.4.1",
     "react-portal": "^3.1.0",
+    "scroll-into-view-if-needed": "^2.2.16",
     "webpack": "1.12.9"
   },
   "license": "BSD-3-Clause",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,6 +1714,10 @@ compress-commons@^1.2.0:
     normalize-path "^2.0.0"
     readable-stream "^2.0.0"
 
+compute-scroll-into-view@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.7.tgz#ad8dbe51093c31d60cf6c2df497b2c077bd9e7d2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -6157,6 +6161,12 @@ sax@>=0.6.0:
 sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+
+scroll-into-view-if-needed@^2.2.16:
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.16.tgz#208232f4d7bb531130177b6c02d760d1e1796cbd"
+  dependencies:
+    compute-scroll-into-view "1.0.7"
 
 semver-diff@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Saw this tweet and thought I'd give it a go: https://twitter.com/aweary/status/1025789362607255552

Related issue: #746

![kapture 2018-08-05 at 22 06 22](https://user-images.githubusercontent.com/81981/43689515-032b97ba-98fc-11e8-9510-e085c81414bb.gif)


This PR adds support for horizontal scrolling and also ensures that vertical scrolling is always in view. There's room for improvements though:
* There's a setTimeout workaround for when the height of the elements scrolling frame changes because of very long multi-row breadcrumbs to ensure things are scrolled into view correctly.
* Some things like textNodes have a very wide width triggering unnecessary scrolling.
* There's little space between the edges and the node being scrolled to, but I'll be adding support for `scroll-margin` CSS in `scroll-into-view-if-needed` soon which will allow changing that.

Benefits to using the [`scroll-into-view-if-needed`](https://scroll-into-view-if-needed.netlify.com/) ponyfill, and later possibly [`scroll-margin`](https://developers.google.com/web/updates/2018/07/css-scroll-snap#scroll_padding_and_margin):
* Standards based approach that allows removing dependencies and custom logic in the future when browser support is good enough.
* Less code to maintain in this project.

Thoughts? 😃 