### PR TITLE
Fix "inspect" functionality for profiler (at least in last snapshot)

### DIFF
--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -20,7 +20,7 @@ const nullthrows = require('nullthrows').default;
 const consts = require('../../agent/consts');
 const previewComplex = require('./previewComplex');
 
-type Inspect = (path: Array<string>, cb: () => void) => void;
+export type Inspect = (path: Array<string>, cb: () => void) => void;
 type ShowMenu = boolean | (e: DOMEvent, val: any, path: Array<string>, name: string) => void;
 
 type DataViewProps = {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -25,6 +25,8 @@ import type Bridge from '../agent/Bridge';
 import type {ControlState, DOMEvent, ElementID, Theme} from './types';
 import type {Snapshot} from '../plugins/Profiler/ProfilerTypes';
 
+export type Inspect = (id: ElementID, path: Array<string>, cb: () => void) => void;
+
 type ListenerFunction = () => void;
 type DataType = Map;
 type ContextMenu = {

--- a/plugins/Profiler/ProfilerStore.js
+++ b/plugins/Profiler/ProfilerStore.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type Bridge from '../../agent/Bridge';
+import type {ElementID} from '../../frontend/types';
 import type {ChartType, Interaction, RootProfilerData, Snapshot} from './ProfilerTypes';
 
 const {List} = require('immutable');
@@ -75,6 +76,9 @@ class ProfilerStore extends EventEmitter {
   getCachedInteractionData(rootID: string): any {
     return this.cachedData.get(`${rootID}-interactions`) || null;
   }
+
+  inspect = (id: ElementID, path: Array<string>, cb: () => void) =>
+    this._mainStore.inspect(id, path, cb);
 
   processInteraction(interaction: Interaction): Interaction {
     const key = `${interaction.name} at ${interaction.timestamp}`;

--- a/plugins/Profiler/views/ProfilerFiberDetailPane.js
+++ b/plugins/Profiler/views/ProfilerFiberDetailPane.js
@@ -10,6 +10,7 @@
  */
 'use strict';
 
+import type {Inspect} from '../../../frontend/DataView/DataView';
 import type {Theme} from '../../../frontend/types';
 import type {Snapshot} from '../ProfilerTypes';
 
@@ -25,6 +26,7 @@ const emptyFunction = () => {};
 
 type Props = {|
   deselectFiber: Function,
+  inspect: Inspect,
   isInspectingSelectedFiber: boolean,
   name?: string,
   snapshot: Snapshot,
@@ -35,6 +37,7 @@ type Props = {|
 
 const ProfilerFiberDetailPane = ({
   deselectFiber,
+  inspect,
   isInspectingSelectedFiber,
   name = 'Unknown',
   snapshot,
@@ -114,7 +117,7 @@ const ProfilerFiberDetailPane = ({
             <DataView
               path={['props']}
               readOnly={true}
-              inspect={emptyFunction}
+              inspect={inspect}
               showMenu={emptyFunction}
               data={snapshotFiber.get('props')}
             />
@@ -124,7 +127,7 @@ const ProfilerFiberDetailPane = ({
               <DataView
                 path={['state']}
                 readOnly={true}
-                inspect={emptyFunction}
+                inspect={inspect}
                 showMenu={emptyFunction}
                 data={snapshotFiber.get('state')}
               />

--- a/plugins/Profiler/views/ProfilerTab.js
+++ b/plugins/Profiler/views/ProfilerTab.js
@@ -20,6 +20,7 @@ import type {
   RootProfilerData,
   Snapshot,
 } from '../ProfilerTypes';
+import type {Inspect} from '../../../frontend/Store';
 
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -45,6 +46,7 @@ type Props = {|
   getCachedInteractionData: GetCachedInteractionData,
   hasMultipleRoots: boolean,
   hideCommitsBelowThreshold: boolean,
+  inspect: Inspect,
   interactionsToSnapshots: Map<Interaction, Set<Snapshot>>,
   isRecording: boolean,
   profilerData: RootProfilerData,
@@ -131,6 +133,13 @@ class ProfilerTab extends React.Component<Props, State> {
       selectedFiberID: id,
       selectedFiberName: name,
     });
+
+  inspectPropsOrState = (path: Array<string>, cb: () => void) => {
+    const { inspect } = this.props;
+    const { selectedFiberID } = this.state;
+
+    inspect(((selectedFiberID: any): string), path, cb);
+  };
 
   // We store the ID and name separately,
   // Because a Fiber may not exist in all snapshots.
@@ -309,6 +318,7 @@ class ProfilerTab extends React.Component<Props, State> {
       details = (
         <ProfilerFiberDetailPane
           deselectFiber={this.deselectFiber}
+          inspect={this.inspectPropsOrState}
           isInspectingSelectedFiber={isInspectingSelectedFiber}
           name={selectedFiberName}
           snapshot={snapshot}
@@ -460,6 +470,7 @@ export default decorate({
       commitThreshold: store.commitThreshold,
       hasMultipleRoots: store.roots.size > 1,
       hideCommitsBelowThreshold: store.hideCommitsBelowThreshold,
+      inspect: (...args) => store.inspect(...args),
       interactionsToSnapshots: profilerData !== null
         ? profilerData.interactionsToSnapshots
         : new Map(),


### PR DESCRIPTION
Related to #1148

Unfortunately the "inspect" functionality only works for the last snapshot.