### PR TITLE
Improve Firefox extension development stability for other configurations

### DIFF
--- a/shells/firefox/build.js
+++ b/shells/firefox/build.js
@@ -23,7 +23,7 @@ const main = async () => {
   console.log('yarn run test:firefox');
   console.log(chalk.gray('\n# You can also test against upcoming Firefox releases.'));
   console.log(chalk.gray('# First download a release from https://www.mozilla.org/en-US/firefox/channel/desktop/'));
-  console.log(chalk.gray('# And then tell web-ext which release to use (eg firefoxdeveloperedition, nigthly, beta):'));
+  console.log(chalk.gray('# And then tell web-ext which release to use (eg firefoxdeveloperedition, nightly, beta):'));
   console.log('WEB_EXT_FIREFOX=nightly yarn run test:firefox');
   console.log(chalk.gray('\n# You can test against older versions too:'));
   console.log('WEB_EXT_FIREFOX=/Applications/Firefox52.app/Contents/MacOS/firefox-bin yarn run test:firefox');

--- a/shells/firefox/test.js
+++ b/shells/firefox/test.js
@@ -28,13 +28,25 @@ const main = async () => {
     });
   });
 
-  const path = await findPathPromise;
-  const trimmedPath = path.replace(' ', '\\ ');
+  const options = [
+    `--source-dir=${EXTENSION_PATH}`,
+    `--start-url=${START_URL}`,
+    '--browser-console',
+  ];
 
-  await exec(
-    `web-ext run --start-url=${START_URL} --firefox-profile=${trimmedPath} --browser-console`,
-    {cwd: EXTENSION_PATH}
-  );
+  try {
+    const path = await findPathPromise;
+    const trimmedPath = path.replace(' ', '\\ ');
+    options.push(`--firefox-profile=${trimmedPath}`);
+  } catch (err) {
+    console.warn('Could not find default profile, using temporary profile.');
+  }
+
+  try {
+    await exec(`web-ext run ${options.join(' ')}`);
+  } catch (err) {
+    console.error('`web-ext run` failed', err.stdout, err.stderr);
+  }
 };
 
 main();


### PR DESCRIPTION
These fixes helped me run the `test` command locally.

- Provide `source-dir` as argument to `web-ext` (the env var used did not match the documentation)
- Handle `async` calls more gracefully, like getting the `default` profile (which my machine does not have)