### PR TITLE
Fix false positive feature-detection check

### DIFF
--- a/plugins/Profiler/backend.js
+++ b/plugins/Profiler/backend.js
@@ -20,12 +20,12 @@ module.exports = (bridge: Bridge, agent: Agent, hook: Object) => {
     let profilingIsSupported = false;
 
     // Feature detection for profiling mode.
-    // The presence of an "actualDuration" field signifies:
-    // 1) This is a new enough version of React
+    // The presence of an "treeBaseDuration" field signifies:
+    // 1) This is a new enough version of React (e.g. > 16.4 which was the initial profiling release)
     // 2) This is a profiling capable bundle (e.g. DEV or PROFILING)
     agent.roots.forEach((rootId: string) => {
       const root = agent.internalInstancesById.get(rootId);
-      if ((root: any).hasOwnProperty('actualDuration')) {
+      if ((root: any).hasOwnProperty('treeBaseDuration')) {
         profilingIsSupported = true;
       }
     });


### PR DESCRIPTION
Addresses the issue brought up with [this comment](https://github.com/facebook/react-devtools/pull/1069#issuecomment-417166634) by improving our feature-detection check to avoid false positive from 16.4

The `actualDuration` field was added by facebook/react/pull/12910 and was released in 16.4.

The `treeBaseDuration` field was renamed with facebook/react/pull/13156 in order to allow us to distinguish between the initial profiling release and a more stable one. I intended to switch DevTools to use this field but apparently forgot to. ☹️ 