### PR TITLE
Add maxWidth to SplitPane to fix Firefox resize issue

### DIFF
--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -111,6 +111,7 @@ const containerStyle = (isVertical: boolean) => ({
   minWidth: 0,
   flex: 1,
   flexDirection: isVertical ? 'column' : 'row',
+  maxWidth: '100vw',
 });
 
 const draggerInnerStyle = (isVertical: boolean, theme: Theme) => ({


### PR DESCRIPTION
Fixes #336 (and duplicates #1107 and #1110)