### PR TITLE
fix(backend): Match Profiler display name in react

### DIFF
--- a/backend/attachRendererFiber.js
+++ b/backend/attachRendererFiber.js
@@ -406,7 +406,7 @@ function attachRendererFiber(hook: Hook, rid: string, renderer: ReactRenderer): 
           case PROFILER_SYMBOL_STRING:
             nodeType = 'Special';
             props = fiber.memoizedProps;
-            name = `Profiler(${fiber.memoizedProps.id})`;
+            name = 'Profiler';
             children = [];
             break;
           default:


### PR DESCRIPTION
Reconciles this fork with `shared/getComponentName` concerning `unstable_Profiler`. Not including the `id` was deliberate: https://github.com/facebook/react/pull/13197/commits/9c990c21f0b3d47769ea9a5c20b0ec906e23d1fb#r202042053

Context:
Currently trying to implement `Profiler` into `enzyme` (airbnb/enzyme#2055). It has an API to find certain components by display name (not saying that this is useful) and display the component tree. It's not obvious what the display name for `unstable_Profiler` should look like since the component stack trace in `react` uses a different name than `react-devtools`.

Since the devtools also include the props of the Profiler component it looks redundant to me to include it in the display name.

Didn't find any other location that might affect the display name. Need some guidance if this isn't enough.