### PR TITLE
Feature: extra configuration to support HTTPS (and VMs)

### DIFF
--- a/packages/react-devtools-core/package.json
+++ b/packages/react-devtools-core/package.json
@@ -24,6 +24,7 @@
   "author": "Jared Forsyth",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "replicator": "^1.0.2",
     "shell-quote": "^1.6.1",
     "ws": "^3.3.1"
   },

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -19,12 +19,14 @@ var Panel = require('../../../frontend/Panel');
 var launchEditor = require('./launchEditor');
 var React = require('react');
 var ReactDOM = require('react-dom');
+var Replicator = require('replicator');
 
 var node = null;
 var onStatusChange = function noop() {};
 var projectRoots = [];
 var wall = null;
 var panel = null;
+var replicator = new Replicator();
 
 var config = {
   reload,
@@ -72,7 +74,7 @@ function onError(e) {
 function initialize(socket) {
   var listeners = [];
   socket.onmessage = (evt) => {
-    var data = JSON.parse(evt.data);
+    var data = replicator.decode(evt.data);
     listeners.forEach((fn) => fn(data));
   };
 
@@ -151,7 +153,16 @@ function startServer(port = 8097) {
     var backendFile = fs.readFileSync(
       path.join(__dirname, '../build/backend.js')
     );
-    res.end(backendFile + '\n;ReactDevToolsBackend.connectToDevTools();');
+    var devToolsConfig = {
+      host: process.env.REACT_DEVTOOLS_HOST,
+      port: process.env.REACT_DEVTOOLS_WS_PORT,
+      websocketProtocol: process.env.REACT_DEVTOOLS_WS_PROTOCOL,
+    };
+    var backendFileWithInit = backendFile +
+      '\n;ReactDevToolsBackend.connectToDevTools(' +
+      JSON.stringify(devToolsConfig) +
+      ');';
+    res.end(backendFileWithInit);
   });
 
   httpServer.on('error', (e) => {

--- a/packages/react-devtools/app.html
+++ b/packages/react-devtools/app.html
@@ -78,6 +78,7 @@
         </div>
         <script>
             var port = process.env.PORT || 8097;
+            var localPath = process.env.REACT_DEVTOOLS_HOST || 'http://localhost:' + port;
             var localIp = require('ip').address();
             var $ = document.querySelector.bind(document);
             function selectAll() {
@@ -86,7 +87,7 @@
             }
             var $localhost = $('#localhost');
             var $byIp = $('#byip');
-            $localhost.value = '<' + 'script src="http://localhost:' + port + '"><' + '/script>';
+            $localhost.value = '<' + 'script src="' + localPath + '"><' + '/script>';
             $byIp.value = '<' + 'script src="http://' + localIp + ':' + port + '"><' + '/script>';
             $localhost.onclick = selectAll;
             $byIp.onclick = selectAll;

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,7 +95,6 @@ addons-linter@0.22.3:
 adm-zip@^0.4.7:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
-  integrity sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==
 
 adm-zip@~0.4.x:
   version "0.4.7"
@@ -5962,6 +5961,10 @@ repeating@^2.0.0:
 replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
+
+replicator@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/replicator/-/replicator-1.0.2.tgz#f21812f28f3b853a34795a7d52814581df652fe1"
 
 request-promise-core@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This PR makes two things possible:
* Use of the standalone React devtools in HTTPS-only enviroments (https://github.com/facebook/react-devtools/issues/1208, https://github.com/facebook/react-devtools/issues/923, https://github.com/facebook/react-devtools/issues/881)
* Use across machine boundaries: e.g., running the devtools locally on Mac and connecting to them from inside a Windows VM (even though the two don't share a `localhost`)

The approach Textio has implemented relies on [ngrok](https://ngrok.com/), which exposes secure tunnels to localhost. With ngrok, you can access `http://localhost:8097` at `https://<your subdomain of choice>.ngrok.io` (even from other computers), with a trusted certificate and everything.

**Note that this PR isn't coupled to ngrok**; it simply supports additional user configuration, falling back to current behavior as defaults. Still, I'll document the ngrok approach here (and I'd be happy to add it to the docs). ngrok is free for the features we're using here.

## Setting up ngrok

1.) Each developer chooses a personal tunnel subdomain to use and sets it as an env variable. It's easiest to store this in your `~/.bash_profile` (or equivalent terminal config), so you don't need to type it all the time:
```
REACT_DEVTOOLS_HOST=<your subdomain>.ngrok.io
```
The other new fields exposed to configuration are `REACT_DEVTOOLS_WS_PORT` (defaults to `8097`) and `REACT_DEVTOOLS_WS_PROTOCOL` (defaults to `ws`). If you're setting up an HTTPS connection, you'll set the former to `443` and the latter to `wss`.

2.) In one terminal window, start the ngrok tunnel with `ngrok http -subdomain=<your subdomain> 8097`. Now start the devtools, and either pass through additional CLI args:
```
# in package.json scripts (assumes process.env.REACT_DEVTOOLS_HOST also set in profile):
"react-devtools": "REACT_DEVTOOLS_WS_PORT=443 REACT_DEVTOOLS_WS_PROTOCOL=wss react-devtools"
```
or set them via `connectToDevTools`:
```
import { connectToDevTools } from 'react-devtools-core';

connectToDevTools({
    host: process.env.REACT_DEVTOOLS_HOST,
    websocketProtocol: 'wss',
    port: 443
});
```
All set! Now you can run devtools locally and connect from secure sites and/or VMs.

## IE11-specific dependency

The one non-configuration change here is pulling in [`replicator`](https://www.npmjs.com/package/replicator) to serialize messages passed from the client script to Electron. In IE11, [`JSON.stringify`](https://github.com/facebook/react-devtools/blob/0207b68e24aa4c7227fe9a760859f1ead4c265aa/packages/react-devtools-core/src/backend.js#L80) and [`JSON.parse`](https://github.com/facebook/react-devtools/blob/0207b68e24aa4c7227fe9a760859f1ead4c265aa/packages/react-devtools-core/src/standalone.js#L75) throw "error converting circular structure to JSON" when passing through the devtools' setup messages—I'm not sure if from DOM nodes or React components.

I experimented with a handful of libraries to handle circular JSON: [`jsan`](https://github.com/kolodny/jsan), [`circular-json`](https://github.com/WebReflection/circular-json), its descendant [`flatted`](https://github.com/WebReflection/flatted), [`json-cycle`](https://www.npmjs.com/package/json-cycle), and a few others. All either didn't fix the problem or generated new errors (e.g., invalid JSON). However, `replicator` passes our messages through perfectly! And it [defaults to `JSON.parse` and `JSON.stringify`](https://github.com/inikulin/replicator/blob/9e8a9151f4bff9c5abbd9c2e5ea838e3e15fceeb/index.js#L34-L43) for regular strings, so it shouldn't affect anyone _not_ dealing with IE11.