### PR TITLE
pass hostname to options in standalone version

### DIFF
--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -149,7 +149,8 @@ function startServer(port = 8097) {
   httpServer.on('request', (req, res) => {
     // Serve a file that immediately sets up the connection.
     var backendFile = readFileSync(join(__dirname, 'backend.js'));
-    res.end(backendFile + '\n;ReactDevToolsBackend.connectToDevTools();');
+    var hostname = req.headers.host.split(':')[0];
+    res.end(backendFile + `\n;ReactDevToolsBackend.connectToDevTools({host: '${hostname}'});`);
   });
 
   httpServer.on('error', (e) => {


### PR DESCRIPTION
Standalone version initializes devtools with default parameters.
If you run devtools on PC and open app on mobile phone, your phone will try to connect to `ws://localhost`
fix #841