### PR TITLE
Standalone shell checks for v4 backend and shows upgrade message

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -194,6 +194,12 @@ class Bridge {
     });
   }
 
+  // Listening directly to the wall isn't advised.
+  // It can be used to listen/detect v4 messages (since they use a different format).
+  get wall(): Wall {
+    return this._wall;
+  }
+
   call(name: string, args: Array<any>, cb: (val: any) => any) {
     var _cid = this._cid++;
     this._cbs.set(_cid, cb);

--- a/packages/react-devtools-core/src/standalone.js
+++ b/packages/react-devtools-core/src/standalone.js
@@ -31,6 +31,7 @@ var config = {
   alreadyFoundReact: true,
   showInspectButton: false,
   showHiddenThemes: true,
+  showUpgradeMessageIfModernBackendDetected: true,
   inject(done) {
     done(wall);
   },
@@ -79,6 +80,12 @@ function initialize(socket) {
   wall = {
     listen(fn) {
       listeners.push(fn);
+      return () => {
+        const index = listeners.indexOf(fn);
+        if (index >= 0) {
+          listeners.splice(index, 1);
+        }
+      };
     },
     send(data) {
       if (socket.readyState === socket.OPEN) {


### PR DESCRIPTION
This sets up a temporary event listener until we've confirmed either v3 or v4 backend, then it's removed. If v4 backend is detected- we show an upgrade message:

![Screen Shot 2019-07-19 at 8 51 31 AM](https://user-images.githubusercontent.com/29597/61548772-458cf400-aa03-11e9-8711-c60190aa28dc.png)
