### PR TITLE
Support editable props for more component types

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -395,7 +395,7 @@ class Agent extends EventEmitter {
       send.children = send.children.map(c => this.getId(c));
     }
     send.id = id;
-    send.canUpdate = send.updater && !!send.updater.forceUpdate;
+    send.canUpdate = send.updater && send.updater.canUpdate;
     delete send.type;
     delete send.updater;
     this.emit('mount', send);
@@ -410,7 +410,7 @@ class Agent extends EventEmitter {
       send.children = send.children.map(c => this.getId(c));
     }
     send.id = id;
-    send.canUpdate = send.updater && !!send.updater.forceUpdate;
+    send.canUpdate = send.updater && send.updater.canUpdate;
     delete send.type;
     delete send.updater;
     this.emit('update', send);
@@ -425,7 +425,7 @@ class Agent extends EventEmitter {
       send.children = send.children.map(c => this.getId(c));
     }
     send.id = id;
-    send.canUpdate = send.updater && !!send.updater.forceUpdate;
+    send.canUpdate = send.updater && send.updater.canUpdate;
     delete send.type;
     delete send.updater;
     this.emit('updateProfileTimes', send);

--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -150,6 +150,7 @@ function getInternalReactConstants(version) {
 }
 
 function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): Helpers {
+  var {overrideProps} = renderer;
   var {ReactTypeOfWork, ReactSymbols, ReactTypeOfSideEffect} = getInternalReactConstants(renderer.version);
   var {PerformedWork} = ReactTypeOfSideEffect;
   var {
@@ -220,6 +221,16 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       }
     }
 
+    if (typeof overrideProps === 'function') {
+      updater = {
+        canUpdate: true,
+        setState: null,
+        setInProps: overrideProps.bind(null, fiber),
+        setInState: null,
+        setInContext: null,
+      };
+    }
+
     switch (fiber.tag) {
       case ClassComponent:
       case FunctionalComponent:
@@ -239,8 +250,8 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
         const inst = publicInstance;
         if (inst) {
           updater = {
+            canUpdate: true,
             setState: inst.setState && inst.setState.bind(inst),
-            forceUpdate: inst.forceUpdate && inst.forceUpdate.bind(inst),
             setInProps: inst.forceUpdate && setInProps.bind(null, fiber),
             setInState: inst.forceUpdate && setInState.bind(null, inst),
             setInContext: inst.forceUpdate && setInContext.bind(null, inst),

--- a/backend/getData.js
+++ b/backend/getData.js
@@ -138,8 +138,8 @@ function getData(internalInstance: Object): DataType {
       inst.updater.enqueueForceUpdate(this, cb, 'forceUpdate');
     });
     updater = {
+      canUpdate: true,
       setState: inst.setState && inst.setState.bind(inst),
-      forceUpdate: forceUpdate && forceUpdate.bind(inst),
       setInProps: forceUpdate && setInProps.bind(null, internalInstance, forceUpdate),
       setInState: inst.forceUpdate && setInState.bind(null, inst),
       setInContext: forceUpdate && setInContext.bind(null, inst, forceUpdate),

--- a/backend/getData012.js
+++ b/backend/getData012.js
@@ -82,8 +82,8 @@ function getData012(internalInstance: Object): DataType {
 
   if (internalInstance.forceUpdate) {
     updater = {
+      canUpdate: true,
       setState: internalInstance.setState.bind(internalInstance),
-      forceUpdate: internalInstance.forceUpdate.bind(internalInstance),
       setInProps: internalInstance.forceUpdate && setInProps.bind(null, internalInstance),
       setInState: internalInstance.forceUpdate && setInState.bind(null, internalInstance),
       setInContext: internalInstance.forceUpdate && setInContext.bind(null, internalInstance),

--- a/backend/types.js
+++ b/backend/types.js
@@ -11,10 +11,10 @@
 'use strict';
 
 type CompositeUpdater = {
+  canUpdate: boolean,
   setInProps: ?(path: Array<string>, value: any) => void,
   setInState: ?(path: Array<string>, value: any) => void,
   setInContext: ?(path: Array<string>, value: any) => void,
-  forceUpdate: ?() => void,
 };
 
 type NativeUpdater = {
@@ -73,6 +73,7 @@ export type ReactRenderer = {
   findFiberByHostInstance: (hostInstance: NativeType) => ?OpaqueNodeHandle,
   version: string,
   bundleType: BundleType,
+  overrideProps?: ?(fiber: Object, path: Array<string | number>, value: any) => void,
 
   // Stack
   Reconciler: {


### PR DESCRIPTION
Use new injected `overrideProps()` function (available in DEV builds only) to support editable props for function components, host elements, and special types like `memo` and `forwardRef`.

Move this update logic into React will also enable us to add more complex behavior in the future– such as the ability to override props in a way that won't get overridden unless the component is re-rendered with a _new_ props value.

## Demo
![kapture 2018-12-12 at 15 40 18](https://user-images.githubusercontent.com/29597/49905941-aaa4b980-fe24-11e8-8d19-c8e7d06d2f0b.gif)

Since there is no `forceUpdate` function for e.g. function components or host nodes, I also removed the `forceUpdate` attribute from the `CompositeUpdater` type. It wasn't being used for anything other than determining if a node supported editing, so I replaced it with a `canUpdate` boolean prop.