### PR TITLE
Add `findAllCurrentHostFibers` instead of `findHostInstanceByFiber`

### DIFF
--- a/backend/types.js
+++ b/backend/types.js
@@ -67,10 +67,12 @@ type BundleType =
   // DEV
   | 1;
 
+// TODO: Better type for Fiber
+export type Fiber = Object;
+
 export type ReactRenderer = {
   // Fiber
-  findHostInstanceByFiber: (fiber: Object) => ?NativeType,
-  findFiberByHostInstance: (hostInstance: NativeType) => ?OpaqueNodeHandle,
+  findFiberByHostInstance: (hostInstance: NativeType) => ?Fiber,
   version: string,
   bundleType: BundleType,
   overrideProps?: ?(fiber: Object, path: Array<string | number>, value: any) => void,


### PR DESCRIPTION
The plan is to remove `findHostInstanceByFiber` from React.
See https://github.com/facebook/react/pull/15466#issuecomment-486050804

Have to copy `findCurrentFiberUsingSlowPath` from React
like the new `react-devtools-experimental` does.
https://github.com/bvaughn/react-devtools-experimental/blob/942f67c9369cc587708bd0cde1e61099ab9ed8f3/src/backend/renderer.js#L1298-L1479

Also clean up related Flow typings.