### PR TITLE
[WIP] Support hiding components in devtools

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -153,6 +153,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
     var nodeType = null;
     var name = null;
     var text = null;
+    var hideSymbol = null;
 
     // Profiler data
     var actualDuration = null;
@@ -176,11 +177,15 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
         publicInstance = fiber.stateNode;
         props = fiber.memoizedProps;
         state = fiber.memoizedState;
+        hideSymbol = typeof Symbol === 'function' && fiber.type[Symbol.for('react.devtools.hide')];
         if (publicInstance != null) {
           context = publicInstance.context;
           if (context && Object.keys(context).length === 0) {
             context = null;
           }
+        }
+        if (name === 'HigherOrderComponent') {
+          console.log('fiber backend', fiber);
         }
         const inst = publicInstance;
         if (inst) {
@@ -360,6 +365,8 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       actualDuration,
       actualStartTime,
       treeBaseDuration,
+
+      hideSymbol,
     };
   }
 

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -154,6 +154,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
     var name = null;
     var text = null;
     var hideSymbol = null;
+    var hideDisplayNamed = null;
 
     // Profiler data
     var actualDuration = null;
@@ -178,6 +179,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
         props = fiber.memoizedProps;
         state = fiber.memoizedState;
         hideSymbol = typeof Symbol === 'function' && fiber.type[Symbol.for('react.devtools.hide')];
+        hideDisplayNamed = fiber.type.hasOwnProperty('displayName');
         if (publicInstance != null) {
           context = publicInstance.context;
           if (context && Object.keys(context).length === 0) {
@@ -358,6 +360,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       updater,
       publicInstance,
       hideSymbol,
+      hideDisplayNamed,
 
       // Profiler data
       actualDuration,

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -179,8 +179,8 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
     var nodeType = null;
     var name = null;
     var text = null;
-    var hideSymbol = null;
-    var hideDisplayNamed = null;
+    var needHideBySymbol = null;
+    var needHideByParensInName = null;
 
     // Profiler data
     var actualDuration = null;
@@ -205,8 +205,8 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
         publicInstance = fiber.stateNode;
         props = fiber.memoizedProps;
         state = fiber.memoizedState;
-        hideSymbol = typeof Symbol === 'function' && fiber.type[Symbol.for('react.devtools.hide')];
-        hideDisplayNamed = fiber.type.hasOwnProperty('displayName');
+        needHideBySymbol = typeof Symbol === 'function' && fiber.type[Symbol.for('react.devtools.hide')];
+        needHideByParensInName = /\(.*\)/.test(name);
         if (publicInstance != null) {
           context = publicInstance.context;
           if (context && Object.keys(context).length === 0) {
@@ -388,8 +388,8 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       updater,
       publicInstance,
       memoizedInteractions,
-      hideSymbol,
-      hideDisplayNamed,
+      needHideBySymbol,
+      needHideByParensInName,
 
       // Profiler data
       actualDuration,

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -184,9 +184,6 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
             context = null;
           }
         }
-        if (name === 'HigherOrderComponent') {
-          console.log('fiber backend', fiber);
-        }
         const inst = publicInstance;
         if (inst) {
           updater = {
@@ -360,13 +357,12 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       text,
       updater,
       publicInstance,
+      hideSymbol,
 
       // Profiler data
       actualDuration,
       actualStartTime,
       treeBaseDuration,
-
-      hideSymbol,
     };
   }
 

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -165,8 +165,10 @@ function getData(internalInstance: Object): DataType {
     };
   }
 
-  const hideSymbol = nodeType === 'Composite' && typeof Symbol === 'function' && type[Symbol.for('react.devtools.hide')];
-
+  const hideSymbol = nodeType === 'Composite' &&
+    typeof Symbol === 'function' &&
+    typeof type === 'function' &&
+    type[Symbol.for('react.devtools.hide')];
 
   // $FlowFixMe
   return {

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -169,6 +169,9 @@ function getData(internalInstance: Object): DataType {
     typeof Symbol === 'function' &&
     typeof type === 'function' &&
     type[Symbol.for('react.devtools.hide')];
+  const hideDisplayNamed = nodeType === 'Composite' &&
+    typeof type === 'function' &&
+    type.hasOwnProperty('displayName');
 
   // $FlowFixMe
   return {
@@ -186,6 +189,7 @@ function getData(internalInstance: Object): DataType {
     updater,
     publicInstance,
     hideSymbol,
+    hideDisplayNamed,
   };
 }
 

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -165,13 +165,13 @@ function getData(internalInstance: Object): DataType {
     };
   }
 
-  const hideSymbol = nodeType === 'Composite' &&
+  const needHideBySymbol = nodeType === 'Composite' &&
     typeof Symbol === 'function' &&
     typeof type === 'function' &&
     type[Symbol.for('react.devtools.hide')];
-  const hideDisplayNamed = nodeType === 'Composite' &&
+  const needHideByParensInName = nodeType === 'Composite' &&
     typeof type === 'function' &&
-    type.hasOwnProperty('displayName');
+    name && /\(.*\)/.test(name);
 
   // $FlowFixMe
   return {
@@ -188,8 +188,8 @@ function getData(internalInstance: Object): DataType {
     text,
     updater,
     publicInstance,
-    hideSymbol,
-    hideDisplayNamed,
+    needHideBySymbol,
+    needHideByParensInName,
   };
 }
 

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -165,6 +165,9 @@ function getData(internalInstance: Object): DataType {
     };
   }
 
+  const hideSymbol = nodeType === 'Composite' && typeof Symbol === 'function' && type[Symbol.for('react.devtools.hide')];
+
+
   // $FlowFixMe
   return {
     nodeType,
@@ -180,6 +183,7 @@ function getData(internalInstance: Object): DataType {
     text,
     updater,
     publicInstance,
+    hideSymbol,
   };
 }
 

--- a/backend/types.js
+++ b/backend/types.js
@@ -35,6 +35,8 @@ export type DataType = {
   text: ?string,
   updater: ?(CompositeUpdater | NativeUpdater),
   publicInstance: ?Object,
+  needHideBySymbol: boolean,
+  needHideByParensInName: boolean
 };
 
 // This type is entirely opaque to the backend.

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -19,7 +19,7 @@ const PropTypes = require('prop-types');
 const React = require('react');
 const decorate = require('./decorate');
 
-type BreadcrumbPath = Array<{id: ElementID, node: Object}>;
+type BreadcrumbPath = Array<{id: ElementID, node: Object, isDimmedNode: boolean}>;
 
 type Props = {
   hover: (string, boolean) => void;
@@ -70,9 +70,9 @@ class Breadcrumb extends React.Component<Props, State> {
 
     return (
       <ul style={containerStyle(theme)}>
-        {path.map(({ id, node }) => {
+        {path.map(({ id, node, isDimmedNode }) => {
           const isSelected = id === selected;
-          const style = itemStyle({isSelected, nodeType: node.get('nodeType')}, theme);
+          const style = itemStyle({isSelected, nodeType: node.get('nodeType'), isDimmedNode}, theme);
 
           return (
             <li
@@ -124,7 +124,7 @@ const containerStyle = (theme: Theme) => ({
 });
 
 const itemStyle = (
-  {isSelected, nodeType}: {isSelected: boolean, nodeType: string},
+  {isSelected, nodeType, isDimmedNode}: {isSelected: boolean, nodeType: string, isDimmedNode: boolean},
   theme: Theme
 ) => {
   let color;
@@ -145,6 +145,8 @@ const itemStyle = (
     MozUserSelect: 'none',
     userSelect: 'none',
     display: 'inline-block',
+    opacity: isDimmedNode ? 0.8 : 1,
+    fontStyle: isDimmedNode ? 'italic' : undefined,
   };
 };
 
@@ -152,9 +154,11 @@ function getBreadcrumbPath(store: Store): BreadcrumbPath {
   var path = [];
   var current = store.breadcrumbHead;
   while (current) {
+    const node = store.get(current);
     path.unshift({
       id: current,
-      node: store.get(current),
+      node: node,
+      isDimmedNode: store.isDimmedNode(node),
     });
     current = store.skipWrapper(store.getParent(current), true);
   }
@@ -162,7 +166,7 @@ function getBreadcrumbPath(store: Store): BreadcrumbPath {
 }
 
 module.exports = decorate({
-  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbolChange', 'hideByParensInNameChange'],
+  listeners: () => ['breadcrumbHead', 'selected', 'hidingStyleChange', 'hideSymbolChange', 'hideByParensInNameChange'],
   props(store, props) {
     return {
       select: id => store.selectBreadcrumb(id),

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -163,7 +163,7 @@ function getBreadcrumbPath(store: Store): BreadcrumbPath {
 }
 
 module.exports = decorate({
-  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbol', 'hideDisplayNamed'],
+  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbolChange', 'hideDisplayNamedChange'],
   props(store, props) {
     return {
       select: id => store.selectBreadcrumb(id),

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -163,7 +163,7 @@ function getBreadcrumbPath(store: Store): BreadcrumbPath {
 }
 
 module.exports = decorate({
-  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbolChange', 'hideDisplayNamedChange'],
+  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbolChange', 'hideByParensInNameChange'],
   props(store, props) {
     return {
       select: id => store.selectBreadcrumb(id),

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -72,11 +72,7 @@ class Breadcrumb extends React.Component<Props, State> {
       <ul style={containerStyle(theme)}>
         {path.map(({ id, node }) => {
           const isSelected = id === selected;
-          const style = itemStyle(
-            isSelected,
-            node.get('nodeType'),
-            theme,
-          );
+          const style = itemStyle({isSelected, nodeType: node.get('nodeType')}, theme);
 
           return (
             <li
@@ -127,7 +123,10 @@ const containerStyle = (theme: Theme) => ({
   overflow: 'auto',
 });
 
-const itemStyle = (isSelected: boolean, nodeType: string, theme: Theme) => {
+const itemStyle = (
+  {isSelected, nodeType}: {isSelected: boolean, nodeType: string},
+  theme: Theme
+) => {
   let color;
   if (isSelected) {
     color = theme.state02;

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -163,7 +163,7 @@ function getBreadcrumbPath(store: Store): BreadcrumbPath {
 }
 
 module.exports = decorate({
-  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbol'],
+  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbol', 'hideDisplayNamed'],
   props(store, props) {
     return {
       select: id => store.selectBreadcrumb(id),

--- a/frontend/Breadcrumb.js
+++ b/frontend/Breadcrumb.js
@@ -163,7 +163,7 @@ function getBreadcrumbPath(store: Store): BreadcrumbPath {
 }
 
 module.exports = decorate({
-  listeners: () => ['breadcrumbHead', 'selected'],
+  listeners: () => ['breadcrumbHead', 'selected', 'hideSymbol'],
   props(store, props) {
     return {
       select: id => store.selectBreadcrumb(id),

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -32,8 +32,7 @@ type PropsType = {
   isBottomTagSelected: boolean,
   searchRegExp: ?RegExp,
   wrappedChildren: ?Array<any>,
-  hideSymbol: boolean,
-  hideDisplayNamed: boolean,
+  isHiddenNode: boolean,
   onHover: (isHovered: boolean) => void,
   onHoverBottom: (isHovered: boolean) => void,
   onContextMenu: () => void,
@@ -204,11 +203,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     let children = node.get('children');
 
-    if (
-        node.get('nodeType') === 'Wrapper' ||
-        (this.props.hideSymbol && node.get('hideSymbol')) ||
-        (this.props.hideDisplayNamed && node.get('hideDisplayNamed'))
-    ) {
+    if (node.get('nodeType') === 'Wrapper' || this.props.isHiddenNode) {
       return children.map(child =>
         <WrappedNode key={child} id={child} depth={depth}/>
       );
@@ -441,8 +436,7 @@ var WrappedNode = decorate({
       isBottomTagHovered: store.isBottomTagHovered,
       hovered: store.hovered === props.id,
       searchRegExp: props.searchRegExp,
-      hideSymbol: store.hideSymbol,
-      hideDisplayNamed: store.hideDisplayNamed,
+      isHiddenNode: store.isHiddenNode(node),
       onToggleCollapse: e => {
         e.preventDefault();
         store.toggleCollapse(props.id);

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -298,7 +298,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     // Single-line tag (collapsed / simple content / no content)
     if (!children || typeof children === 'string' || !children.length) {
-      const jsxSingleLineTagStyle = jsxTagStyle(inverted, nodeType, theme);
+      const jsxSingleLineTagStyle = jsxTagStyle({inverted, nodeType}, theme);
       const content = children;
       const isCollapsed = content === null || content === undefined;
       return (
@@ -329,7 +329,7 @@ class Node extends React.Component<PropsType, StateType> {
       );
     }
 
-    const jsxCloseTagStyle = jsxTagStyle(inverted && (isBottomTagSelected || collapsed), nodeType, theme);
+    const jsxCloseTagStyle = jsxTagStyle({inverted: inverted && (isBottomTagSelected || collapsed), nodeType}, theme);
     const closeTag = (
       <Fragment>
         &lt;/
@@ -343,7 +343,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     const headInverted = inverted && (!isBottomTagSelected || collapsed);
 
-    const jsxOpenTagStyle = jsxTagStyle(inverted && (!isBottomTagSelected || collapsed), nodeType, theme);
+    const jsxOpenTagStyle = jsxTagStyle({inverted: inverted && (!isBottomTagSelected || collapsed), nodeType}, theme);
     const head = (
       <div style={sharedHeadStyle} {...headEvents}>
         <span
@@ -512,7 +512,10 @@ const headStyle = ({
   };
 };
 
-const jsxTagStyle = (inverted: boolean, nodeType: string, theme: Theme) => {
+const jsxTagStyle = (
+  {inverted, nodeType}: {inverted: boolean, nodeType: string},
+  theme: Theme
+) => {
   let color;
   if (inverted) {
     color = theme.state02;

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -33,6 +33,7 @@ type PropsType = {
   searchRegExp: ?RegExp,
   wrappedChildren: ?Array<any>,
   hideSymbol: boolean,
+  hideDisplayNamed: boolean,
   onHover: (isHovered: boolean) => void,
   onHoverBottom: (isHovered: boolean) => void,
   onContextMenu: () => void,
@@ -203,7 +204,11 @@ class Node extends React.Component<PropsType, StateType> {
 
     let children = node.get('children');
 
-    if (node.get('nodeType') === 'Wrapper' || (this.props.hideSymbol && node.get('hideSymbol'))) {
+    if (
+        node.get('nodeType') === 'Wrapper' ||
+        (this.props.hideSymbol && node.get('hideSymbol')) ||
+        (this.props.hideDisplayNamed && node.get('hideDisplayNamed'))
+    ) {
       return children.map(child =>
         <WrappedNode key={child} id={child} depth={depth}/>
       );
@@ -419,7 +424,7 @@ Node.contextTypes = {
 
 var WrappedNode = decorate({
   listeners(props) {
-    return [props.id, 'hideSymbol'];
+    return [props.id, 'hideSymbol', 'hideDisplayNamed'];
   },
   props(store, props) {
     var node = store.get(props.id);
@@ -437,6 +442,7 @@ var WrappedNode = decorate({
       hovered: store.hovered === props.id,
       searchRegExp: props.searchRegExp,
       hideSymbol: store.hideSymbol,
+      hideDisplayNamed: store.hideDisplayNamed,
       onToggleCollapse: e => {
         e.preventDefault();
         store.toggleCollapse(props.id);

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -419,7 +419,7 @@ Node.contextTypes = {
 
 var WrappedNode = decorate({
   listeners(props) {
-    return [props.id, 'hideSymbol', 'hideDisplayNamed'];
+    return [props.id, 'hideSymbolChange', 'hideDisplayNamedChange'];
   },
   props(store, props) {
     var node = store.get(props.id);

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -33,6 +33,7 @@ type PropsType = {
   searchRegExp: ?RegExp,
   wrappedChildren: ?Array<any>,
   isHiddenNode: boolean,
+  isDimmedNode: boolean,
   onHover: (isHovered: boolean) => void,
   onHoverBottom: (isHovered: boolean) => void,
   onContextMenu: () => void,
@@ -196,6 +197,7 @@ class Node extends React.Component<PropsType, StateType> {
       wrappedChildren,
     } = this.props;
     const {isWindowFocused} = this.state;
+    const isDimmed = this.props.isDimmedNode;
 
     if (!node) {
       return 'Node was deleted';
@@ -298,7 +300,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     // Single-line tag (collapsed / simple content / no content)
     if (!children || typeof children === 'string' || !children.length) {
-      const jsxSingleLineTagStyle = jsxTagStyle({inverted, nodeType}, theme);
+      const jsxSingleLineTagStyle = jsxTagStyle({inverted, nodeType, isDimmed}, theme);
       const content = children;
       const isCollapsed = content === null || content === undefined;
       return (
@@ -329,7 +331,7 @@ class Node extends React.Component<PropsType, StateType> {
       );
     }
 
-    const jsxCloseTagStyle = jsxTagStyle({inverted: inverted && (isBottomTagSelected || collapsed), nodeType}, theme);
+    const jsxCloseTagStyle = jsxTagStyle({inverted: inverted && (isBottomTagSelected || collapsed), nodeType, isDimmed}, theme);
     const closeTag = (
       <Fragment>
         &lt;/
@@ -343,7 +345,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     const headInverted = inverted && (!isBottomTagSelected || collapsed);
 
-    const jsxOpenTagStyle = jsxTagStyle({inverted: inverted && (!isBottomTagSelected || collapsed), nodeType}, theme);
+    const jsxOpenTagStyle = jsxTagStyle({inverted: inverted && (!isBottomTagSelected || collapsed), nodeType, isDimmed}, theme);
     const head = (
       <div style={sharedHeadStyle} {...headEvents}>
         <span
@@ -419,7 +421,7 @@ Node.contextTypes = {
 
 var WrappedNode = decorate({
   listeners(props) {
-    return [props.id, 'hideSymbolChange', 'hideByParensInNameChange'];
+    return [props.id, 'hidingStyleChange', 'hideSymbolChange', 'hideByParensInNameChange'];
   },
   props(store, props) {
     var node = store.get(props.id);
@@ -437,6 +439,7 @@ var WrappedNode = decorate({
       hovered: store.hovered === props.id,
       searchRegExp: props.searchRegExp,
       isHiddenNode: store.isHiddenNode(node),
+      isDimmedNode: store.isDimmedNode(node),
       onToggleCollapse: e => {
         e.preventDefault();
         store.toggleCollapse(props.id);
@@ -513,7 +516,7 @@ const headStyle = ({
 };
 
 const jsxTagStyle = (
-  {inverted, nodeType}: {inverted: boolean, nodeType: string},
+  {inverted, nodeType, isDimmed}: {inverted: boolean, nodeType: string, isDimmed: boolean},
   theme: Theme
 ) => {
   let color;
@@ -529,6 +532,8 @@ const jsxTagStyle = (
 
   return {
     color,
+    opacity: isDimmed ? 0.8 : 1,
+    fontStyle: isDimmed ? 'italic' : undefined,
   };
 };
 

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -32,6 +32,7 @@ type PropsType = {
   isBottomTagSelected: boolean,
   searchRegExp: ?RegExp,
   wrappedChildren: ?Array<any>,
+  hideSymbol: boolean,
   onHover: (isHovered: boolean) => void,
   onHoverBottom: (isHovered: boolean) => void,
   onContextMenu: () => void,
@@ -202,7 +203,7 @@ class Node extends React.Component<PropsType, StateType> {
 
     let children = node.get('children');
 
-    if (node.get('nodeType') === 'Wrapper') {
+    if (node.get('nodeType') === 'Wrapper' || (this.props.hideSymbol && node.get('hideSymbol'))) {
       return children.map(child =>
         <WrappedNode key={child} id={child} depth={depth}/>
       );
@@ -418,7 +419,7 @@ Node.contextTypes = {
 
 var WrappedNode = decorate({
   listeners(props) {
-    return [props.id];
+    return [props.id, 'hideSymbol'];
   },
   props(store, props) {
     var node = store.get(props.id);
@@ -435,6 +436,7 @@ var WrappedNode = decorate({
       isBottomTagHovered: store.isBottomTagHovered,
       hovered: store.hovered === props.id,
       searchRegExp: props.searchRegExp,
+      hideSymbol: store.hideSymbol,
       onToggleCollapse: e => {
         e.preventDefault();
         store.toggleCollapse(props.id);

--- a/frontend/Node.js
+++ b/frontend/Node.js
@@ -419,7 +419,7 @@ Node.contextTypes = {
 
 var WrappedNode = decorate({
   listeners(props) {
-    return [props.id, 'hideSymbolChange', 'hideDisplayNamedChange'];
+    return [props.id, 'hideSymbolChange', 'hideByParensInNameChange'];
   },
   props(store, props) {
     var node = store.get(props.id);

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -71,6 +71,7 @@ type State = {
   themeKey: number,
   themeName: ?string,
   showTroubleshooting: boolean,
+  hideSymbol: boolean,
 };
 
 class Panel extends React.Component<Props, State> {
@@ -99,6 +100,7 @@ class Panel extends React.Component<Props, State> {
       isReact: props.alreadyFoundReact,
       themeKey: 0,
       themeName: props.themeName,
+      hideSymbol: true,
     };
     this._unMounted = false;
     window.panel = this;

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -71,8 +71,6 @@ type State = {
   themeKey: number,
   themeName: ?string,
   showTroubleshooting: boolean,
-  hideSymbol: boolean,
-  hideDisplayNamed: boolean,
 };
 
 class Panel extends React.Component<Props, State> {
@@ -101,8 +99,6 @@ class Panel extends React.Component<Props, State> {
       isReact: props.alreadyFoundReact,
       themeKey: 0,
       themeName: props.themeName,
-      hideSymbol: true,
-      hideDisplayNamed: true,
     };
     this._unMounted = false;
     window.panel = this;

--- a/frontend/Panel.js
+++ b/frontend/Panel.js
@@ -72,6 +72,7 @@ type State = {
   themeName: ?string,
   showTroubleshooting: boolean,
   hideSymbol: boolean,
+  hideDisplayNamed: boolean,
 };
 
 class Panel extends React.Component<Props, State> {
@@ -101,6 +102,7 @@ class Panel extends React.Component<Props, State> {
       themeKey: 0,
       themeName: props.themeName,
       hideSymbol: true,
+      hideDisplayNamed: true,
     };
     this._unMounted = false;
     window.panel = this;

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -22,6 +22,7 @@ const ThemeEditor = require('./Themes/Editor/Editor');
 const Hoverable = require('./Hoverable');
 const TraceUpdatesFrontendControl = require('../plugins/TraceUpdates/TraceUpdatesFrontendControl');
 const ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
+const HidingEffectFrontendControl = require('../plugins/HidingComponents/EffectFrontendControl');
 const HidingSymbolFrontendControl = require('../plugins/HidingComponents/SymbolFrontendControl');
 const HidingDisplayNamedFrontendControl = require('../plugins/HidingComponents/DisplayNamedFrontendControl');
 
@@ -121,6 +122,11 @@ class PreferencesPanel extends React.Component<Props, State> {
             </EditButton>
           </div>
           <h4 style={styles.header}>Hiding components</h4>
+          <div style={styles.preference}>
+            <HidingEffectFrontendControl value="none" text="No hiding" />
+            <HidingEffectFrontendControl value="hide" text="Hiding" />
+            <HidingEffectFrontendControl value="dim" text="Dimming"/>
+          </div>
           <div style={styles.preference}>
             <HidingSymbolFrontendControl />
           </div>

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -27,9 +27,11 @@ import type {Theme} from './types';
 
 type Props = {
   changeTheme: (themeName: string) => void,
+  changeHideSymbol: (enabled: boolean) => void,
   hasCustomTheme: boolean,
   hide: () => void,
   open: bool,
+  hideSymbol: bool,
 };
 
 type State = {
@@ -44,7 +46,7 @@ class PreferencesPanel extends React.Component<Props, State> {
     showHiddenThemes: boolean,
     theme: Theme,
     themeName: string,
-    themes: { [key: string]: Theme },
+    themes: { [key: string]: Theme }
   };
 
   constructor(props, context) {
@@ -69,7 +71,7 @@ class PreferencesPanel extends React.Component<Props, State> {
 
   render() {
     const {browserName, showHiddenThemes, theme, themeName, themes} = this.context;
-    const {hasCustomTheme, hide, open} = this.props;
+    const {hasCustomTheme, hide, open, hideSymbol} = this.props;
     const {editMode} = this.state;
 
     if (!open) {
@@ -118,6 +120,16 @@ class PreferencesPanel extends React.Component<Props, State> {
               <EditIcon />
             </EditButton>
           </div>
+          <div>
+            <label>
+              <input
+                type="checkbox"
+                checked={hideSymbol}
+                onChange={this._changeHideSymbol}
+              />
+              Hide components with truthy <code>Symbol.for('react.devtools.hide')</code> property
+            </label>
+          </div>
           <div style={styles.buttonBar}>
             <button
               onClick={hide}
@@ -142,6 +154,12 @@ class PreferencesPanel extends React.Component<Props, State> {
 
     changeTheme(event.target.value);
   };
+
+  _changeHideSymbol = (event) => {
+    const {changeHideSymbol} = this.props;
+
+    changeHideSymbol(event.target.checked);
+  }
 
   _hide = () => {
     const {hide} = this.props;
@@ -208,14 +226,16 @@ const blockClick = event => event.stopPropagation();
 
 const WrappedPreferencesPanel = decorate({
   listeners() {
-    return ['preferencesPanelShown'];
+    return ['preferencesPanelShown', 'hideSymbol'];
   },
   props(store, props) {
     return {
       changeTheme: themeName => store.changeTheme(themeName),
+      changeHideSymbol: enabled => store.changeHideSymbol(enabled),
       hasCustomTheme: !!store.themeStore.customTheme,
       hide: () => store.hidePreferencesPanel(),
       open: store.preferencesPanelShown,
+      hideSymbol: store.hideSymbol,
     };
   },
 }, PreferencesPanel);

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -28,10 +28,12 @@ import type {Theme} from './types';
 type Props = {
   changeTheme: (themeName: string) => void,
   changeHideSymbol: (enabled: boolean) => void,
+  changeHideDisplayNamed: (enabled: boolean) => void,
   hasCustomTheme: boolean,
   hide: () => void,
   open: bool,
   hideSymbol: bool,
+  hideDisplayNamed: bool,
 };
 
 type State = {
@@ -71,7 +73,7 @@ class PreferencesPanel extends React.Component<Props, State> {
 
   render() {
     const {browserName, showHiddenThemes, theme, themeName, themes} = this.context;
-    const {hasCustomTheme, hide, open, hideSymbol} = this.props;
+    const {hasCustomTheme, hide, open, hideSymbol, hideDisplayNamed} = this.props;
     const {editMode} = this.state;
 
     if (!open) {
@@ -130,6 +132,16 @@ class PreferencesPanel extends React.Component<Props, State> {
               Hide components with truthy <code>Symbol.for('react.devtools.hide')</code> property
             </label>
           </div>
+          <div>
+            <label>
+              <input
+                type="checkbox"
+                checked={hideDisplayNamed}
+                onChange={this._changeHideDisplayNamed}
+              />
+              Hide components with custom <code>displayName</code> property
+            </label>
+          </div>
           <div style={styles.buttonBar}>
             <button
               onClick={hide}
@@ -159,6 +171,12 @@ class PreferencesPanel extends React.Component<Props, State> {
     const {changeHideSymbol} = this.props;
 
     changeHideSymbol(event.target.checked);
+  }
+
+  _changeHideDisplayNamed = (event) => {
+    const {changeHideDisplayNamed} = this.props;
+
+    changeHideDisplayNamed(event.target.checked);
   }
 
   _hide = () => {
@@ -226,16 +244,18 @@ const blockClick = event => event.stopPropagation();
 
 const WrappedPreferencesPanel = decorate({
   listeners() {
-    return ['preferencesPanelShown', 'hideSymbol'];
+    return ['preferencesPanelShown', 'hideSymbol', 'hideDisplayNamed'];
   },
   props(store, props) {
     return {
       changeTheme: themeName => store.changeTheme(themeName),
       changeHideSymbol: enabled => store.changeHideSymbol(enabled),
+      changeHideDisplayNamed: enabled => store.changeHideDisplayNamed(enabled),
       hasCustomTheme: !!store.themeStore.customTheme,
       hide: () => store.hidePreferencesPanel(),
       open: store.preferencesPanelShown,
       hideSymbol: store.hideSymbol,
+      hideDisplayNamed: store.hideDisplayNamed,
     };
   },
 }, PreferencesPanel);

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -22,18 +22,16 @@ const ThemeEditor = require('./Themes/Editor/Editor');
 const Hoverable = require('./Hoverable');
 const TraceUpdatesFrontendControl = require('../plugins/TraceUpdates/TraceUpdatesFrontendControl');
 const ColorizerFrontendControl = require('../plugins/Colorizer/ColorizerFrontendControl');
+const HidingSymbolFrontendControl = require('../plugins/HidingComponents/SymbolFrontendControl');
+const HidingDisplayNamedFrontendControl = require('../plugins/HidingComponents/DisplayNamedFrontendControl');
 
 import type {Theme} from './types';
 
 type Props = {
   changeTheme: (themeName: string) => void,
-  changeHideSymbol: (enabled: boolean) => void,
-  changeHideDisplayNamed: (enabled: boolean) => void,
   hasCustomTheme: boolean,
   hide: () => void,
   open: bool,
-  hideSymbol: bool,
-  hideDisplayNamed: bool,
 };
 
 type State = {
@@ -73,7 +71,7 @@ class PreferencesPanel extends React.Component<Props, State> {
 
   render() {
     const {browserName, showHiddenThemes, theme, themeName, themes} = this.context;
-    const {hasCustomTheme, hide, open, hideSymbol, hideDisplayNamed} = this.props;
+    const {hasCustomTheme, hide, open} = this.props;
     const {editMode} = this.state;
 
     if (!open) {
@@ -122,25 +120,12 @@ class PreferencesPanel extends React.Component<Props, State> {
               <EditIcon />
             </EditButton>
           </div>
-          <div>
-            <label>
-              <input
-                type="checkbox"
-                checked={hideSymbol}
-                onChange={this._changeHideSymbol}
-              />
-              Hide components with truthy <code>Symbol.for('react.devtools.hide')</code> property
-            </label>
+          <h4 style={styles.header}>Hiding components</h4>
+          <div style={styles.preference}>
+            <HidingSymbolFrontendControl />
           </div>
-          <div>
-            <label>
-              <input
-                type="checkbox"
-                checked={hideDisplayNamed}
-                onChange={this._changeHideDisplayNamed}
-              />
-              Hide components with custom <code>displayName</code> property
-            </label>
+          <div style={styles.preference}>
+            <HidingDisplayNamedFrontendControl />
           </div>
           <div style={styles.buttonBar}>
             <button
@@ -166,18 +151,6 @@ class PreferencesPanel extends React.Component<Props, State> {
 
     changeTheme(event.target.value);
   };
-
-  _changeHideSymbol = (event) => {
-    const {changeHideSymbol} = this.props;
-
-    changeHideSymbol(event.target.checked);
-  }
-
-  _changeHideDisplayNamed = (event) => {
-    const {changeHideDisplayNamed} = this.props;
-
-    changeHideDisplayNamed(event.target.checked);
-  }
 
   _hide = () => {
     const {hide} = this.props;
@@ -244,18 +217,14 @@ const blockClick = event => event.stopPropagation();
 
 const WrappedPreferencesPanel = decorate({
   listeners() {
-    return ['preferencesPanelShown', 'hideSymbol', 'hideDisplayNamed'];
+    return ['preferencesPanelShown'];
   },
   props(store, props) {
     return {
       changeTheme: themeName => store.changeTheme(themeName),
-      changeHideSymbol: enabled => store.changeHideSymbol(enabled),
-      changeHideDisplayNamed: enabled => store.changeHideDisplayNamed(enabled),
       hasCustomTheme: !!store.themeStore.customTheme,
       hide: () => store.hidePreferencesPanel(),
       open: store.preferencesPanelShown,
-      hideSymbol: store.hideSymbol,
-      hideDisplayNamed: store.hideDisplayNamed,
     };
   },
 }, PreferencesPanel);

--- a/frontend/PreferencesPanel.js
+++ b/frontend/PreferencesPanel.js
@@ -46,7 +46,7 @@ class PreferencesPanel extends React.Component<Props, State> {
     showHiddenThemes: boolean,
     theme: Theme,
     themeName: string,
-    themes: { [key: string]: Theme }
+    themes: { [key: string]: Theme },
   };
 
   constructor(props, context) {

--- a/frontend/SettingsCheckbox.js
+++ b/frontend/SettingsCheckbox.js
@@ -45,8 +45,8 @@ class SettingsCheckbox extends React.Component<Props, State> {
   }
 
   componentDidMount(): void {
-    if (!this.props.state !== this._defaultState) {
-      this.props.onChange(this._defaultState);
+    if (!this._defaultState.equals(this.props.state)) {
+      this.props.onChange(this._defaultState.merge(this.props.state));
     }
   }
 

--- a/frontend/SettingsRadio.js
+++ b/frontend/SettingsRadio.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const React = require('react');
+
+const {sansSerif} = require('./Themes/Fonts');
+
+
+type StateValue = any;
+
+type Props = {
+  state: StateValue,
+  value: StateValue,
+  text: string,
+  onChange: (v: StateValue) => void,
+};
+
+class SettingsRadio extends React.Component<Props> {
+  _toggle: (b: boolean) => void;
+
+  constructor(props: Props) {
+    super(props);
+    this._toggle = this._toggle.bind(this);
+  }
+
+  render() {
+    var {state, value} = this.props;
+    return (
+      <label style={styles.container} onClick={this._toggle} tabIndex={0}>
+        <input
+          style={styles.radio}
+          type="radio"
+          checked={state === value}
+          readOnly={true}
+        />
+        <span>{this.props.text}</span>
+      </label>
+    );
+  }
+
+  _toggle() {
+    var {onChange, value} = this.props;
+    onChange(value);
+  }
+}
+
+var styles = {
+  radio: {
+    pointerEvents: 'none',
+    marginRight: '0.5rem',
+  },
+  container: {
+    WebkitUserSelect: 'none',
+    cursor: 'default',
+    display: 'inline-block',
+    outline: 'none',
+    fontFamily: sansSerif.family,
+    userSelect: 'none',
+    marginRight: '0.5rem',
+  },
+};
+
+module.exports = SettingsRadio;

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -23,7 +23,7 @@ var ThemeStore = require('./Themes/Store');
 var {get, set} = require('../utils/storage');
 
 const LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL = 'preferences:hideSymbol';
-const LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED = 'preferences:hideDisplayNamed';
+const LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED = 'preferences:hideByParensInName';
 
 import type Bridge from '../agent/Bridge';
 import type {ControlState, DOMEvent, ElementID, Theme} from './types';
@@ -113,7 +113,7 @@ class Store extends EventEmitter {
   selected: ?ElementID;
   themeStore: ThemeStore;
   hideSymbol: ControlState;
-  hideDisplayNamed: ControlState;
+  hideByParensInName: ControlState;
   breadcrumbHead: ?ElementID;
   snapshotQueue: Array<Snapshot> = [];
   // an object describing the capabilities of the inspected runtime.
@@ -149,7 +149,7 @@ class Store extends EventEmitter {
     this.refreshSearch = false;
     this.themeStore = themeStore;
     this.hideSymbol = {enabled: get(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, false)};
-    this.hideDisplayNamed = {enabled: get(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, false)};
+    this.hideByParensInName = {enabled: get(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, false)};
 
     // for debugging
     window.store = this;
@@ -394,10 +394,10 @@ class Store extends EventEmitter {
     this._reselect();
   }
 
-  changeHideDisplayNamed(state: ControlState) {
-    this.hideDisplayNamed = state;
+  changeHideByParensInName(state: ControlState) {
+    this.hideByParensInName = state;
     set(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, state.enabled);
-    this.emit('hideDisplayNamedChange');
+    this.emit('hideByParensInNameChange');
     this._reselect();
   }
 
@@ -578,8 +578,8 @@ class Store extends EventEmitter {
   }
 
   isHiddenNode(node: DataType) {
-    return this.hideSymbol.enabled && node.get('hideSymbol') ||
-      this.hideDisplayNamed.enabled && node.get('hideDisplayNamed');
+    return this.hideSymbol.enabled && node.get('needHideBySymbol') ||
+      this.hideByParensInName.enabled && node.get('needHideByParensInName');
   }
 
   off(evt: string, fn: ListenerFunction): void {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -11,6 +11,8 @@
 'use strict';
 
 var {EventEmitter} = require('events');
+// TODO $FlowFixMe - it is not documented API? any alternatives?
+var {flushSync} = require('react-dom');
 var {Map, Set, List} = require('immutable');
 var assign = require('object-assign');
 var { copy } = require('clipboard-js');
@@ -215,7 +217,7 @@ class Store extends EventEmitter {
     }
     this._eventQueue.push(event);
     if (!this._eventTimer) {
-      this._eventTimer = setTimeout(() => this.flush(), 50);
+      this._eventTimer = setTimeout(flushSync, 50, () => this.flush());
     }
     return true;
   }

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -419,7 +419,7 @@ class Store extends EventEmitter {
       return;
     }
     this._revealDeep(selected);
-    this.select(this.skipWrapper(selected));
+    this.select(this.skipWrapper(selected), true);
   }
 
   showPreferencesPanel() {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -112,8 +112,8 @@ class Store extends EventEmitter {
   selectedTab: string;
   selected: ?ElementID;
   themeStore: ThemeStore;
-  hideSymbol: boolean;
-  hideDisplayNamed: boolean;
+  hideSymbol: ControlState;
+  hideDisplayNamed: ControlState;
   breadcrumbHead: ?ElementID;
   snapshotQueue: Array<Snapshot> = [];
   // an object describing the capabilities of the inspected runtime.
@@ -148,8 +148,8 @@ class Store extends EventEmitter {
     this.colorizerState = {enabled: false};
     this.refreshSearch = false;
     this.themeStore = themeStore;
-    this.hideSymbol = get(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, false);
-    this.hideDisplayNamed = get(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, false);
+    this.hideSymbol = {enabled: get(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, false)};
+    this.hideDisplayNamed = {enabled: get(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, false)};
 
     // for debugging
     window.store = this;
@@ -387,17 +387,17 @@ class Store extends EventEmitter {
     this.emit('theme');
   }
 
-  changeHideSymbol(enabled: boolean) {
-    this.hideSymbol = enabled;
-    set(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, enabled);
-    this.emit('hideSymbol');
+  changeHideSymbol(state: ControlState) {
+    this.hideSymbol = state;
+    set(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, state.enabled);
+    this.emit('hideSymbolChange');
     this._reselect();
   }
 
-  changeHideDisplayNamed(enabled: boolean) {
-    this.hideDisplayNamed = enabled;
-    set(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, enabled);
-    this.emit('hideDisplayNamed');
+  changeHideDisplayNamed(state: ControlState) {
+    this.hideDisplayNamed = state;
+    set(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, state.enabled);
+    this.emit('hideDisplayNamedChange');
     this._reselect();
   }
 
@@ -578,8 +578,8 @@ class Store extends EventEmitter {
   }
 
   isHiddenNode(node: DataType) {
-    return this.hideSymbol && node.get('hideSymbol') ||
-      this.hideDisplayNamed && node.get('hideDisplayNamed');
+    return this.hideSymbol.enabled && node.get('hideSymbol') ||
+      this.hideDisplayNamed.enabled && node.get('hideDisplayNamed');
   }
 
   off(evt: string, fn: ListenerFunction): void {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -536,8 +536,8 @@ class Store extends EventEmitter {
 
       if (
           nodeType !== 'Wrapper' && nodeType !== 'Native' &&
-          !(nodeType === 'Composite' && this.hideSymbol && node.get('hideSymbol')) &&
-          !(nodeType === 'Composite' && this.hideDisplayNamed && node.get('hideDisplayNamed'))
+          !(this.hideSymbol && node.get('hideSymbol')) &&
+          !(this.hideDisplayNamed && node.get('hideDisplayNamed'))
       ) {
         return id;
       }

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -109,6 +109,7 @@ class Store extends EventEmitter {
   selected: ?ElementID;
   themeStore: ThemeStore;
   hideSymbol: boolean;
+  hideDisplayNamed: boolean;
   breadcrumbHead: ?ElementID;
   snapshotQueue: Array<Snapshot> = [];
   // an object describing the capabilities of the inspected runtime.
@@ -144,6 +145,7 @@ class Store extends EventEmitter {
     this.refreshSearch = false;
     this.themeStore = themeStore;
     this.hideSymbol = true;
+    this.hideDisplayNamed = true;
 
     // for debugging
     window.store = this;
@@ -385,6 +387,11 @@ class Store extends EventEmitter {
     this.emit('hideSymbol');
   }
 
+  changeHideDisplayNamed(enabled: boolean) {
+    this.hideDisplayNamed = enabled;
+    this.emit('hideDisplayNamed');
+  }
+
   showPreferencesPanel() {
     this.preferencesPanelShown = true;
     this.emit('preferencesPanelShown');
@@ -527,7 +534,11 @@ class Store extends EventEmitter {
       var node = this.get(id);
       var nodeType = node.get('nodeType');
 
-      if (nodeType !== 'Wrapper' && nodeType !== 'Native' && !(nodeType === 'Composite' && this.hideSymbol && node.get('hideSymbol'))) {
+      if (
+          nodeType !== 'Wrapper' && nodeType !== 'Native' &&
+          !(nodeType === 'Composite' && this.hideSymbol && node.get('hideSymbol')) &&
+          !(nodeType === 'Composite' && this.hideDisplayNamed && node.get('hideDisplayNamed'))
+      ) {
         return id;
       }
       if (nodeType === 'Native' && (!up || this.get(this._parents.get(id)).get('nodeType') !== 'NativeWrapper')) {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -144,8 +144,8 @@ class Store extends EventEmitter {
     this.colorizerState = null;
     this.refreshSearch = false;
     this.themeStore = themeStore;
-    this.hideSymbol = true;
-    this.hideDisplayNamed = true;
+    this.hideSymbol = false;
+    this.hideDisplayNamed = false;
 
     // for debugging
     window.store = this;

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -108,6 +108,7 @@ class Store extends EventEmitter {
   selectedTab: string;
   selected: ?ElementID;
   themeStore: ThemeStore;
+  hideSymbol: boolean;
   breadcrumbHead: ?ElementID;
   snapshotQueue: Array<Snapshot> = [];
   // an object describing the capabilities of the inspected runtime.
@@ -142,6 +143,7 @@ class Store extends EventEmitter {
     this.colorizerState = null;
     this.refreshSearch = false;
     this.themeStore = themeStore;
+    this.hideSymbol = true;
 
     // for debugging
     window.store = this;
@@ -378,6 +380,11 @@ class Store extends EventEmitter {
     this.emit('theme');
   }
 
+  changeHideSymbol(enabled: boolean) {
+    this.hideSymbol = enabled;
+    this.emit('hideSymbol');
+  }
+
   showPreferencesPanel() {
     this.preferencesPanelShown = true;
     this.emit('preferencesPanelShown');
@@ -520,7 +527,7 @@ class Store extends EventEmitter {
       var node = this.get(id);
       var nodeType = node.get('nodeType');
 
-      if (nodeType !== 'Wrapper' && nodeType !== 'Native') {
+      if (nodeType !== 'Wrapper' && nodeType !== 'Native' && !(nodeType === 'Composite' && this.hideSymbol && node.get('hideSymbol'))) {
         return id;
       }
       if (nodeType === 'Native' && (!up || this.get(this._parents.get(id)).get('nodeType') !== 'NativeWrapper')) {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -144,8 +144,8 @@ class Store extends EventEmitter {
     this.isBottomTagSelected = false;
     this.searchText = '';
     this.capabilities = {};
-    this.traceupdatesState = null;
-    this.colorizerState = null;
+    this.traceupdatesState = {enabled: false};
+    this.colorizerState = {enabled: false};
     this.refreshSearch = false;
     this.themeStore = themeStore;
     this.hideSymbol = get(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, false);
@@ -225,10 +225,11 @@ class Store extends EventEmitter {
       clearTimeout(this._eventTimer);
       this._eventTimer = null;
     }
-    this._eventQueue.forEach(evt => {
+    var eventQueue = this._eventQueue;
+    this._eventQueue = [];
+    eventQueue.forEach(evt => {
       EventEmitter.prototype.emit.call(this, evt);
     });
-    this._eventQueue = [];
   }
 
   // Public actions

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -390,12 +390,23 @@ class Store extends EventEmitter {
     this.hideSymbol = enabled;
     set(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, enabled);
     this.emit('hideSymbol');
+    this._reselect();
   }
 
   changeHideDisplayNamed(enabled: boolean) {
     this.hideDisplayNamed = enabled;
     set(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, enabled);
     this.emit('hideDisplayNamed');
+    this._reselect();
+  }
+
+  _reselect() {
+    var selected = this.selected;
+    if (!selected) {
+      return;
+    }
+    this._revealDeep(selected);
+    this.select(this.skipWrapper(selected));
   }
 
   showPreferencesPanel() {

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -20,6 +20,10 @@ var serializePropsForCopy = require('../utils/serializePropsForCopy');
 var invariant = require('./invariant');
 var SearchUtils = require('./SearchUtils');
 var ThemeStore = require('./Themes/Store');
+var {get, set} = require('../utils/storage');
+
+const LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL = 'preferences:hideSymbol';
+const LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED = 'preferences:hideDisplayNamed';
 
 import type Bridge from '../agent/Bridge';
 import type {ControlState, DOMEvent, ElementID, Theme} from './types';
@@ -144,8 +148,8 @@ class Store extends EventEmitter {
     this.colorizerState = null;
     this.refreshSearch = false;
     this.themeStore = themeStore;
-    this.hideSymbol = false;
-    this.hideDisplayNamed = false;
+    this.hideSymbol = get(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, false);
+    this.hideDisplayNamed = get(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, false);
 
     // for debugging
     window.store = this;
@@ -384,11 +388,13 @@ class Store extends EventEmitter {
 
   changeHideSymbol(enabled: boolean) {
     this.hideSymbol = enabled;
+    set(LOCAL_STORAGE_PREFERENCES_HIDE_SYMBOL, enabled);
     this.emit('hideSymbol');
   }
 
   changeHideDisplayNamed(enabled: boolean) {
     this.hideDisplayNamed = enabled;
+    set(LOCAL_STORAGE_PREFERENCES_HIDE_DISPLAY_NAMED, enabled);
     this.emit('hideDisplayNamed');
   }
 

--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -540,11 +540,7 @@ class Store extends EventEmitter {
       var node = this.get(id);
       var nodeType = node.get('nodeType');
 
-      if (
-          nodeType !== 'Wrapper' && nodeType !== 'Native' &&
-          !(this.hideSymbol && node.get('hideSymbol')) &&
-          !(this.hideDisplayNamed && node.get('hideDisplayNamed'))
-      ) {
+      if (nodeType !== 'Wrapper' && nodeType !== 'Native' && !this.isHiddenNode(node)) {
         return id;
       }
       if (nodeType === 'Native' && (!up || this.get(this._parents.get(id)).get('nodeType') !== 'NativeWrapper')) {
@@ -567,6 +563,11 @@ class Store extends EventEmitter {
         id = childId;
       }
     }
+  }
+
+  isHiddenNode(node: DataType) {
+    return this.hideSymbol && node.get('hideSymbol') ||
+      this.hideDisplayNamed && node.get('hideDisplayNamed');
   }
 
   off(evt: string, fn: ListenerFunction): void {

--- a/frontend/Themes/Preview.js
+++ b/frontend/Themes/Preview.js
@@ -125,6 +125,7 @@ const fauxStore = {
   setHover: noop,
   selectBottom: noop,
   selectTop: noop,
+  isHiddenNode: noop,
 };
 
 const panelStyle = (theme: Theme) => ({

--- a/frontend/types.js
+++ b/frontend/types.js
@@ -76,6 +76,8 @@ export type ControlState = {
   enabled: boolean,
 } & Record;
 
+export type HidingStyle = 'none' | 'hide' | 'dim';
+
 /**
  * A theme is a color template used throughout devtools.
  * All devtools coloring is declared by themes, with one minor exception: status colors.

--- a/plugins/HidingComponents/DisplayNamedFrontendControl.js
+++ b/plugins/HidingComponents/DisplayNamedFrontendControl.js
@@ -16,13 +16,13 @@ var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
 
 var Wrapped = decorate({
   listeners() {
-    return ['hideDisplayNamedChange'];
+    return ['hideByParensInNameChange'];
   },
   props(store) {
     return {
-      state: store.hideDisplayNamed,
-      text: 'Hide components with custom \'displayName\' property',
-      onChange: state => store.changeHideDisplayNamed(state),
+      state: store.hideByParensInName,
+      text: 'Hide HOC\'s with parens in name',
+      onChange: state => store.changeHideByParensInName(state),
     };
   },
 }, SettingsCheckbox);

--- a/plugins/HidingComponents/DisplayNamedFrontendControl.js
+++ b/plugins/HidingComponents/DisplayNamedFrontendControl.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+var decorate = require('../../frontend/decorate');
+var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
+
+var Wrapped = decorate({
+  listeners() {
+    return ['hideDisplayNamedChange'];
+  },
+  props(store) {
+    return {
+      state: store.hideDisplayNamed,
+      text: 'Hide components with custom \'displayName\' property',
+      onChange: state => store.changeHideDisplayNamed(state),
+    };
+  },
+}, SettingsCheckbox);
+
+module.exports = Wrapped;

--- a/plugins/HidingComponents/EffectFrontendControl.js
+++ b/plugins/HidingComponents/EffectFrontendControl.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+var decorate = require('../../frontend/decorate');
+var SettingsRadio = require('../../frontend/SettingsRadio');
+
+var Wrapped = decorate({
+  listeners() {
+    return ['hidingStyleChange'];
+  },
+  props(store) {
+    return {
+      state: store.hidingStyle,
+      onChange: state => store.changeHidingStyle(state),
+    };
+  },
+}, SettingsRadio);
+
+module.exports = Wrapped;

--- a/plugins/HidingComponents/SymbolFrontendControl.js
+++ b/plugins/HidingComponents/SymbolFrontendControl.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+var decorate = require('../../frontend/decorate');
+var SettingsCheckbox = require('../../frontend/SettingsCheckbox');
+
+var Wrapped = decorate({
+  listeners() {
+    return ['hideSymbolChange'];
+  },
+  props(store) {
+    return {
+      state: store.hideSymbol,
+      text: 'Hide components with truthy `Symbol.for(\'react.devtools.hide\')` property',
+      onChange: state => store.changeHideSymbol(state),
+    };
+  },
+}, SettingsCheckbox);
+
+module.exports = Wrapped;

--- a/test/example/target.js
+++ b/test/example/target.js
@@ -505,6 +505,7 @@ function wrapWithHoc(Component) {
       return <div><Component /></div>;
     }
   }
+  HigherOrderComponent.displayName = 'HigherOrderComponent(Nested)';
   if (typeof Symbol === 'function') {
     HigherOrderComponent[Symbol.for('react.devtools.hide')] = true;
   }

--- a/test/example/target.js
+++ b/test/example/target.js
@@ -505,6 +505,9 @@ function wrapWithHoc(Component) {
       return <div><Component /></div>;
     }
   }
+  if (typeof Symbol === 'function') {
+    HigherOrderComponent[Symbol.for('react.devtools.hide')] = true;
+  }
 
   return HigherOrderComponent;
 }


### PR DESCRIPTION
Add two options for hiding components
1) For components with `[Symbol.for('react.devtools.hide')] = true` - rebase of PR #997 
2) If component define `displayName` - I think that most popular case for HOC

I'm waiting for feedbacks
It is time to move forward on this issue after long discussions.