### PR TITLE
Resolve defaultProps for lazy etc

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -17,6 +17,22 @@ var semver = require('semver');
 var copyWithSet = require('./copyWithSet');
 var getDisplayName = require('./getDisplayName');
 
+// Taken from ReactElement.
+function resolveDefaultProps(Component: any, baseProps: Object): Object {
+  if (Component && Component.defaultProps) {
+    // Resolve default props. Taken from ReactElement
+    const props = Object.assign({}, baseProps);
+    const defaultProps = Component.defaultProps;
+    for (const propName in defaultProps) {
+      if (props[propName] === undefined) {
+        props[propName] = defaultProps[propName];
+      }
+    }
+    return props;
+  }
+  return baseProps;
+}
+
 function getInternalReactConstants(version) {
   var ReactTypeOfWork;
   var ReactSymbols;
@@ -352,6 +368,14 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
             break;
         }
         break;
+    }
+
+    if (
+      props !== null &&
+      typeof fiber.elementType !== undefined &&
+      fiber.type !== fiber.elementType
+    ) {
+      props = resolveDefaultProps(fiber.type, props);
     }
 
     if (Array.isArray(children)) {

--- a/test/regression/shared.js
+++ b/test/regression/shared.js
@@ -103,6 +103,27 @@ switch (major) {
             </React.Suspense>
           </Feature>
         );
+
+        // lazy
+        const LazyWithDefaultProps = React.lazy(() => new Promise(resolve => {
+          function FooWithDefaultProps(props) {
+            return <h1>{props.greeting}, {props.name}</h1>;
+          }
+          FooWithDefaultProps.defaultProps = {
+            name: 'World',
+            greeting: 'Bonjour',
+          };
+          resolve({
+            default: FooWithDefaultProps,
+          });
+        }));
+        apps.push(
+          <Feature key="lazy" label="lazy" version="16.6+">
+            <React.Suspense fallback={<div>loading...</div>}>
+              <LazyWithDefaultProps greeting="Hello" />
+            </React.Suspense>
+          </Feature>
+        );
       case 5:
       case 4:
         // unstable_Profiler


### PR DESCRIPTION
Related to https://github.com/facebook/react/pull/13902.

If `fiber.elementType` exists and differs from `fiber.type`, we need to respect the `defaultProps` defined on the `fiber.type`. Such default props wouldn't be kept in `fiber.memoizedProps`. This is why in the React code we also call `resolveDefaultProps()` in those cases.

I added a regression case to demonstrate it. It should display `<FooWithDefaultProps greeting="Hello" name="World" />`. In master, it is missing `name="World"` (that’s the issue I am fixing).