### PR TITLE
Pull memoizedInteractions from DataType instead of Fiber

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -380,9 +380,9 @@ class Agent extends EventEmitter {
     this.emit('root', id);
   }
 
-  rootCommitted(renderer: RendererID, internalInstance: OpaqueNodeHandle) {
+  rootCommitted(renderer: RendererID, internalInstance: OpaqueNodeHandle, data: DataType) {
     var id = this.getId(internalInstance);
-    this.emit('rootCommitted', id, internalInstance);
+    this.emit('rootCommitted', id, internalInstance, data);
   }
 
   onMounted(renderer: RendererID, component: OpaqueNodeHandle, data: DataType) {

--- a/agent/inject.js
+++ b/agent/inject.js
@@ -28,7 +28,7 @@ module.exports = function(hook: Hook, agent: Agent) {
 
     // Required by Profiler plugin
     hook.sub('root', ({renderer, internalInstance}) => agent.addRoot(renderer, internalInstance)),
-    hook.sub('rootCommitted', ({renderer, internalInstance}) => agent.rootCommitted(renderer, internalInstance)),
+    hook.sub('rootCommitted', ({renderer, internalInstance, data}) => agent.rootCommitted(renderer, internalInstance, data)),
     hook.sub('updateProfileTimes', ({renderer, internalInstance, data}) => agent.onUpdatedProfileTimes(internalInstance, data)),
   ];
 

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -158,6 +158,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
     var actualDuration = null;
     var actualStartTime = null;
     var treeBaseDuration = null;
+    var memoizedInteractions = null;
 
     var resolvedType = type;
     if (typeof type === 'object' && type !== null) {
@@ -181,6 +182,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
           if (context && Object.keys(context).length === 0) {
             context = null;
           }
+          memoizedInteractions = publicInstance.memoizedInteractions;
         }
         const inst = publicInstance;
         if (inst) {
@@ -355,6 +357,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       text,
       updater,
       publicInstance,
+      memoizedInteractions,
 
       // Profiler data
       actualDuration,
@@ -524,6 +527,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
   function markRootCommitted(fiber) {
     pendingEvents.push({
       internalInstance: getOpaqueNode(fiber),
+      data: getDataFiber(fiber),
       renderer: rid,
       type: 'rootCommitted',
     });

--- a/plugins/Profiler/ProfileCollector.js
+++ b/plugins/Profiler/ProfileCollector.js
@@ -48,8 +48,8 @@ class ProfileCollector {
   }
 
   _takeCommitSnapshotForRoot(id: string, data: any) {
-    const interactionsArray = data.stateNode.memoizedInteractions != null
-      ? Array.from(data.stateNode.memoizedInteractions)
+    const interactionsArray = data.memoizedInteractions != null
+      ? Array.from(data.memoizedInteractions)
       : [];
 
     // Map interaction start times to when we started profiling.
@@ -95,7 +95,7 @@ class ProfileCollector {
     this._maxActualDuration = Math.max(this._maxActualDuration, data.actualDuration);
   };
 
-  _onRootCommitted = (id: string, data: any) => {
+  _onRootCommitted = (id: string, internalInstance: any, data: any) => {
     if (!this._isRecording) {
       return;
     }


### PR DESCRIPTION
I'm currently integrating the profiler into preactjs as an experimental feature and noticed, that the profiler reads from the `memoizedInteractions` property directly from a `fiber` instead of from `event.data` like it is done for all other properties.

The integration is nearly done and this is the only inconsistency I've come across. I'm really impressed by the profiler and how easy it was to add support for it. It's really amazing 💯 👍 

This PR fixes that by adding a `data` property to the `rootCommitted` event similar to how all other events work.