### PR TITLE
Pin Lerna version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "devDependencies": {
     "chrome-launch": "^1.1.4",
     "firefox-profile": "^1.0.2",
-    "lerna": "^2.8.0",
+    "lerna": "2.8.0",
     "web-ext": "^1.10.1"
   }
 }


### PR DESCRIPTION
It would be good to convert this to use Yarn workspaces (given the project is already using Yarn), but for now let's at least pin the Lerna version to avoid unintentionally pulling in a new version with a different license.