### PR TITLE
Added props visibility for ForwardRef and Memo'ed components

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -316,6 +316,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
           const displayName = type.displayName || type.name;
           name = displayName ? `Memo(${displayName})` : 'Memo';
         }
+        props = fiber.memoizedProps;
         children = [];
         break;
       default:

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -256,6 +256,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
             ? `ForwardRef(${functionName})`
             : 'ForwardRef'
         );
+        props = fiber.memoizedProps;
         children = [];
         break;
       case HostRoot:


### PR DESCRIPTION
ForwardRef components props now showing in devtools

- Resolves #1213
- Commit b08863e 

Added missing props assignment

<img width="860" alt="screen shot 2018-12-08 at 22 46 41" src="https://user-images.githubusercontent.com/23095052/49691502-8e123400-fb3b-11e8-8a9e-1dac4ce100e3.png">


Memo'ed components props now showing in devtools

- Resolves #1238
- Commit 20f748b 

Added missing props assignment

<img width="907" alt="screen shot 2018-12-08 at 22 47 34" src="https://user-images.githubusercontent.com/23095052/49691505-95d1d880-fb3b-11e8-8f6f-51d7a24a3200.png">


