### PR TITLE
fix:standalone missing highlight update plugin

### DIFF
--- a/packages/react-devtools-core/src/backend.js
+++ b/packages/react-devtools-core/src/backend.js
@@ -21,6 +21,7 @@ type ConnectOptions = {
 var Agent = require('../../../agent/Agent');
 var Bridge = require('../../../agent/Bridge');
 var ProfileCollector = require('../../../plugins/Profiler/ProfileCollector');
+var TraceUpdatesBackendManager = require('../../../plugins/TraceUpdates/TraceUpdatesBackendManager');
 var installGlobalHook = require('../../../backend/installGlobalHook');
 var inject = require('../../../agent/inject');
 var invariant = require('assert');
@@ -161,6 +162,7 @@ function setupBackend(wall, resolveRNStyle) {
   });
 
   ProfileCollector.init(agent);
+  TraceUpdatesBackendManager.init(agent);
 }
 
 module.exports = { connectToDevTools };


### PR DESCRIPTION
fix for #1309 
Highlight updates was not worked on standalone.
I found that `TraceUpdatesBackendManager` was missing in standalone for some reason but I don't know why.