### PR TITLE
Fixed standalone+DOM integration

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -11,7 +11,6 @@
 
 var ws = require('ws');
 var fs = require('fs');
-var path = require('path');
 
 var installGlobalHook = require('../../../backend/installGlobalHook');
 installGlobalHook(window);
@@ -147,10 +146,14 @@ function startServer(port = 8097) {
   });
 
   httpServer.on('request', (req, res) => {
+    // NPM installs should read from node_modules,
+    // But local dev mode needs to use a relative path.
+    const basePath = fs.existsSync('./node_modules/react-devtools-core')
+      ? 'node_modules/react-devtools-core'
+      : '../react-devtools-core';
+
     // Serve a file that immediately sets up the connection.
-    var backendFile = fs.readFileSync(
-      path.join(__dirname, '../build/backend.js')
-    );
+    var backendFile = fs.readFileSync(`${basePath}/build/backend.js`);
     res.end(backendFile + '\n;ReactDevToolsBackend.connectToDevTools();');
   });
 

--- a/packages/react-devtools-core/webpack.backend.js
+++ b/packages/react-devtools-core/webpack.backend.js
@@ -24,7 +24,9 @@ module.exports = {
   output: {
     path: __dirname + '/build',
     filename: '[name].js',
-    library: '[name]',
+
+    // This name is important; standalone references it in order to connect.
+    library: 'ReactDevToolsBackend',
     libraryTarget: 'umd',
   },
   plugins: __DEV__ ? [] : [


### PR DESCRIPTION
Resolves issue #1269

I guess this was broken by the recent Webpack upgrade (#1235) and we didn't notice because it's not a common use case.

Things I tested:
* Local standalone (`yarn build:standalone && yarn test:standalone`)
* NPM install (although this required editing the nested `node_modules/react-devtools-core` to copy over local changes)
* Standalone + RN (shouldn't be impacted by this change)