### PR TITLE
Add text node highlighter on hover using range

### DIFF
--- a/frontend/Highlighter/Overlay.js
+++ b/frontend/Highlighter/Overlay.js
@@ -120,7 +120,7 @@ class Overlay {
         width: box.width + dims.marginLeft + dims.marginRight,
       }, this.win);
 
-    } else if (node.nodeType === Node.TEXT_NODE && node.data.trim()) {
+    } else if (node.nodeType === Node.TEXT_NODE) {
       // Get the bounding rect for a text node using range
       box = getTextRect(node);
 


### PR DESCRIPTION
Related to issue [566](https://github.com/facebook/react-devtools/issues/566). The PR [598](https://github.com/facebook/react-devtools/pull/598) fixing the issue just checks for comment node and ignores it. I have added support for highlighting the text node similar to chrome/firefox dev tools. Hope these gifs help...

**Before**:
![before fix](https://user-images.githubusercontent.com/11175019/62286658-cc1aea00-b475-11e9-9e1d-6e43ddbc6577.gif)

**After**:
![after fix](https://user-images.githubusercontent.com/11175019/62286719-ef459980-b475-11e9-951a-999d8a54e37a.gif)

