### PR TITLE
Prevent invocation of getters/setters during Object inspection

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -436,8 +436,9 @@ class Bridge {
         if (isFn && (name === 'arguments' || name === 'callee' || name === 'caller')) {
           return;
         }
+        var desc = Object.getOwnPropertyDescriptor(val, name);
         // $FlowIgnore This is intentional
-        result[name] = dehydrate(val[name], cleaned, [name]);
+        result[name] = dehydrate(desc.value, cleaned, [name]);
       });
 
       /* eslint-disable no-proto */
@@ -448,7 +449,8 @@ class Bridge {
           if (pIsFn && (name === 'arguments' || name === 'callee' || name === 'caller')) {
             return;
           }
-          newProto[name] = dehydrate(val.__proto__[name], protoclean, [name]);
+          var desc = Object.getOwnPropertyDescriptor(val.__proto__, name);
+          newProto[name] = dehydrate(desc.value, protoclean, [name]);
         });
         proto = newProto;
       }


### PR DESCRIPTION
Currently, the code is using `val.__proto__[name]` to retrieve prototype values during Object inspection. Unfortunately, when dealing with getter and setters, this invokes the function itself, instead of referring to it. This can have side-effects, including crashes.

By using the property descriptors, we have clean access to the prototype values. Note that the code could be expanded to provide on-demand getter inspections similar to the Chrome devtools inspections.

Note: it would be preferable to use getOwnPropertyDescriptors() instead of getOwnPropertyNames() + getOwnPropertyDescriptor(), but flowcheck does not have the getOwnPropertyDescriptors function registered.