### PR TITLE
Stop sending profile data when recording is off

### DIFF
--- a/agent/Agent.js
+++ b/agent/Agent.js
@@ -96,6 +96,7 @@ class Agent extends EventEmitter {
   capabilities: {[key: string]: boolean};
   _updateScroll: () => void;
   _inspectEnabled: boolean;
+  _isRecordingProfile: boolean
 
   constructor(global: Object, capabilities?: Object) {
     super();
@@ -163,7 +164,10 @@ class Agent extends EventEmitter {
     bridge.on('startInspecting', () => this.emit('startInspecting'));
     bridge.on('stopInspecting', () => this.emit('stopInspecting'));
     bridge.on('selected', id => this.emit('selected', id));
-    bridge.on('isRecording', isRecording => this.emit('isRecording', isRecording));
+    bridge.on('isRecording', isRecording => {
+      this._isRecordingProfile = isRecording;
+      this.emit('isRecording', isRecording);
+    });
     bridge.on('setInspectEnabled', enabled => {
       this._inspectEnabled = enabled;
       this.emit('stopInspecting');
@@ -419,6 +423,9 @@ class Agent extends EventEmitter {
   }
 
   onUpdatedProfileTimes(component: OpaqueNodeHandle, data: DataType) {
+    if (!this._isRecordingProfile) {
+      return;
+    }
     var id = this.getId(component);
     this.elementData.set(id, data);
 


### PR DESCRIPTION
In https://github.com/facebook/react/issues/14574, I have reported an issue where the devtools can get really slow.
It happens when a lot of profiling data are sent via the bridge to the frontend.

This PR disables sending the profile data to the frontend when the profiler isn't recording.

I wasn't sure where to prevent the data from being sent and how to do it. Also, I'm not sure if not sending this data when not recording can break other features.