### PR TITLE
Make Breadcrumb resizable

### DIFF
--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -123,7 +123,6 @@ const containerStyle = (theme: Theme) => ({
   maxHeight: '80px',
   backgroundColor: theme.base01,
   borderTop: `1px solid ${theme.base03}`,
-  whiteSpace: 'nowrap',
   overflow: 'auto',
 });
 

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -120,10 +120,11 @@ const containerStyle = (theme: Theme) => ({
   listStyle: 'none',
   padding: '0 0.5rem',
   margin: 0,
-  maxHeight: '80px',
   backgroundColor: theme.base01,
   borderTop: `1px solid ${theme.base03}`,
   overflow: 'auto',
+  width: '100%',
+  height: '100%',
 });
 
 const itemStyle = (isSelected: boolean, nodeType: string, theme: Theme) => {

--- a/frontend/Container.js
+++ b/frontend/Container.js
@@ -101,8 +101,6 @@ class Container extends React.Component<Props, State> {
     var tabs = {
       Elements: () => (
         <SplitPane
-          initialWidth={10}
-          initialHeight={10}
           left={() => <LeftPane reload={this.props.reload} />}
           right={() => (
             <PropState

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -82,7 +82,7 @@ class SplitPane extends React.Component<Props, State> {
 
     return (
       <div style={containerStyle(isVertical)}>
-        <div style={styles.leftPane}>
+        <div style={leftPaneStyle(isVertical)}>
           {this.props.left()}
         </div>
         <div style={rightStyle(isVertical, width, height)}>
@@ -112,6 +112,7 @@ const containerStyle = (isVertical: boolean) => ({
   flex: 1,
   flexDirection: isVertical ? 'column' : 'row',
   maxWidth: '100vw',
+  minHeight: isVertical ? 30 : null,
 });
 
 const draggerInnerStyle = (isVertical: boolean, theme: Theme) => ({
@@ -133,22 +134,22 @@ const rightStyle = (isVertical: boolean, width: number, height: number) => ({
   width: isVertical ? null : width,
   height: isVertical ? height : null,
   flex: 'initial',
-  minHeight: 120,
-  minWidth: 150,
+});
+
+const leftPaneStyle = (isVertical: boolean) => ({
+  display: 'flex',
+  minWidth: '50%',
+  minHeight: isVertical ? '10%' : '50%',
+  flex: 1,
+  overflow: 'hidden',
 });
 
 const styles = {
   rightPane: {
     display: 'flex',
     width: '100%',
+    height: '100%',
     overflow: 'auto',
-  },
-  leftPane: {
-    display: 'flex',
-    minWidth: '50%',
-    minHeight: '50%',
-    flex: 1,
-    overflow: 'hidden',
   },
 };
 

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -78,11 +78,11 @@ class SplitPane extends React.Component<Props, State> {
   render() {
     const {theme} = this.context;
     const {isVertical} = this.props;
-    const {height, width} = this.state;
+    const {height, width, moving} = this.state;
 
     return (
       <div style={containerStyle(isVertical)}>
-        <div style={leftPaneStyle(isVertical)}>
+        <div style={leftPaneStyle(isVertical, moving)}>
           {this.props.left()}
         </div>
         <div style={rightStyle(isVertical, width, height)}>
@@ -93,7 +93,7 @@ class SplitPane extends React.Component<Props, State> {
             onStop={() => this.setState({moving: false})}>
             <div style={draggerInnerStyle(isVertical, theme)} />
           </Draggable>
-          <div style={styles.rightPane}>
+          <div style={rightPaneStyle(moving)}>
             {this.props.right()}
           </div>
         </div>
@@ -136,21 +136,21 @@ const rightStyle = (isVertical: boolean, width: number, height: number) => ({
   flex: 'initial',
 });
 
-const leftPaneStyle = (isVertical: boolean) => ({
+const leftPaneStyle = (isVertical: boolean, moving: boolean) => ({
   display: 'flex',
   minWidth: '50%',
   minHeight: isVertical ? '10%' : '50%',
   flex: 1,
   overflow: 'hidden',
+  pointerEvents: moving ? 'none' : null,
 });
 
-const styles = {
-  rightPane: {
-    display: 'flex',
-    width: '100%',
-    height: '100%',
-    overflow: 'auto',
-  },
-};
+const rightPaneStyle = (moving: boolean) => ({
+  display: 'flex',
+  width: '100%',
+  height: '100%',
+  overflow: 'auto',
+  pointerEvents: moving ? 'none' : null,
+});
 
 module.exports = SplitPane;

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -26,8 +26,8 @@ type Props = {
   style?: {[key: string]: any},
   left: () => React.Node,
   right: () => React.Node,
-  initialWidth: number,
-  initialHeight: number,
+  initialWidth?: number,
+  initialHeight?: number,
   isVertical: bool,
 };
 
@@ -53,11 +53,13 @@ class SplitPane extends React.Component<Props, State> {
     // $FlowFixMe use a ref on the root
     var node: HTMLDivElement = nullthrows(ReactDOM.findDOMNode(this));
 
-    const width = Math.floor(node.offsetWidth * (this.props.isVertical ? 0.6 : 0.3));
+    const { initialWidth, initialHeight } = this.props;
 
+    // come up with a size when initial size values are not provided
+    const width = Math.floor(node.offsetWidth * (this.props.isVertical ? 0.6 : 0.3));
     this.setState({
-      width: Math.min(250, width),
-      height: Math.floor(node.offsetHeight * 0.3),
+      width: initialWidth || Math.min(250, width),
+      height: initialHeight || Math.floor(node.offsetHeight * 0.3),
     });
   }
 

--- a/frontend/SplitPane.js
+++ b/frontend/SplitPane.js
@@ -44,8 +44,9 @@ class SplitPane extends React.Component<Props, State> {
     super(props);
     this.state = {
       moving: false,
-      width: props.initialWidth,
-      height: props.initialHeight,
+      // actual size will be set in cDM
+      width: 10,
+      height: 10,
     };
   }
 

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -15,6 +15,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const SearchUtils = require('./SearchUtils');
 const Breadcrumb = require('./Breadcrumb');
+const SplitPane = require('./SplitPane');
 
 const decorate = require('./decorate');
 const {monospace, sansSerif} = require('./Themes/Fonts');
@@ -115,19 +116,28 @@ class TreeView extends React.Component<Props> {
 
     return (
       <div style={styles.container}>
-        <div ref={n => this.node = n} style={styles.scroll}>
-          <div style={styles.scrollContents}>
-            {this.props.roots.map(id => (
-              <Node
-                depth={0}
-                id={id}
-                key={id}
-                searchRegExp={searchRegExp}
-              />
-            )).toJS()}
-          </div>
-        </div>
-        <Breadcrumb />
+        <SplitPane
+          initialWidth={10}
+          initialHeight={30}
+          left={() => (
+            <div ref={n => this.node = n} style={styles.scroll}>
+              <div style={styles.scrollContents}>
+                {this.props.roots.map(id => (
+                  <Node
+                    depth={0}
+                    id={id}
+                    key={id}
+                    searchRegExp={searchRegExp}
+                  />
+                )).toJS()}
+              </div>
+            </div>
+          )}
+          right={() => (
+            <Breadcrumb />
+          )}
+          isVertical={true}
+        />
       </div>
     );
   }

--- a/frontend/TreeView.js
+++ b/frontend/TreeView.js
@@ -117,7 +117,6 @@ class TreeView extends React.Component<Props> {
     return (
       <div style={styles.container}>
         <SplitPane
-          initialWidth={10}
           initialHeight={30}
           left={() => (
             <div ref={n => this.node = n} style={styles.scroll}>

--- a/plugins/Relay/QueriesTab.js
+++ b/plugins/Relay/QueriesTab.js
@@ -29,8 +29,6 @@ class QueriesTab extends React.Component<Props> {
     } else {
       contents = (
         <SplitPane
-          initialWidth={500}
-          initialHeight={500}
           left={() => <QueryList />}
           right={() => <QueryViewer />}
           isVertical={false}

--- a/shells/theme-preview/source/Application.js
+++ b/shells/theme-preview/source/Application.js
@@ -61,8 +61,6 @@ class Application extends React.Component<Props> {
         </div>
         <div style={themeWrapper(theme)}>
           <SplitPane
-            initialWidth={10}
-            initialHeight={10}
             isVertical={false}
             left={() => <LeftPane />}
             right={() => <RightPane />}


### PR DESCRIPTION
![react-dev-tools-resizable-breadcrumbs](https://user-images.githubusercontent.com/8769273/44619932-d6f3f480-a88c-11e8-9c3a-2abc660751b0.gif)

I'm using Breadcrumb a lot, that is my primary view to understand the component tree.
