### PR TITLE
Disable props/state inspection for Profiler

### DIFF
--- a/agent/dehydrate.js
+++ b/agent/dehydrate.js
@@ -15,6 +15,7 @@
 // unless the frontend explicitly requests it (e.g. a user clicks to expand a props object).
 // This value was originally set to 2, but we reduced it to improve performance:
 // see https://github.com/facebook/react-devtools/issues/1200
+// Note this value also indirectly determines how far props can be drilled into within the Profiler.
 const LEVEL_THRESHOLD = 1;
 
 /**

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -245,7 +245,7 @@ class DataItem extends React.Component<Props, State> {
     }
 
     var inspectable = typeof this.props.inspect === 'function' && (!data || !data[consts.meta] || !data[consts.meta].uninspectable);
-    var open = inspectable && this.state.open && (!data || data[consts.inspected] !== false);
+    var open = this.state.open && (!data || data[consts.inspected] !== false);
     var opener = null;
 
     if (complex && inspectable) {

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -195,14 +195,15 @@ class DataItem extends React.Component<Props, State> {
   }
 
   inspect() {
-    if (this.props.inspect === null) {
+    const inspect = this.props.inspect;
+    if (inspect === null) {
       // The Profiler displays props/state for oudated Fibers.
       // These Fibers have already been mutated so they can't be inspected.
       return;
     }
 
     this.setState({loading: true, open: true});
-    this.props.inspect(this.props.path, () => {
+    inspect(this.props.path, () => {
       this.setState({loading: false});
     });
   }

--- a/frontend/DataView/DataView.js
+++ b/frontend/DataView/DataView.js
@@ -196,6 +196,8 @@ class DataItem extends React.Component<Props, State> {
 
   inspect() {
     if (this.props.inspect === null) {
+      // The Profiler displays props/state for oudated Fibers.
+      // These Fibers have already been mutated so they can't be inspected.
       return;
     }
 

--- a/plugins/Profiler/views/ProfilerFiberDetailPane.js
+++ b/plugins/Profiler/views/ProfilerFiberDetailPane.js
@@ -114,7 +114,7 @@ const ProfilerFiberDetailPane = ({
             <DataView
               path={['props']}
               readOnly={true}
-              inspect={emptyFunction}
+              inspect={null}
               showMenu={emptyFunction}
               data={snapshotFiber.get('props')}
             />
@@ -124,7 +124,7 @@ const ProfilerFiberDetailPane = ({
               <DataView
                 path={['state']}
                 readOnly={true}
-                inspect={emptyFunction}
+                inspect={null}
                 showMenu={emptyFunction}
                 data={snapshotFiber.get('state')}
               />

--- a/plugins/Profiler/views/ProfilerFiberDetailPane.js
+++ b/plugins/Profiler/views/ProfilerFiberDetailPane.js
@@ -116,6 +116,7 @@ const ProfilerFiberDetailPane = ({
               readOnly={true}
               inspect={null}
               showMenu={emptyFunction}
+              startOpen={true}
               data={snapshotFiber.get('props')}
             />
           </DetailPaneSection>
@@ -126,6 +127,7 @@ const ProfilerFiberDetailPane = ({
                 readOnly={true}
                 inspect={null}
                 showMenu={emptyFunction}
+                startOpen={true}
                 data={snapshotFiber.get('state')}
               />
             </DetailPaneSection>


### PR DESCRIPTION
Follow up for something I noticed while testing #1258

Inspecting props/state within the Profiler never worked right because React mutates fibers, so older "snapshots" of props/state _can't_ be inspected. However the UI seemed to suggest that props _could_ be expanded– which was confusing.

This changes things to make the UI more intuitive. For example, the `state.object` object below doesn't show a carrot or mouse pointer cursor for inspecting.

Here's the Elements panel style:
![screen shot 2019-01-02 at 2 53 57 pm](https://user-images.githubusercontent.com/29597/50616670-54182180-0e9e-11e9-9f20-d9dd81f322d2.png)

And here's the Profiler panel style:
![screen shot 2019-01-02 at 2 54 10 pm](https://user-images.githubusercontent.com/29597/50616667-511d3100-0e9e-11e9-93b1-2db953c28c2d.png)

I also changed the `DataView` component displayed inside of the profiler to expand objects by default up until the point where they're dehydrated, to offset the fact that we don't allow you to toggle them expanded/collapsed any more.