### PR TITLE
Support React.memo and timed-out Suspense trees

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -40,6 +40,7 @@ function getInternalReactConstants(version) {
       HostPortal: 4,
       HostRoot: 3,
       HostText: 6,
+      IncompleteClassComponent: 17,
       IndeterminateComponent: 2,
       LazyComponent: 16,
       MemoComponent: 14,
@@ -63,6 +64,7 @@ function getInternalReactConstants(version) {
       HostPortal: 6,
       HostRoot: 5,
       HostText: 8,
+      IncompleteClassComponent: -1, // Doesn't exist yet
       IndeterminateComponent: 4,
       LazyComponent: -1, // Doesn't exist yet
       MemoComponent: -1, // Doesn't exist yet
@@ -86,6 +88,7 @@ function getInternalReactConstants(version) {
       HostPortal: 4,
       HostRoot: 3,
       HostText: 6,
+      IncompleteClassComponent: -1, // Doesn't exist yet
       IndeterminateComponent: 0,
       LazyComponent: -1, // Doesn't exist yet
       MemoComponent: -1, // Doesn't exist yet
@@ -137,12 +140,14 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
     FunctionalComponent,
     ClassComponent,
     ContextConsumer,
+    Fragment,
+    ForwardRef,
     HostRoot,
     HostPortal,
     HostComponent,
     HostText,
-    Fragment,
-    ForwardRef,
+    IncompleteClassComponent,
+    IndeterminateComponent,
     MemoComponent,
     SimpleMemoComponent,
   } = ReactTypeOfWork;
@@ -197,8 +202,10 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
     // TODO: Add support for new tags LazyComponent, MemoComponent, and SimpleMemoComponent
 
     switch (fiber.tag) {
-      case FunctionalComponent:
       case ClassComponent:
+      case FunctionalComponent:
+      case IncompleteClassComponent:
+      case IndeterminateComponent:
         nodeType = 'Composite';
         name = getDisplayName(resolvedType);
         publicInstance = fiber.stateNode;

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -199,8 +199,6 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       }
     }
 
-    // TODO: Add support for new tags LazyComponent, MemoComponent, and SimpleMemoComponent
-
     switch (fiber.tag) {
       case ClassComponent:
       case FunctionalComponent:


### PR DESCRIPTION
# Support `React.memo`

* **Resolves** #1193
* **Commit** 4d85b12

Remove `React.pure` (since it was never released in a stable) and add support for `React.memo`. Preserve previous custom `displayName` semantics.

#### Code
```js
function CounterFunction({count}) {
  return <small>{count}</small>;
}
const A = React.memo(({count}) => <small>{count}</small>);
const B = React.memo(CounterFunction);
const C = React.memo(CounterFunction);
C.displayName = 'MemoCounterFunction';
```

#### DevTools
![screen shot 2018-10-29 at 11 16 27 am](https://user-images.githubusercontent.com/29597/47671120-1cbe8900-db6c-11e8-991d-ae350d3b6637.png)

# Support timed-out suspense subtrees

* **Resolves** #1189.
* **Commit** 34ed7be

**Backstory**: [A special case (hack)](https://github.com/facebook/react/blob/8c67bbf183cc5ae1cab15a8265c612daf80cd86f/packages/react-reconciler/src/ReactFiberBeginWork.js#L1107-L1132) was added to fiber to maintain state for components within timed-out suspended trees. In this event, React hides the original UI and shows a fallback UI. Rather than destroying the hidden UI, it holds onto it so the state isn't lost (e.g. component state, untracked input values).

DevTools mostly just worked with this hack, but [use cases like this one](https://gist.github.com/bvaughn/476d0e54bb57870e7e384680a7a15056) left the Elements panel in a broken state after the suspended render completed– due to an incorrect child->parent pointer.

I'm not sure of a great way to model this within [`attachRendererFiber`](https://github.com/facebook/react-devtools/blob/master/backend/attachRendererFiber.js) (where it probably belongs), but it seemed reasonably easy to handle as a generic reparenting check. So let's discuss? 😄 

# Misc

* **Commit** ef8c92d

Also fixed the Elements panel display name for `IndeterminateComponent` type components.