### PR TITLE
Serialize nested attributes less aggressively

### DIFF
--- a/agent/__tests__/dehydrate-test.js
+++ b/agent/__tests__/dehydrate-test.js
@@ -33,26 +33,31 @@ describe('dehydrate', () => {
     var object = {a: {b: {c: {d: 4}}}};
     var cleaned = [];
     var result = dehydrate(object, cleaned);
-    expect(cleaned).toEqual([['a', 'b', 'c']]);
-    expect(result.a.b.c).toEqual({type: 'object', name: '', meta: {}});
+    expect(cleaned).toEqual([['a', 'b']]);
+    expect(result.a.b).toEqual({type: 'object', name: '', meta: {}});
+    expect(result.a.b.c).toBeUndefined(); // Dehydrated
+
+    // Re-hydrate
+    result.a.b = dehydrate(object.a.b, [], ['a', 'b']);
+    expect(result).toEqual(object);
   });
 
   it('cleans a deeply nested array', () => {
-    var object = {a: {b: {c: [1, 3]}}};
+    var object = {a: {b: [1, 3]}};
     var cleaned = [];
     var result = dehydrate(object, cleaned);
-    expect(cleaned).toEqual([['a', 'b', 'c']]);
-    expect(result.a.b.c).toEqual({type: 'array', name: 'Array', meta: {length: 2}});
+    expect(cleaned).toEqual([['a', 'b']]);
+    expect(result.a.b).toEqual({type: 'array', name: 'Array', meta: {length: 2}});
   });
 
   it('cleans multiple things', () => {
     var Something = function() {};
-    var object = {a: {b: {c: [1, 3], d: new Something()}}};
+    var object = {a: {b: [1, 3], c: new Something()}};
     var cleaned = [];
     var result = dehydrate(object, cleaned);
-    expect(cleaned).toEqual([['a', 'b', 'c'], ['a', 'b', 'd']]);
-    expect(result.a.b.c).toEqual({type: 'array', name: 'Array', meta: {length: 2}});
-    expect(result.a.b.d).toEqual({type: 'object', name: 'Something', meta: {}});
+    expect(cleaned).toEqual([['a', 'b'], ['a', 'c']]);
+    expect(result.a.b).toEqual({type: 'array', name: 'Array', meta: {length: 2}});
+    expect(result.a.c).toEqual({type: 'object', name: 'Something', meta: {}});
   });
 
   it('returns readable name for dates', () => {

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+const LEVEL_THRESHOLD = 1;
+
 /**
  * Get a enhanced/artificial type string based on the object instance
  */
@@ -69,7 +71,7 @@ function createDehydrated(type: string, data: Object, cleaned: Array<Array<strin
 }
 
 /**
- * Strip out complex data (instances, functions, and data nested > 2 levels
+ * Strip out complex data (instances, functions, and data nested > LEVEL_THRESHOLD levels
  * deep). The paths of the stripped out objects are appended to the `cleaned`
  * list. On the other side of the barrier, the cleaned list is used to
  * "re-hydrate" the cleaned representation into an object with symbols as
@@ -131,7 +133,7 @@ function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<str
       };
 
     case 'array':
-      if (level > 2) {
+      if (level > LEVEL_THRESHOLD) {
         return createDehydrated(type, data, cleaned, path);
       }
       return data.map((item, i) => dehydrate(item, cleaned, path.concat([i]), level + 1));
@@ -149,7 +151,7 @@ function dehydrate(data: Object, cleaned: Array<Array<string>>, path?: Array<str
         },
       };
     case 'object':
-      if (level > 2 || (data.constructor && typeof data.constructor === 'function' && data.constructor.name !== 'Object')) {
+      if (level > LEVEL_THRESHOLD || (data.constructor && typeof data.constructor === 'function' && data.constructor.name !== 'Object')) {
         return createDehydrated(type, data, cleaned, path);
       } else {
 

--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -10,6 +10,11 @@
  */
 'use strict';
 
+// This threshold determines the depth at which the bridge "dehydrates" nested data.
+// Dehydration means that we don't serialize the data for e.g. postMessage or stringify,
+// unless the frontend explicitly requests it (e.g. a user clicks to expand a props object).
+// This value was originally set to 2, but we reduced it to improve performance:
+// see https://github.com/facebook/react-devtools/issues/1200
 const LEVEL_THRESHOLD = 1;
 
 /**


### PR DESCRIPTION
Related to #1200 

In the current version of DevTools, the bridge serializes object attributes for a few levels– after which, attributes that are more deeply nested are lazily serialized when the frontend requests them.

This PR makes the bridge _lazier_ by reducing the nested threshold from 2 to 1– enough to drill into props (e.g. `props.object`) but no further (e.g. `props.object.foo`) unless/until a user clicks to expand the value.

In my testing, this improves performance _a lot_ for some of the more extreme poor performance test harnesses. For example, here are the perf profiles for opening the DevTools extension on a fresh tab of [the treeherder repro](https://github.com/facebook/react-devtools/issues/1200#issuecomment-437346433)):

#### Before
![screen shot 2019-01-02 at 11 02 28 am](https://user-images.githubusercontent.com/29597/50607401-efe56580-0e7d-11e9-8880-fece7c096b28.png)

#### After
![screen shot 2019-01-02 at 11 03 25 am](https://user-images.githubusercontent.com/29597/50607440-0c819d80-0e7e-11e9-8f67-574f2b39714a.png)

The numbers above vary a bit by run, but the extension consistently feels much more responsive after these changes.