### PR TITLE
Bug: handle "replacement" connections correctly

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -40,6 +40,8 @@ if (window.document) {
   });
 }
 
+var CONNECTION_REPLACED = 'CONNECTION_REPLACED';
+
 function connectToDevTools(options: ?ConnectOptions) {
   var {
     host = 'localhost',
@@ -87,10 +89,12 @@ function connectToDevTools(options: ?ConnectOptions) {
   };
 
   var hasClosed = false;
-  function handleClose() {
+  function handleClose(ev) {
     if (!hasClosed) {
       hasClosed = true;
-      scheduleRetry();
+      if (ev.reason !== CONNECTION_REPLACED) {
+        scheduleRetry();
+      }
       closeListeners.forEach(fn => fn());
     }
   }
@@ -159,4 +163,7 @@ function setupBackend(wall, resolveRNStyle) {
   ProfileCollector.init(agent);
 }
 
-module.exports = { connectToDevTools };
+module.exports = {
+  connectToDevTools,
+  CONNECTION_REPLACED,
+};


### PR DESCRIPTION
Hi, and thanks for this amazing tool!

I noticed that the standalone package has [logic intended to handle cases where a new devtools connection "replaces" a previous one](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L122-L128). However, it's not quite working right:

![repro](https://user-images.githubusercontent.com/6352327/48364389-24e2f200-e65d-11e8-868f-b287ce836f9d.gif)

(^ Two instances of Create React App pointing at the same `localhost:8097` standalone instance; second instance fails to connect)

### Problem

It looks like there are two things going on:

1.) The [onclose](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L135) callback from the _previous_ (replaced) connection seems to fire asynchronously. That is, these steps take place in this order:
* We detect a replacement connection and [close it](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L135)
* We [initialize](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L140) the new connection, and [re-render](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L46-L52)
* Then the `onclose` callback of the previous connection detects that it's been closed, and tries to shut down. But by now, `connected` is the _new_ connection (so we don't want to [set it to false](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L136)), and we've already set up the DOM (so we don't want to [clear it with `onDisconnected`](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/standalone.js#L137))

Here's that sequence via breakpoints:

![sequence](https://user-images.githubusercontent.com/6352327/48364672-e0a42180-e65d-11e8-8975-d08773fb8cad.gif)

2.) Over in `backend.js`, we have logic to [schedule retries 2 seconds after a connection closes](https://github.com/facebook/react-devtools/blob/0228043b3b07a9dcc54269c859d11b6f0efeef9d/packages/react-devtools-core/src/backend.js#L90). If we solely make changes to accommodate 1.), we end up in a looping state where both connections keep retrying ad infinitum.

### Solution

In both cases, the code needs to be aware when a connection is being closed because of an incoming replacement. When it is, we can skip the usual `onClose` steps (the incoming connection will have already set everything up) and the scheduled retry.

This PR implements that approach by passing a string to the socket's `close` method (in cases of replacement) and checking it in both relevant event handlers.