### PR TITLE
Expose meaningful $r as fallback for function components

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -322,6 +322,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
         break;
       case HostText:
         nodeType = 'Text';
+        publicInstance = fiber.stateNode;
         text = fiber.memoizedProps;
         break;
       case Fragment:
@@ -454,6 +455,14 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
       actualDuration = fiber.actualDuration;
       actualStartTime = fiber.actualStartTime;
       treeBaseDuration = fiber.treeBaseDuration;
+    }
+
+    if (publicInstance === null) {
+      // publicInstance is used for $r.
+      // If we have nothing useful to expose, at least give props and state.
+      // This is an escape hatch to avoid a situation where there is useful
+      // data in the tree but DevTools don't offer any way to get it through console.
+      publicInstance = { props, state, type };
     }
 
     // $FlowFixMe


### PR DESCRIPTION
Fixes https://github.com/facebook/react-devtools/issues/1142, https://github.com/facebook/react-devtools/issues/645, https://github.com/facebook/react-devtools/issues/929. This is a minimally invasive fix.


Before:

<img width="320" alt="screen shot 2019-01-17 at 9 55 52 pm" src="https://user-images.githubusercontent.com/810438/51351517-f93c1800-1aa2-11e9-84b2-7b7f44f92de1.png">

<img width="443" alt="screen shot 2019-01-17 at 9 55 49 pm" src="https://user-images.githubusercontent.com/810438/51351518-f93c1800-1aa2-11e9-87bf-e0c8230744f4.png">

After:

<img width="284" alt="screen shot 2019-01-17 at 9 56 24 pm" src="https://user-images.githubusercontent.com/810438/51351529-ffca8f80-1aa2-11e9-8d71-cd825c18b1f2.png">

Kinda works with Hooks too:

<img width="421" alt="screen shot 2019-01-17 at 9 56 49 pm" src="https://user-images.githubusercontent.com/810438/51351549-0c4ee800-1aa3-11e9-98d8-15d1bf73621c.png">

For Hooks state, this exposes our internal implementation but I think it's better than nothing if you're debugging. We can later improve it to flatten the list into an array or even show a tree representation.

I made it a fallback and not just for functions in case you want to inspect props of some exotic type. I see nothing wrong with that.

(I also used this as an opportunity to make it work for text nodes too.)