### PR TITLE
Profiler UI/UX tweaks and bug-fixes

### DIFF
--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -157,7 +157,9 @@ class Node extends React.Component<PropsType, StateType> {
   ensureInView() {
     var node = this.props.isBottomTagSelected ? this._tail : this._head;
     if (node != null) {
-      if (typeof node.scrollIntoView === 'function') {
+      if (typeof node.scrollIntoViewIfNeeded === 'function') {
+        node.scrollIntoViewIfNeeded();
+      } else if (typeof node.scrollIntoView === 'function') {
         node.scrollIntoView({
           // $FlowFixMe Flow does not realize block:"nearest" is a valid option
           block: 'nearest',
@@ -166,6 +168,13 @@ class Node extends React.Component<PropsType, StateType> {
       }
     }
   }
+
+  _setTailRef = tail => {
+    this._tail = tail;
+  };
+  _setHeadRef = head => {
+    this._head = head;
+  };
 
   render() {
     const {theme} = this.context;
@@ -251,7 +260,7 @@ class Node extends React.Component<PropsType, StateType> {
       }
       return (
         <div
-          ref={h => this._head = h}
+          ref={this._setHeadRef}
           style={sharedHeadStyle}
           {...headEvents}
         >
@@ -293,9 +302,9 @@ class Node extends React.Component<PropsType, StateType> {
       const isCollapsed = content === null || content === undefined;
       return (
         <div style={headWrapperStyle}>
-          <div ref={h => this._head = h} style={sharedHeadStyle} {...headEvents}>
+          <div style={sharedHeadStyle} {...headEvents}>
             &lt;
-            <span style={jsxSingleLineTagStyle}>{name}</span>
+            <span ref={this._setHeadRef} style={jsxSingleLineTagStyle}>{name}</span>
             {node.get('key') &&
               <Props key="key" props={{'key': node.get('key')}} inverted={inverted}/>
             }
@@ -323,7 +332,7 @@ class Node extends React.Component<PropsType, StateType> {
     const closeTag = (
       <Fragment>
         &lt;/
-        <span style={jsxCloseTagStyle}>{name}</span>
+        <span ref={this._setTailRef} style={jsxCloseTagStyle}>{name}</span>
         &gt;
         {selected && ((collapsed && !this.props.isBottomTagSelected) || this.props.isBottomTagSelected) &&
           <span style={dollarRStyle}>&nbsp;== $r</span>
@@ -335,7 +344,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     const jsxOpenTagStyle = jsxTagStyle(inverted && (!isBottomTagSelected || collapsed), nodeType, theme);
     const head = (
-      <div ref={h => this._head = h} style={sharedHeadStyle} {...headEvents}>
+      <div style={sharedHeadStyle} {...headEvents}>
         <span
           onClick={onToggleCollapse}
           style={{
@@ -347,7 +356,7 @@ class Node extends React.Component<PropsType, StateType> {
           {collapsed ? '▶' : '▼'}
         </span>
         &lt;
-        <span style={jsxOpenTagStyle}>{name}</span>
+        <span ref={this._setHeadRef} style={jsxOpenTagStyle}>{name}</span>
         {node.get('key') &&
           <Props key="key" props={{'key': node.get('key')}} inverted={headInverted}/>
         }
@@ -394,7 +403,7 @@ class Node extends React.Component<PropsType, StateType> {
         }}>
           {children.map(id => <WrappedNode key={id} depth={depth + 1} id={id}/>)}
         </div>
-        <div ref={t => this._tail = t} style={tailStyleActual} {...tailEvents}>
+        <div style={tailStyleActual} {...tailEvents}>
           {closeTag}
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jest": "22.1.4",
     "json-loader": "0.5.4",
     "log-update": "^2.0.0",
+    "lru-cache": "^4.1.3",
     "memoize-one": "^3.1.1",
     "node-libs-browser": "0.5.3",
     "nullthrows": "^1.0.0",

--- a/plugins/Profiler/ProfilerStore.js
+++ b/plugins/Profiler/ProfilerStore.js
@@ -18,7 +18,6 @@ const {EventEmitter} = require('events');
 const {get, set} = require('../../utils/storage');
 const LRU = require('lru-cache');
 
-const LOCAL_STORAGE_CHART_TYPE_KEY = 'profiler:selectedChartType';
 const LOCAL_STORAGE_COMMIT_THRESHOLD = 'profiler:commitThreshold';
 const LOCAL_STORAGE_HIDE_COMMITS_BELOW_THRESHOLD = 'profiler:hideCommitsBelowThreshold';
 const LOCAL_STORAGE_SHOW_NATIVE_NODES_KEY = 'profiler:showNativeNodes';
@@ -35,7 +34,7 @@ class ProfilerStore extends EventEmitter {
   processedInteractions: {[id: string]: Interaction} = {};
   rootsToProfilerData: Map<string, RootProfilerData> = new Map();
   roots: List = new List();
-  selectedChartType: ChartType = ((get(LOCAL_STORAGE_CHART_TYPE_KEY, 'flamegraph'): any): ChartType);
+  selectedChartType: ChartType = 'flamegraph';
   selectedRoot: string | null = null;
   showNativeNodes: boolean = ((get(LOCAL_STORAGE_SHOW_NATIVE_NODES_KEY, false): any): boolean);
 
@@ -118,7 +117,6 @@ class ProfilerStore extends EventEmitter {
   setSelectedChartType(selectedChartType: ChartType) {
     this.selectedChartType = selectedChartType;
     this.emit('selectedChartType', selectedChartType);
-    set(LOCAL_STORAGE_CHART_TYPE_KEY, selectedChartType);
   }
 
   setShowNativeNodes(showNativeNodes: boolean) {

--- a/plugins/Profiler/ProfilerStore.js
+++ b/plugins/Profiler/ProfilerStore.js
@@ -16,6 +16,7 @@ import type {ChartType, Interaction, RootProfilerData, Snapshot} from './Profile
 const {List} = require('immutable');
 const {EventEmitter} = require('events');
 const {get, set} = require('../../utils/storage');
+const LRU = require('lru-cache');
 
 const LOCAL_STORAGE_CHART_TYPE_KEY = 'profiler:selectedChartType';
 const LOCAL_STORAGE_COMMIT_THRESHOLD = 'profiler:commitThreshold';
@@ -26,7 +27,7 @@ class ProfilerStore extends EventEmitter {
   _bridge: Bridge;
   _mainStore: Object;
 
-  cachedData = {};
+  cachedData = LRU(50); // Evict items from the cache after this number
   commitThreshold: number = ((get(LOCAL_STORAGE_COMMIT_THRESHOLD, 0): any): number);
   hideCommitsBelowThreshold: boolean = ((get(LOCAL_STORAGE_HIDE_COMMITS_BELOW_THRESHOLD, false): any): boolean);
   isRecording: boolean = false;
@@ -54,26 +55,26 @@ class ProfilerStore extends EventEmitter {
   }
 
   cacheDataForSnapshot(snapshotIndex: number, snapshotRootID: string, key: string, data: any): void {
-    this.cachedData[`${snapshotIndex}-${snapshotRootID}-${key}`] = data;
+    this.cachedData.set(`${snapshotIndex}-${snapshotRootID}-${key}`, data);
   }
 
   cacheInteractionData(rootID: string, data: any): void {
-    this.cachedData[`${rootID}-interactions`] = data;
+    this.cachedData.set(`${rootID}-interactions`, data);
   }
 
   clearSnapshots = () => {
-    this.cachedData = {};
+    this.cachedData.reset();
     this.processedInteractions = {};
     this.rootsToProfilerData = new Map();
     this.emit('profilerData', this.rootsToProfilerData);
   };
 
   getCachedDataForSnapshot(snapshotIndex: number, snapshotRootID: string, key: string): any {
-    return this.cachedData[`${snapshotIndex}-${snapshotRootID}-${key}`] || null;
+    return this.cachedData.get(`${snapshotIndex}-${snapshotRootID}-${key}`) || null;
   }
 
   getCachedInteractionData(rootID: string): any {
-    return this.cachedData[`${rootID}-interactions`] || null;
+    return this.cachedData.get(`${rootID}-interactions`) || null;
   }
 
   processInteraction(interaction: Interaction): Interaction {

--- a/plugins/Profiler/views/FiberRenderDurations.js
+++ b/plugins/Profiler/views/FiberRenderDurations.js
@@ -36,7 +36,7 @@ type ChartData = {|
 type ItemData = {|
   height: number,
   nodes: Array<Node>,
-  scaleY: (value: number) => number,
+  scaleY: (value: number, fallbackValue: number) => number,
   selectedSnapshot: Snapshot,
   selectSnapshot: SelectSnapshot,
   stopInspecting: Function,
@@ -179,7 +179,7 @@ class ListItem extends PureComponent<any, void> {
     const { height, nodes, scaleY, selectedSnapshot, selectSnapshot, stopInspecting, theme } = itemData;
 
     const node = nodes[index];
-    const safeHeight = Math.max(minBarHeight, scaleY(node.value));
+    const safeHeight = Math.max(minBarHeight, scaleY(node.value, minBarHeight));
 
     // List items are absolutely positioned using the CSS "left" attribute.
     // The "top" value will always be 0.

--- a/plugins/Profiler/views/InteractionTimeline.js
+++ b/plugins/Profiler/views/InteractionTimeline.js
@@ -18,14 +18,13 @@ import React, { PureComponent } from 'react';
 import { FixedSizeList as List } from 'react-window';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import NoInteractionsMessage from './NoInteractionsMessage';
-import { scale } from './constants';
+import { getGradientColor, scale } from './constants';
 
 const INTERACTION_SIZE = 4;
 const ITEM_SIZE = 25;
 const SNAPSHOT_SIZE = 10;
 
 type SelectInteraction = (interaction: Interaction) => void;
-type ViewSnapshot = (snapshot: Snapshot) => void;
 
 type ChartItem = {|
   interaction: Interaction,
@@ -35,6 +34,7 @@ type ChartItem = {|
 
 type ChartData = {|
   items: Array<ChartItem>,
+  maxDuration: number,
   stopTime: number,
 |};
 
@@ -47,7 +47,6 @@ type ItemData = {|
   selectedSnapshot: Snapshot,
   selectInteraction: SelectInteraction,
   theme: Theme,
-  viewSnapshot: ViewSnapshot,
 |};
 
 type Props = {|
@@ -55,12 +54,12 @@ type Props = {|
   getCachedInteractionData: GetCachedInteractionData,
   hasMultipleRoots: boolean,
   interactionsToSnapshots: Map<Interaction, Set<Snapshot>>,
+  maxDuration: number,
   selectedInteraction: Interaction | null,
   selectedSnapshot: Snapshot,
   selectInteraction: SelectInteraction,
   theme: Theme,
   timestampsToInteractions: Map<number, Set<Interaction>>,
-  viewSnapshot: ViewSnapshot,
 |};
 
 const InteractionTimeline = ({
@@ -68,17 +67,17 @@ const InteractionTimeline = ({
   getCachedInteractionData,
   hasMultipleRoots,
   interactionsToSnapshots,
+  maxDuration,
   selectedInteraction,
   selectedSnapshot,
   selectInteraction,
   theme,
   timestampsToInteractions,
-  viewSnapshot,
 }: Props) => {
   // Cache data in ProfilerStore so we only have to compute it the first time the interactions tab is shown
   let chartData = getCachedInteractionData(selectedSnapshot.root);
   if (chartData === null) {
-    chartData = getChartData(interactionsToSnapshots, timestampsToInteractions);
+    chartData = getChartData(interactionsToSnapshots, maxDuration, timestampsToInteractions);
     cacheInteractionData(selectedSnapshot.root, chartData);
   }
 
@@ -94,7 +93,6 @@ const InteractionTimeline = ({
           selectInteraction={selectInteraction}
           theme={theme}
           width={width}
-          viewSnapshot={viewSnapshot}
         />
       )}
     </AutoSizer>
@@ -109,7 +107,6 @@ type InteractionsListProps = {|
   selectedSnapshot: Snapshot,
   selectInteraction: SelectInteraction,
   theme: Theme,
-  viewSnapshot: ViewSnapshot,
   width: number,
 |};
 
@@ -153,7 +150,6 @@ class InteractionsList extends PureComponent<InteractionsListProps, void> {
       selectedSnapshot,
       selectInteraction,
       theme,
-      viewSnapshot,
       width,
     } = this.props;
 
@@ -176,7 +172,6 @@ class InteractionsList extends PureComponent<InteractionsListProps, void> {
       selectedSnapshot,
       selectInteraction,
       theme,
-      viewSnapshot,
       width,
     );
 
@@ -214,44 +209,36 @@ type ListItemProps = {|
 |};
 type ListItemState = {|
   isHovered: boolean,
-  hoveredSnapshot: Snapshot | null,
 |};
 
 class ListItem extends PureComponent<ListItemProps, ListItemState> {
   state = {
     isHovered: false,
-    hoveredSnapshot: null,
   };
 
-  handleMouseEnter = (snapshot: Snapshot | null) => this.setState({
-    isHovered: true,
-    hoveredSnapshot: snapshot,
-  });
-
+  handleMouseEnter = () => this.setState({isHovered: true});
   handleMouseLeave = () => this.setState({isHovered: false});
 
   render() {
     const { data: itemData, index: itemIndex, style } = this.props;
-    const { isHovered, hoveredSnapshot } = this.state;
+    const { isHovered } = this.state;
 
     const { chartData, labelColumnWidth, scaleX, selectedInteraction, selectedSnapshot, theme } = itemData;
-    const { items } = chartData;
+    const { items, maxDuration } = chartData;
 
     const item: ChartItem = items[itemIndex];
     const { interaction, lastSnapshotCommitTime } = item;
 
-    const showRowHover = isHovered && hoveredSnapshot === null;
-
     return (
       <div
         onClick={() => itemData.selectInteraction(interaction)}
-        onMouseEnter={() => this.handleMouseEnter(null)}
+        onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
         style={{
           ...style,
           display: 'flex',
           alignItems: 'center',
-          backgroundColor: showRowHover ? theme.state03 : (selectedInteraction === interaction ? theme.base01 : 'transparent'),
+          backgroundColor: isHovered ? theme.state03 : (selectedInteraction === interaction ? theme.base01 : 'transparent'),
           borderBottom: `1px solid ${theme.base01}`,
           cursor: 'pointer',
         }}
@@ -265,8 +252,8 @@ class ListItem extends PureComponent<ListItemProps, ListItemState> {
             lineHeight: `${ITEM_SIZE}px`,
             boxSizing: 'border-box',
             padding: '0 0.25rem',
-            color: showRowHover ? theme.state00 : theme.base05,
-            textDecoration: showRowHover ? 'underline' : 'none',
+            color: isHovered ? theme.state00 : theme.base05,
+            textDecoration: isHovered ? 'underline' : 'none',
             userSelect: 'none',
           }}
           title={interaction.name}
@@ -283,25 +270,27 @@ class ListItem extends PureComponent<ListItemProps, ListItemState> {
             borderRadius: '0.125rem',
           }}
         />
-        {item.snapshots.map((snapshot, snapshotIndex) => (
-          <div
-            key={snapshotIndex}
-            onClick={() => itemData.viewSnapshot(snapshot)}
-            onMouseEnter={() => this.handleMouseEnter(snapshot)}
-            onMouseLeave={() => this.handleMouseEnter(null)}
-            style={{
-              position: 'absolute',
-              left: `${labelColumnWidth + scaleX(snapshot.commitTime)}px`,
-              width: `${SNAPSHOT_SIZE}px`,
-              height: `${SNAPSHOT_SIZE}px`,
-              borderRadius: `${SNAPSHOT_SIZE}px`,
-              backgroundColor: hoveredSnapshot === snapshot || selectedSnapshot === snapshot ? theme.state00 : theme.base00,
-              border: `2px solid ${theme.state00}`,
-              boxSizing: 'border-box',
-              cursor: 'pointer',
-            }}
-          />
-        ))}
+        {item.snapshots.map((snapshot, snapshotIndex) => {
+          // Guard against commits with duration 0
+          const percentage = Math.min(1, Math.max(0, snapshot.duration / maxDuration)) || 0;
+
+          return (
+            <div
+              key={snapshotIndex}
+              style={{
+                position: 'absolute',
+                left: `${labelColumnWidth + scaleX(snapshot.commitTime)}px`,
+                width: `${SNAPSHOT_SIZE}px`,
+                height: `${SNAPSHOT_SIZE}px`,
+                backgroundColor: selectedSnapshot === snapshot
+                  ? theme.state06
+                  : getGradientColor(percentage),
+                boxSizing: 'border-box',
+                cursor: 'pointer',
+              }}
+            />
+          );
+        })}
       </div>
     );
   }
@@ -309,6 +298,7 @@ class ListItem extends PureComponent<ListItemProps, ListItemState> {
 
 const getChartData = memoize((
   interactionsToSnapshots: Map<Interaction, Set<Snapshot>>,
+  maxDuration: number,
   timestampsToInteractions: Map<number, Set<Interaction>>,
 ): ChartData => {
   const items: Array<ChartItem> = [];
@@ -332,6 +322,7 @@ const getChartData = memoize((
 
   return {
     items,
+    maxDuration,
     stopTime,
   };
 });
@@ -342,7 +333,6 @@ const getItemData = memoize((
   selectedSnapshot: Snapshot,
   selectInteraction: SelectInteraction,
   theme: Theme,
-  viewSnapshot: ViewSnapshot,
   width: number,
 ): ItemData => {
   const labelColumnWidth = Math.min(200, width / 5);
@@ -357,7 +347,6 @@ const getItemData = memoize((
     selectedSnapshot,
     selectInteraction,
     theme,
-    viewSnapshot,
   };
 });
 

--- a/plugins/Profiler/views/InteractionTimeline.js
+++ b/plugins/Profiler/views/InteractionTimeline.js
@@ -42,7 +42,7 @@ type ItemData = {|
   chartData: ChartData,
   labelColumnWidth: number,
   graphColumnWidth: number,
-  scaleX: (value: number) => number,
+  scaleX: (value: number, fallbackValue: number) => number,
   selectedInteraction: Interaction | null,
   selectedSnapshot: Snapshot,
   selectInteraction: SelectInteraction,
@@ -263,8 +263,8 @@ class ListItem extends PureComponent<ListItemProps, ListItemState> {
         <div
           style={{
             position: 'absolute',
-            left: `${labelColumnWidth + scaleX(interaction.timestamp)}px`,
-            width: `${scaleX(lastSnapshotCommitTime - interaction.timestamp) + SNAPSHOT_SIZE}px`,
+            left: `${labelColumnWidth + scaleX(interaction.timestamp, 0)}px`,
+            width: `${scaleX(lastSnapshotCommitTime - interaction.timestamp, 0) + SNAPSHOT_SIZE}px`,
             height: `${INTERACTION_SIZE}px`,
             backgroundColor: theme.base03,
             borderRadius: '0.125rem',
@@ -279,7 +279,7 @@ class ListItem extends PureComponent<ListItemProps, ListItemState> {
               key={snapshotIndex}
               style={{
                 position: 'absolute',
-                left: `${labelColumnWidth + scaleX(snapshot.commitTime)}px`,
+                left: `${labelColumnWidth + scaleX(snapshot.commitTime, 0)}px`,
                 width: `${SNAPSHOT_SIZE}px`,
                 height: `${SNAPSHOT_SIZE}px`,
                 backgroundColor: selectedSnapshot === snapshot

--- a/plugins/Profiler/views/NoInteractionsMessage.js
+++ b/plugins/Profiler/views/NoInteractionsMessage.js
@@ -49,7 +49,7 @@ export default ({ hasMultipleRoots, height, width }: Props) => {
       )}
       <p>
         <a href="https://fb.me/react-interaction-tracking" target="_blank">
-          Learn more about the interaction-tracking API here
+          Learn more about the interaction tracking API here
         </a>.
       </p>
     </div>

--- a/plugins/Profiler/views/NoSnapshotDataMessage.js
+++ b/plugins/Profiler/views/NoSnapshotDataMessage.js
@@ -35,6 +35,7 @@ export default ({ height, width }: Props) => (
     </p>
     <p>
       This can indicate that a render occurred too quickly for the timing API to measure.
+      Try selecting another commit in the upper, right-hand corner.
     </p>
   </div>
 );

--- a/plugins/Profiler/views/ProfilerFiberDetailPane.js
+++ b/plugins/Profiler/views/ProfilerFiberDetailPane.js
@@ -44,29 +44,33 @@ const ProfilerFiberDetailPane = ({
 }: Props) => (
   <Fragment>
     <div style={{
-      width: '100%',
-      display: 'flex',
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      padding: '0.25rem',
+      height: '2rem',
+      lineHeight: '2rem',
       backgroundColor: theme.base01,
       borderBottom: `1px solid ${theme.base03}`,
-      boxSizing: 'border-box',
     }}>
-      <div
-        style={{
-          fontFamily: monospace.family,
-          fontSize: monospace.sizes.large,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-        }}
-        title={name}
-      >
-        {name}
-      </div>
-      <div>
+      <div style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: '0.25rem',
+        boxSizing: 'border-box',
+      }}>
+        <div
+          style={{
+            fontFamily: monospace.family,
+            fontSize: monospace.sizes.large,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            flex: '1 1 auto',
+          }}
+          title={name}
+        >
+          {name}
+        </div>
         <IconButton
           disabled={isInspectingSelectedFiber}
           icon={Icons.BARS}
@@ -74,6 +78,7 @@ const ProfilerFiberDetailPane = ({
           style={{
             backgroundColor: theme.state00,
             color: theme.base00,
+            flex: '0 0 auto',
           }}
           theme={theme}
           title={`Inspect ${name}`}
@@ -85,6 +90,7 @@ const ProfilerFiberDetailPane = ({
             marginLeft: '0.25rem',
             backgroundColor: theme.base03,
             color: theme.base05,
+            flex: '0 0 auto',
           }}
           theme={theme}
           title="Close"

--- a/plugins/Profiler/views/ProfilerInteractionDetailPane.js
+++ b/plugins/Profiler/views/ProfilerInteractionDetailPane.js
@@ -14,7 +14,7 @@ import type {Theme} from '../../../frontend/types';
 import type {Interaction, Snapshot} from '../ProfilerTypes';
 
 import React, {Fragment} from 'react';
-import { formatDuration, formatPercentage, formatTime } from './constants';
+import { getGradientColor, formatDuration, formatTime } from './constants';
 import {sansSerif} from '../../../frontend/Themes/Fonts';
 import Hoverable from '../../../frontend/Hoverable';
 
@@ -22,6 +22,7 @@ type ViewSnapshot = (snapshot: Snapshot) => void;
 
 type Props = {|
   interaction: Interaction,
+  maxDuration: number,
   selectedSnapshot: Snapshot | null,
   snapshots: Set<Snapshot>,
   theme: Theme,
@@ -30,6 +31,7 @@ type Props = {|
 
 const ProfilerInteractionDetailPane = ({
   interaction,
+  maxDuration,
   selectedSnapshot,
   snapshots,
   theme,
@@ -50,16 +52,19 @@ const ProfilerInteractionDetailPane = ({
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
+          display: 'flex',
+          justifyContent: 'space-between',
         }}
         title={interaction.name}
       >
-        {interaction.name}
+        {interaction.name} at {formatTime(interaction.timestamp)}s
       </div>
       <div style={{
         padding: '0.5rem',
       }}>
-        <div><strong>Timestamp</strong>: {formatTime(interaction.timestamp)}s</div>
-        <div style={{margin: '0.5rem 0'}}><strong>Renders</strong>:</div>
+        <div style={{marginBottom: '0.5rem'}}>
+          <strong>Commits</strong>:
+        </div>
         <ul style={{
           listStyle: 'none',
           margin: 0,
@@ -72,6 +77,7 @@ const ProfilerInteractionDetailPane = ({
             return (
               <SnapshotLink
                 key={index}
+                maxDuration={maxDuration}
                 onClick={() => viewSnapshot(snapshot)}
                 previousTimestamp={previousTimestamp}
                 selectedSnapshot={selectedSnapshot}
@@ -89,6 +95,7 @@ const ProfilerInteractionDetailPane = ({
 
 const SnapshotLink = Hoverable(({
   isHovered,
+  maxDuration,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -98,9 +105,6 @@ const SnapshotLink = Hoverable(({
   theme,
   viewSnapshot,
 }) => {
-  const cpuPercentage = Math.max(0, Math.min(snapshot.duration / (snapshot.commitTime - previousTimestamp)));
-  const cpuSvg = CPU_SVGS[Math.round(cpuPercentage * (CPU_SVGS.length - 1))];
-
   return (
     <li
       onClick={onClick}
@@ -114,59 +118,26 @@ const SnapshotLink = Hoverable(({
         display: 'flex',
         alignItems: 'center',
         padding: '0.5rem',
-        borderBottom: `1px solid ${theme.base01}`,
+        borderTop: `1px solid ${theme.base01}`,
       }}
     >
-      {cpuSvg}
+      <div
+        style={{
+          width: '1rem',
+          height: '1rem',
+          backgroundColor: getGradientColor(snapshot.duration / maxDuration),
+        }}
+      />
       <ul style={{paddingLeft: '1.5rem'}}>
-        <li>Timestamp: {formatTime(snapshot.commitTime)}s</li>
-        <li>Duration: {formatDuration(snapshot.duration)}ms</li>
-        <li>CPU: {formatPercentage(cpuPercentage)}%</li>
+        <li style={{marginBottom: '0.25rem'}}>
+          Timestamp: {formatTime(snapshot.commitTime)}s
+        </li>
+        <li>
+          Duration: {formatDuration(snapshot.duration)}ms
+        </li>
       </ul>
     </li>
   );
 });
-
-const CPU_STYLE = {
-  width: '1.5rem',
-  height: '1.5rem',
-  fill: 'currentColor',
-  marginRight: '0.5rem',
-};
-
-const CPU_0 = (
-  <svg style={CPU_STYLE} viewBox="0 0 24 24">
-    <path fillOpacity=".3" d="M2 22h20V2z" />
-  </svg>
-);
-
-const CPU_25 = (
-  <svg style={CPU_STYLE} viewBox="0 0 24 24">
-    <path fillOpacity=".3" d="M2 22h20V2z" />
-    <path d="M12 12L2 22h10z" />
-  </svg>
-);
-
-const CPU_50 = (
-  <svg style={CPU_STYLE} viewBox="0 0 24 24">
-    <path fillOpacity=".3" d="M2 22h20V2z" />
-    <path d="M14 10L2 22h12z" />
-  </svg>
-);
-
-const CPU_75 = (
-  <svg style={CPU_STYLE} viewBox="0 0 24 24">
-    <path fillOpacity=".3" d="M2 22h20V2z" />
-    <path d="M17 7L2 22h15z" />
-  </svg>
-);
-
-const CPU_100 = (
-  <svg style={CPU_STYLE} viewBox="0 0 24 24">
-    <path d="M2 22h20V2z" />
-  </svg>
-);
-
-const CPU_SVGS = [CPU_0, CPU_25, CPU_50, CPU_75, CPU_100];
 
 export default ProfilerInteractionDetailPane;

--- a/plugins/Profiler/views/ProfilerInteractionDetailPane.js
+++ b/plugins/Profiler/views/ProfilerInteractionDetailPane.js
@@ -125,7 +125,9 @@ const SnapshotLink = Hoverable(({
         style={{
           width: '1rem',
           height: '1rem',
-          backgroundColor: getGradientColor(snapshot.duration / maxDuration),
+          backgroundColor: selectedSnapshot === snapshot
+            ? theme.state06
+            : getGradientColor(snapshot.duration / maxDuration),
         }}
       />
       <ul style={{paddingLeft: '1.5rem'}}>

--- a/plugins/Profiler/views/ProfilerInteractionDetailPane.js
+++ b/plugins/Profiler/views/ProfilerInteractionDetailPane.js
@@ -43,8 +43,8 @@ const ProfilerInteractionDetailPane = ({
     <Fragment>
       <div
         style={{
-          height: '34px',
-          lineHeight: '34px',
+          height: '2rem',
+          lineHeight: '2rem',
           padding: '0 0.5rem',
           backgroundColor: theme.base01,
           borderBottom: `1px solid ${theme.base03}`,

--- a/plugins/Profiler/views/ProfilerSnapshotDetailPane.js
+++ b/plugins/Profiler/views/ProfilerSnapshotDetailPane.js
@@ -34,8 +34,8 @@ const ProfilerSnapshotDetailPane = ({
   <Fragment>
     <div
       style={{
-        height: '34px',
-        lineHeight: '34px',
+        height: '2rem',
+        lineHeight: '2rem',
         padding: '0 0.5rem',
         backgroundColor: theme.base01,
         borderBottom: `1px solid ${theme.base03}`,

--- a/plugins/Profiler/views/ProfilerTab.js
+++ b/plugins/Profiler/views/ProfilerTab.js
@@ -25,6 +25,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import decorate from '../../../frontend/decorate';
 import {sansSerif} from '../../../frontend/Themes/Fonts';
+import { getMaxDuration } from './constants';
 import FiberRenderDurations from './FiberRenderDurations';
 import InteractionTimeline from './InteractionTimeline';
 import NoProfilingDataMessage from './NoProfilingDataMessage';
@@ -200,6 +201,7 @@ class ProfilerTab extends React.Component<Props, State> {
 
     const snapshot = snapshots[snapshotIndex];
     const snapshotFiber = selectedFiberID && snapshot.nodes.get(selectedFiberID) || null;
+    const maxDuration = getMaxDuration(snapshots);
 
     let content;
     if (isRecording) {
@@ -238,12 +240,12 @@ class ProfilerTab extends React.Component<Props, State> {
             getCachedInteractionData={getCachedInteractionData}
             hasMultipleRoots={hasMultipleRoots}
             interactionsToSnapshots={interactionsToSnapshots}
+            maxDuration={maxDuration}
             selectedInteraction={selectedInteraction}
             selectedSnapshot={snapshot}
             selectInteraction={this.selectInteraction}
             theme={theme}
             timestampsToInteractions={timestampsToInteractions}
-            viewSnapshot={this.viewSnapshot}
           />
         );
       } else {
@@ -296,6 +298,7 @@ class ProfilerTab extends React.Component<Props, State> {
       details = (
         <ProfilerInteractionDetailPane
           interaction={((selectedInteraction: any): Interaction)}
+          maxDuration={getMaxDuration(snapshots)}
           selectedSnapshot={snapshot}
           snapshots={((interactionsToSnapshots.get(((selectedInteraction: any): Interaction)): any): Set<Snapshot>)}
           theme={theme}

--- a/plugins/Profiler/views/ProfilerTabToolbar.js
+++ b/plugins/Profiler/views/ProfilerTabToolbar.js
@@ -97,6 +97,7 @@ const ProfilerTabToolbar = ({
     position: 'relative',
     boxSizing: 'border-box',
     width,
+    userSelect: 'none',
   }}>
     <RecordButton
       isActive={isRecording}

--- a/plugins/Profiler/views/SnapshotRanked.js
+++ b/plugins/Profiler/views/SnapshotRanked.js
@@ -37,10 +37,11 @@ type ItemData = {|
   inspectFiber: SelectOrInspectFiber,
   nodes: Array<Node>,
   maxValue: number,
-  scaleX: (value: number) => number,
+  scaleX: (value: number, fallbackValue: number) => number,
   selectFiber: SelectOrInspectFiber,
   snapshot: Snapshot,
   theme: Theme,
+  width: number,
 |};
 
 type Props = {|
@@ -182,7 +183,7 @@ class ListItem extends PureComponent<any, void> {
 
     const node = data.nodes[index];
 
-    const { scaleX } = data;
+    const { scaleX, width } = data;
 
     // List items are absolutely positioned using the CSS "top" attribute.
     // The "left" value will always be 0.
@@ -201,7 +202,7 @@ class ListItem extends PureComponent<any, void> {
         onDoubleClick={this.handleDoubleClick}
         theme={data.theme}
         title={node.title}
-        width={Math.max(minBarWidth, scaleX(node.value))}
+        width={Math.max(minBarWidth, scaleX(node.value, width))}
         x={0}
         y={top}
       />
@@ -227,6 +228,7 @@ const getItemData = memoize((
   selectFiber,
   snapshot,
   theme,
+  width,
 }));
 
 const getNodeIndex = memoize((rankedData: RankedData, id: string | null): number => {
@@ -247,10 +249,7 @@ const convertSnapshotToChartData = (snapshot: Snapshot, showNativeNodes: boolean
     .filter(nodeID => {
       const node = snapshot.nodes.get(nodeID);
       const nodeType = node && node.get('nodeType');
-      return (
-        (nodeType === 'Composite' || (nodeType === 'Native' && showNativeNodes)) &&
-        node.get('actualDuration') > 0
-      );
+      return (nodeType === 'Composite' || (nodeType === 'Native' && showNativeNodes));
     })
     .map((nodeID, index) => {
       const node = snapshot.nodes.get(nodeID).toJSON();

--- a/plugins/Profiler/views/constants.js
+++ b/plugins/Profiler/views/constants.js
@@ -29,8 +29,10 @@ export const minBarWidth = 5;
 export const textHeight = 18;
 
 export const scale = (minValue: number, maxValue: number, minRange: number, maxRange: number) =>
-  (value: number) =>
-    ((value - minValue) / (maxValue - minValue)) * (maxRange - minRange);
+  (value: number, fallbackValue: number) =>
+    maxValue - minValue === 0
+      ? fallbackValue
+      : ((value - minValue) / (maxValue - minValue)) * (maxRange - minRange);
 
 const gradientMaxIndex = gradient.length - 1;
 export const getGradientColor = (value: number) => {

--- a/plugins/Profiler/views/constants.js
+++ b/plugins/Profiler/views/constants.js
@@ -50,6 +50,10 @@ export const formatDuration = (duration: number) => Math.round(duration * 10) / 
 export const formatPercentage = (percentage: number) => Math.round(percentage * 100);
 export const formatTime = (timestamp: number) => Math.round(Math.round(timestamp) / 100) / 10;
 
+export const getMaxDuration = (snapshots: Array<Snapshot>): number =>
+  snapshots.reduce((maxDuration: number, snapshot: Snapshot) =>
+    Math.max(maxDuration, snapshot.duration || 0), 0);
+
 type FilteredSnapshotData = {|
   snapshotIndex: number,
   snapshots: Array<Snapshot>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4769,6 +4769,13 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
+lru-cache@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 make-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
@@ -5580,7 +5587,7 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
-pseudomap@^1.0.1:
+pseudomap@^1.0.1, pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
@@ -7333,6 +7340,10 @@ y18n@^3.2.1:
 yallist@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
 yargs-parser@^4.2.0:
   version "4.2.1"


### PR DESCRIPTION
Resolves #1104 and umbrella issue #1099

#### Interactions
- 09edccb: Tie the commits more to the chart views. Maybe use the colors (based on commit duration) for the circles in the interactions view?
- 09edccb: Commits are shown as bars in the charts, but in the interactions tab they're circles. Maybe they should be little colored squares? At least in the "renders" side pane, rather than showing the triangle that fills in, show the colored squares?
- 09edccb: Maybe use black for selected (like we do in the snapshot selector)

#### Elements panel
- cca8b0c: Only scroll selected node if not already visible

#### General
- f984a56: Replace simple cache with LRU cache for charting data