### PR TITLE
Fix a potential crash error when starting

### DIFF
--- a/plugins/Profiler/backend.js
+++ b/plugins/Profiler/backend.js
@@ -13,6 +13,8 @@
 import type Bridge from '../../agent/Bridge';
 import type Agent from '../../agent/Agent';
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
 const emptyFunction = () => {};
 
 module.exports = (bridge: Bridge, agent: Agent, hook: Object) => {
@@ -25,7 +27,7 @@ module.exports = (bridge: Bridge, agent: Agent, hook: Object) => {
     // 2) This is a profiling capable bundle (e.g. DEV or PROFILING)
     agent.roots.forEach((rootId: string) => {
       const root = agent.internalInstancesById.get(rootId);
-      if ((root: any).hasOwnProperty('treeBaseDuration')) {
+      if (root && hasOwnProperty.call((root: any), 'treeBaseDuration')) {
         profilingIsSupported = true;
       }
     });


### PR DESCRIPTION
For some reason, if I have React Devtools open on my app, the rendering of my app would crash when I render a certain component.

I made the check more resilient and it doesn't crash on my build anymore.

<img width="958" alt="screen shot 2018-09-04 at 11 21 50 pm" src="https://user-images.githubusercontent.com/6135313/45041273-72117900-b09a-11e8-8d28-fbe37b70b0f1.png">
