### PR TITLE
Fix showing component source when React Hot Loader is enabled

### DIFF
--- a/shells/webextension/src/panel.js
+++ b/shells/webextension/src/panel.js
@@ -77,7 +77,11 @@ var config: Props = {
         window.${globalPathToType}.prototype &&
         window.${globalPathToType}.prototype.isReactComponent
       ) {
-        inspect(window.${globalPathToInst}.render);
+        if (window.${globalPathToInst}.REACT_HOT_LOADER_RENDERED_GENERATION) {
+          inspect(Object.getPrototypeOf(window.${globalPathToType}));
+        } else {
+          inspect(window.${globalPathToInst}.render);
+        }
       } else {
         inspect(window.${globalPathToType});
       }


### PR DESCRIPTION
There is a problem with a `Show <Component> Source` feature when you are running React with [React Hot Loader](https://github.com/gaearon/react-hot-loader). After selecting the option from a context menu, you will be navigated to a React Hot Loader `ProxyFacade` component instead of the source of a selected component.

## How to reproduce?
1. Go to this page: https://jnwlwrm1qw.codesandbox.io/
2. Open React Devtools
3. Select `App` component on the Elements tab
4. From the context menu select `Show App Source`

## Current behavior
Devtools are activating Source tab and highlighting `ProxyFacade` that is coming from React Hot Loader.

## Expected behavior
Devtools should go to the Source tab and highlight the source of `App` component.

## Demo
![rhl-bug](https://user-images.githubusercontent.com/227305/47355933-70654880-d70e-11e8-849d-a1a5e25c7d6d.gif)
