### PR TITLE
Check for node before calling methods

### DIFF
--- a/frontend/Store.js
+++ b/frontend/Store.js
@@ -530,6 +530,9 @@ class Store extends EventEmitter {
     }
     while (true) {
       var node = this.get(id);
+      if (!node) {
+        return undefined;
+      }
       var nodeType = node.get('nodeType');
 
       if (nodeType !== 'Wrapper' && nodeType !== 'Native') {


### PR DESCRIPTION
Nodes that unmount while they are highlighted in the inspection panel crashes devtools. In `Store.skipWrapper`, the while loop `node.get('nodeType')` is invoked on `undefined`.  

Fixes https://github.com/facebook/react-devtools/issues/1291