### PR TITLE
Update adm-zip dependency to v0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "adm-zip": "^0.4.7",
+    "adm-zip": "^0.4.11",
     "babel-core": "6.3.21",
     "babel-eslint": "6.0.4",
     "babel-jest": "22.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,7 +92,11 @@ addons-linter@0.22.3:
     yargs "8.0.2"
     yauzl "2.8.0"
 
-adm-zip@^0.4.7, adm-zip@~0.4.x:
+adm-zip@^0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
+
+adm-zip@~0.4.x:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.7.tgz#8606c2cbf1c426ce8c8ec00174447fd49b6eafc1"
 


### PR DESCRIPTION
I was trying to build the Chrome extension and was running into this issue: https://github.com/cthackers/adm-zip/issues/218.

Updating `adm-zip` to `0.4.11`, as suggested there, fixed the issue for me.