### PR TITLE
Fix inspection of getter-based properties that access "this"

### DIFF
--- a/agent/Bridge.js
+++ b/agent/Bridge.js
@@ -454,7 +454,8 @@ class Bridge {
           if (pIsFn && (name === 'arguments' || name === 'callee' || name === 'caller')) {
             return;
           }
-          newProto[name] = dehydrate(val.__proto__[name], protoclean, [name]);
+          var desc = Object.getOwnPropertyDescriptor(val.__proto__, name);
+          newProto[name] = dehydrate(desc && desc.get ? desc.get.call(val) : val.__proto__[name], protoclean, [name]);
         });
         proto = newProto;
       }


### PR DESCRIPTION
This PR addresses #893. When a class defines a `get` property, the expression `val.__proto__[name]` invokes the getter with the wrong `this`. To resolve this, we check whether the prototype property has a property descriptor with a getter, and if so, invoke the getter with the correct `this`.

Note that this PR conflicts with #1329, which simply suppresses the property.