### PR TITLE
Adjust overlay font size

### DIFF
--- a/frontend/Highlighter/Overlay.js
+++ b/frontend/Highlighter/Overlay.js
@@ -58,7 +58,7 @@ class Overlay {
       fontWeight: 'bold',
       padding: '3px 5px',
       position: 'fixed',
-      fontSize: monospace.sizes.normal,
+      fontSize: monospace.sizes.normal + 'px',
     });
 
     this.nameSpan = doc.createElement('span');


### PR DESCRIPTION
Fix https://github.com/facebook/react-devtools/issues/1084

`monospace.sizes.normal` is set to a number:
https://github.com/facebook/react-devtools/blob/4d3ae51dc31617bd813339fb7baa00e0154a0023/frontend/Themes/Fonts.js#L17

In React, setting a font-size to a number will automatically add `px` to the back:

```js
<div style={{fontSize: 20}}>ok</div>
```

However, this is not valid on regular JS:

```
document.body.style.fontSize = 20; // wrong
```