### PR TITLE
Use request-supplied host and port in connectToDevTools

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -149,7 +149,26 @@ function startServer(port = 8097) {
   httpServer.on('request', (req, res) => {
     // Serve a file that immediately sets up the connection.
     var backendFile = readFileSync(join(__dirname, 'backend.js'));
-    res.end(backendFile + '\n;ReactDevToolsBackend.connectToDevTools();');
+
+    var headerHostAndPort = (req.headers || {}).host || '';
+    var headerHostAndPortParts = headerHostAndPort.split(':');
+    var headersHost = headerHostAndPortParts[0];
+    var headersPort = headerHostAndPortParts[1];
+
+    var connectOptions = {};
+    if (headersHost) {
+      connectOptions.host = headersHost;
+    }
+    if (headersPort) {
+      connectOptions.port = headersPort;
+    }
+
+    res.end(
+      backendFile + '\n;' +
+      'ReactDevToolsBackend.connectToDevTools(' +
+      JSON.stringify(connectOptions, null, 2) +
+      ');'
+    );
   });
 
   httpServer.on('error', (e) => {


### PR DESCRIPTION
### What changed
When using the standalone react devtools the `connectToDevtools` call passes no arguments. The fallback behavior in this case is for the devtools instance to try and connect at `localhost`.

This PR changes the behavior so that if a `host` header is supplied in the initial request, then the `connectToDevtools` call will use the header host and port values.

### Motivation
This simplifies development when the devtools server is running on one host and the client is running on another. Simply dropping in the devtools-provided script snippet should be sufficient to get the two halves communicating successfully.

### Caveats
The host-header checking code is pretty simplistic, and not robust to weird or malformed host headers. However, so long as execution passes those host-header checks, no regressions should be introduced to the current arg-less `connectToDevtools` behavior.