### PR TITLE
Enhance extension popup styles + support OS dark mode

### DIFF
--- a/shells/webextension/popups/deadcode.html
+++ b/shells/webextension/popups/deadcode.html
@@ -1,30 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<link href="shared.css" rel="stylesheet">
 <script src="shared.js"></script>
-<style>
-  html, body {
-    font-size: 14px;
-    min-width: 460px;
-    min-height: 133px;
-  }
-
-  body {
-    margin: 8px;
-  }
-
-  hr {
-    width: 100%;
-  }
-</style>
 <p>
   <b>This page includes an extra development build of React. &#x1f6a7;</b>
 </p>
 <p>
   The React build on this page includes both development and production versions because dead code elimination has not been applied correctly.
-  <br />
-  <br />
+</p>
+<p>
   This makes its size larger, and causes React to run slower.
-  <br />
-  <br />
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">set up dead code elimination</a> before deployment.
+</p>
+<p>
+  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">set up dead code elimination</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/development.html
+++ b/shells/webextension/popups/development.html
@@ -1,26 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<link href="shared.css" rel="stylesheet">
 <script src="shared.js"></script>
-<style>
-  html, body {
-    font-size: 14px;
-    min-width: 460px;
-    min-height: 101px;
-  }
-
-  body {
-    margin: 8px;
-  }
-
-  hr {
-    width: 100%;
-  }
-</style>
 <p>
   <b>This page is using the development build of React. &#x1f6a7;</b>
 </p>
 <p>
   Note that the development build is not suitable for production.
-  <br />
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">use the production build</a> before deployment.
+</p>
+<p>
+  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">use the production build</a> before deployment.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/disabled.html
+++ b/shells/webextension/popups/disabled.html
@@ -1,21 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<link href="shared.css" rel="stylesheet">
 <script src="shared.js"></script>
-<style>
-  html, body {
-    font-size: 14px;
-    min-width: 410px;
-    min-height: 33px;
-  }
-
-  body {
-    margin: 8px;
-  }
-
-  hr {
-    width: 100%;
-  }
-</style>
 <p>
   <b>This page doesn&rsquo;t appear to be using React.</b>
-  <br />
+</p>
+<p>
   If this seems wrong, follow the <a href="https://github.com/facebook/react-devtools/blob/master/README.md#the-react-tab-doesnt-show-up">troubleshooting instructions</a>.
 </p>

--- a/shells/webextension/popups/outdated.html
+++ b/shells/webextension/popups/outdated.html
@@ -1,27 +1,15 @@
+<!doctype html>
+<meta charset="utf-8">
+<link href="shared.css" rel="stylesheet">
 <script src="shared.js"></script>
-<style>
-  html, body {
-    font-size: 14px;
-    min-width: 460px;
-    min-height: 117px;
-  }
-
-  body {
-    margin: 8px;
-  }
-
-  hr {
-    width: 100%;
-  }
-</style>
 <p>
   <b>This page is using an outdated version of React. &#8987;</b>
 </p>
 <p>
   We recommend updating React to ensure that you receive important bugfixes and performance improvements.
-  <br />
-  <br />
-  You can find the upgrade instructions on the <a href="https://facebook.github.io/react/blog/">React blog</a>.
+</p>
+<p>
+  You can find the upgrade instructions on the <a href="https://reactjs.org/blog/">React blog</a>.
 </p>
 <hr />
 <p>

--- a/shells/webextension/popups/production.html
+++ b/shells/webextension/popups/production.html
@@ -1,21 +1,10 @@
+<!doctype html>
+<meta charset="utf-8">
+<link href="shared.css" rel="stylesheet">
 <script src="shared.js"></script>
-<style>
-  html, body {
-    font-size: 14px;
-    min-width: 460px;
-    min-height: 39px;
-  }
-
-  body {
-    margin: 8px;
-  }
-
-  hr {
-    width: 100%;
-  }
-</style>
 <p>
   <b>This page is using the production build of React. &#x2705;</b>
-  <br />
+</p>
+<p>
   Open the developer tools, and the React tab will appear to the right.
 </p>

--- a/shells/webextension/popups/shared.css
+++ b/shells/webextension/popups/shared.css
@@ -1,0 +1,72 @@
+/* Theme colors taken from https://github.com/reactjs/reactjs.org/blob/b50fe64c1e88489022eddf2cfff0995778827f84/src/theme.js */
+
+body {
+  background: #fff;
+  color: #000;
+  font-family: -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+    "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1.5;
+  margin: 8px;
+  text-align: left;
+  width: 460px;
+
+  /* Re-enable text selection on Firefox */
+  cursor: auto;
+  -webkit-user-select: text;
+  -moz-user-select: text;
+  user-select: text;
+}
+
+p {
+  margin: 0 0 1rem;
+}
+
+p:last-child {
+  margin-bottom: 0;
+}
+
+a {
+  background-color: rgba(187, 239, 253, 0.3);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+  color: #1a1a1a;
+  text-decoration: none;
+}
+
+a:hover {
+  background-color: #bbeffd;
+  border-bottom-color: #1a1a1a;
+}
+
+hr {
+  width: 100%;
+  height: 1px;
+  margin: 0 0 1rem;
+  border: none;
+  border-bottom: 1px solid #ececec;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: rgb(49, 54, 56);
+    color: #fff;
+  }
+
+  a {
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+    color: #fff;
+  }
+  
+  a:hover {
+    background-color: rgba(97, 218, 251, 0.3);
+    border-bottom-color: #fff;
+  }
+
+  hr {
+    border-bottom-color: #444;
+  }
+}

--- a/shells/webextension/popups/unminified.html
+++ b/shells/webextension/popups/unminified.html
@@ -1,29 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<link href="shared.css" rel="stylesheet">
 <script src="shared.js"></script>
-<style>
-  html, body {
-    font-size: 14px;
-    min-width: 460px;
-    min-height: 133px;
-  }
-
-  body {
-    margin: 8px;
-  }
-
-  hr {
-    width: 100%;
-  }
-</style>
 <p>
   <b>This page is using an unminified build of React. &#x1f6a7;</b>
 </p>
 <p>
   The React build on this page appears to be unminified.
-  <br />
+</p>
+<p>
   This makes its size larger, and causes React to run slower.
-  <br />
-  <br />
-  Make sure to <a href="https://facebook.github.io/react/docs/optimizing-performance.html#use-the-production-build">set up minification</a> before deployment.
+</p>
+<p>
+  Make sure to <a href="https://reactjs.org/docs/optimizing-performance.html#use-the-production-build">set up minification</a> before deployment.
 </p>
 <hr />
 <p>


### PR DESCRIPTION
Originally I just wanted to add `prefers-color-scheme: dark` for dark mode support, but I ended up revamping the style to look more like the reactjs.org website.

Screenshots of both light/dark modes on Chrome/Firefox:

![chrome-1](https://user-images.githubusercontent.com/6135313/54012412-eeebef80-41b0-11e9-909d-d12769e19785.png)
![chrome-2](https://user-images.githubusercontent.com/6135313/54012415-f14e4980-41b0-11e9-9206-8d5ed71b7afa.png)
![firefox-1](https://user-images.githubusercontent.com/6135313/54012416-f1e6e000-41b0-11e9-88dc-d9c0c41f59d2.png)
![firefox-2](https://user-images.githubusercontent.com/6135313/54012417-f3180d00-41b0-11e9-8747-d07ff7a1129f.png)

You can easily test the different states at https://ngyikp.github.io/react-devtools-minification-diagnosis/