### PR TITLE
Doesn't error when rendering Context.Provider in old React.

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -269,7 +269,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
           case CONTEXT_PROVIDER_SYMBOL_STRING:
             nodeType = 'Special';
             props = fiber.memoizedProps;
-            name = `${fiber.type._context.displayName || 'Context'}.Provider`;
+            name = `${(fiber.type._context || fiber.type.context).displayName || 'Context'}.Provider`;
             children = [];
             break;
           case CONTEXT_CONSUMER_NUMBER:


### PR DESCRIPTION
Fixes #1168.
Fixes #1174.

Patches devtools to work with older versions of React that used `fiber.type.context` instead of `fiber.type._context`.